### PR TITLE
Added a yuidoc Grunt task to be able to generate a documentation

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -2,6 +2,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-typescript');
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-contrib-yuidoc');
 
     var wrapPhaserInUmd = function(content, isAddon) {
         var replacement = [
@@ -69,6 +70,21 @@ module.exports = function (grunt) {
                 }
             },
         },
+
+        yuidoc: {
+            compile: {
+                name: '<%= pkg.name %>',
+                description: '<%= pkg.description %>',
+                version: '<%= pkg.version %>',
+                url: '<%= pkg.homepage %>',
+                options: {
+                    paths: 'src/',
+                    themedir: 'Docs/yuidoc-theme-dana/',
+                    outdir: 'Docs/API/'
+                }
+            }
+        },
+
         watch: {
             files: '**/*.ts',
             tasks: ['typescript', 'copy']

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-contrib-watch": "~0.3.1",
     "grunt-contrib-connect": "~0.3.0",
     "grunt-open": "~0.2.0",
-    "grunt-contrib-copy": "~0.4.1"
+    "grunt-contrib-copy": "~0.4.1",
+    "grunt-contrib-yuidoc": "~0.5.0"
   }
 }


### PR DESCRIPTION
Hi,

I've added a yuidoc grunt-task to generate a documentation with grunt. simply use `grunt yuidoc` for updating the documentation with needed parameters.

Maybe you want to add, otherwise close it ;) 
