### PR TITLE
Fixed accidentally overwroting remove function with a prepend function

### DIFF
--- a/src/core/LinkedList.js
+++ b/src/core/LinkedList.js
@@ -38,17 +38,14 @@ Phaser.LinkedList.prototype = {
     },
 
     remove: function (child) {
-		if( this.first ) {
-		  child.next = this.last.next;
-		  child.prev = this.last;
-		  if( this.last.next ) {
-		    this.last.next.prev = child;
-		  }
-		  this.last.next = child;
-		  this.last = this.last.next;
-		} else {
-		  this.first = this.last = child;
-		}
+    	if( child == this.first )  this.first = this.first.next;      // It was 'first', make 'first' point to first.next
+		else if ( child == this.last ) this.last = this.last.prev; // It was 'last', make 'last' point to last.prev
+
+		if( child.prev ) child.prev.next = child.next; // make child.prev.next point to childs.next instead of child
+		if( child.next ) child.next.prev = child.prev; // make child.next.prev point to child.prev instead of child
+		child.next = child.prev = null;
+
+		if( this.first == null ) this.last = null;
 
 		this.total--;
     },


### PR DESCRIPTION
I crossed my commits, and accidentally placed my prepend function in the remove function for, when I submitted a pull request within the dev branch. If you compare to the original request, this is the correct code - not the one I submitted yesterday (that was for a l-list prepend function). Bone head move on my part when recreating the pull request. Appologies
