### PR TITLE
fix for mouse input events still firing after game.destroy

### DIFF
--- a/src/input/Mouse.js
+++ b/src/input/Mouse.js
@@ -238,9 +238,9 @@ Phaser.Mouse.prototype = {
 
         document.exitPointerLock();
 
-        document.removeEventListener('pointerlockchange', this._pointerLockChange);
-        document.removeEventListener('mozpointerlockchange', this._pointerLockChange);
-        document.removeEventListener('webkitpointerlockchange', this._pointerLockChange);
+        document.removeEventListener('pointerlockchange', this._pointerLockChange, false);
+        document.removeEventListener('mozpointerlockchange', this._pointerLockChange, false);
+        document.removeEventListener('webkitpointerlockchange', this._pointerLockChange, false);
 
     },
 
@@ -250,9 +250,9 @@ Phaser.Mouse.prototype = {
     */
     stop: function () {
 
-        this.game.stage.canvas.removeEventListener('mousedown', this._onMouseDown);
-        this.game.stage.canvas.removeEventListener('mousemove', this._onMouseMove);
-        this.game.stage.canvas.removeEventListener('mouseup', this._onMouseUp);
+        this.game.stage.canvas.removeEventListener('mousedown', this._onMouseDown, true);
+        this.game.stage.canvas.removeEventListener('mousemove', this._onMouseMove, true);
+        this.game.stage.canvas.removeEventListener('mouseup', this._onMouseUp, true);
 
     }
 


### PR DESCRIPTION
The problem was that the events were registered with useCapture true, but removed without specifying.
According to the MDN (https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.removeEventListener)

"If not specified, useCapture defaults to false. If a listener was registered twice, one with capture and one without, each must be removed separately. Removal of a capturing listener does not affect a non-capturing version of the same listener, and vice versa."

So I added 'true' to the removed, and it now correctly removes them.

Some of the other add/remove pairings probably need checking as well, but I had a look and most of the addEventListsner calls use false, so the corresponding removes use the default of false, and work.
