### PR TITLE
Some small animation fixes

### DIFF
--- a/src/animation/FrameData.js
+++ b/src/animation/FrameData.js
@@ -164,12 +164,12 @@ Phaser.Animation.FrameData.prototype = {
                 if (useNumericIndex)
                 {
                     //  The actual frame
-                    output.push(this.getFrame(input[i]));
+                    output.push(this.getFrame(frames[i]));
                 }
                 else
                 {
                     //  The actual frame
-                    output.push(this.getFrameByName(input[i]));
+                    output.push(this.getFrameByName(frames[i]));
                 }
             }
         }


### PR DESCRIPTION
When adding an animation using frame indexes, the getFrameIndexes function was attempting to access the .index property of the elements of the frames array, which are integers.

I've switched to using the raw frame index, which works for my trivial case, but perhaps it should be:

```
output.push(this.getFrame(frames[i]).index);
```

---

Also, getFrames (which doesn't appear to be used anywhere) was looping through the wrong array.

There doesn't appear to be a test case for this, however changing the sprite sheet example to include explicit frame numbers should demonstrate this.
