### PR TITLE
Added init method to plugins, to be called as they are added to the PluginManager

### DIFF
--- a/src/core/PluginManager.js
+++ b/src/core/PluginManager.js
@@ -103,6 +103,13 @@ Phaser.PluginManager.prototype = {
             }
 
             this._pluginsLength = this.plugins.push(plugin);
+
+            // Allows plugins to run potentially destructive code outside of the constructor, and only if being added to the PluginManager
+            if (typeof plugin['init'] === 'function')
+            {
+                plugin.init();
+            }
+
             return plugin;
         }
         else


### PR DESCRIPTION
This will allow potentially destructive code to run outside of the plugin constructor, and only if it has been successfully added to the PluginManager.

I've been playing around with plugins, and found a couple of examples when I needed to create an instance of my plugin, but without certain code running at that point. For example, I may want to create the plugin instance, then set a variable, or call a method, then add it to the game, and have some code occur at that point, prior to the first update/render, but still within the plugin.
