### PR TITLE
Add a postUpdate function to plugins

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -437,6 +437,7 @@ Phaser.Game.prototype = {
 	        this.plugins.update();
 
 			this.world.postUpdate();
+            this.plugins.postUpdate();
 
 			this.renderer.render(this.stage._stage);
 			this.plugins.render();

--- a/src/core/Plugin.js
+++ b/src/core/Plugin.js
@@ -50,6 +50,12 @@ Phaser.Plugin = function (game, parent) {
 	* @default
 	*/
     this.hasUpdate = false;
+
+    /**
+    * @property {boolean} hasPostUpdate - A flag to indicate if this plugin has a postUpdate method.
+    * @default
+    */
+    this.hasPostUpdate = false;
     
     /**
 	* @property {boolean} hasRender - A flag to indicate if this plugin has a render method.

--- a/src/core/PluginManager.js
+++ b/src/core/PluginManager.js
@@ -77,6 +77,12 @@ Phaser.PluginManager.prototype = {
             result = true;
         }
 
+        if (typeof plugin['postUpdate'] === 'function')
+        {
+            plugin.hasPostUpdate = true;
+            result = true;
+        }
+
         if (typeof plugin['render'] === 'function')
         {
             plugin.hasRender = true;
@@ -171,6 +177,30 @@ Phaser.PluginManager.prototype = {
             if (this.plugins[this._p].active && this.plugins[this._p].hasUpdate)
             {
                 this.plugins[this._p].update();
+            }
+        }
+
+    },
+
+    /**
+    * PostUpdate is the last thing to be called before the world render.
+    * In particular, it is called after the world postUpdate, which means the camera has been adjusted.
+    * It only calls plugins who have active=true.
+    * 
+    * @method Phaser.PluginManager#postUpdate
+    */
+    postUpdate: function () {
+        
+        if (this._pluginsLength == 0)
+        {
+            return;
+        }
+
+        for (this._p = 0; this._p < this._pluginsLength; this._p++)
+        {
+            if (this.plugins[this._p].active && this.plugins[this._p].hasPostUpdate)
+            {
+                this.plugins[this._p].postUpdate();
             }
         }
 


### PR DESCRIPTION
This plugin function is called after world.postUpdate, which is responsible for setting up the camera.

This allows plugins like this Shake plugin: https://gist.github.com/cocoademon/7276093

(In the example, the camera position is restored in postRender, as Phaser appears to base some physics on camera.displayObject.position)
