### PR TITLE
Fixed a bug where FrameData.getFrameIndexes ignores the input parameter.

### DIFF
--- a/src/animation/FrameData.js
+++ b/src/animation/FrameData.js
@@ -193,7 +193,7 @@ Phaser.Animation.FrameData.prototype = {
         if (typeof useNumericIndex === "undefined") { useNumericIndex = true; }
         if (typeof output === "undefined") { output = []; }
 
-        if (typeof frames === "undefined" || frames.length == 0)
+        if (typeof input === "undefined" || input.length == 0)
         {
             //  No input array, so we loop through all frames
             for (var i = 0, len = this._frames.length; i < len; i++)
@@ -209,7 +209,7 @@ Phaser.Animation.FrameData.prototype = {
                 //  Does the input array contain names or indexes?
                 if (useNumericIndex)
                 {
-                    output.push(input[i].index);
+                    output.push(input[i]);
                 }
                 else
                 {


### PR DESCRIPTION
Fixed a bug where FrameData.getFrameIndexes always ignores the input parameter.
Fixed a bug where FrameData.getFrameIndexes requires objects with an index property instead of just the numeric indexes.

I posted details of the problem I encountered here:
http://www.html5gamedevs.com/topic/1426-sprite-animation-play-only-frames-1-to-x-numeric-index/
