### PR TITLE
Switched Tilemap to use user-specified layer.

### DIFF
--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -114,9 +114,9 @@ Phaser.Tilemap.prototype = {
 
         if (typeof layer === "undefined") { layer = this.currentLayer; }
 
-    	if (x >= 0 && x < this.layers[this.currentLayer].width && y >= 0 && y < this.layers[this.currentLayer].height)
+    	if (x >= 0 && x < this.layers[layer].width && y >= 0 && y < this.layers[layer].height)
     	{
-    		this.layers[this.currentLayer].data[y][x] = index;
+    		this.layers[layer].data[y][x] = index;
     	}
 
         this.dirty = true;
@@ -127,9 +127,9 @@ Phaser.Tilemap.prototype = {
 
         if (typeof layer === "undefined") { layer = this.currentLayer; }
 
-        if (x >= 0 && x < this.layers[this.currentLayer].width && y >= 0 && y < this.layers[this.currentLayer].height)
+        if (x >= 0 && x < this.layers[layer].width && y >= 0 && y < this.layers[layer].height)
         {
-            return this.layers[this.currentLayer].data[y][x];
+            return this.layers[layer].data[y][x];
         }
 
     },
@@ -141,9 +141,9 @@ Phaser.Tilemap.prototype = {
         x = this.game.math.snapToFloor(x, tileWidth) / tileWidth;
         y = this.game.math.snapToFloor(y, tileHeight) / tileHeight;
 
-        if (x >= 0 && x < this.layers[this.currentLayer].width && y >= 0 && y < this.layers[this.currentLayer].height)
+        if (x >= 0 && x < this.layers[layer].width && y >= 0 && y < this.layers[layer].height)
         {
-            return this.layers[this.currentLayer].data[y][x];
+            return this.layers[layer].data[y][x];
         }
 
     },
@@ -160,9 +160,9 @@ Phaser.Tilemap.prototype = {
         x = this.game.math.snapToFloor(x, tileWidth) / tileWidth;
         y = this.game.math.snapToFloor(y, tileHeight) / tileHeight;
 
-        if (x >= 0 && x < this.layers[this.currentLayer].width && y >= 0 && y < this.layers[this.currentLayer].height)
+        if (x >= 0 && x < this.layers[layer].width && y >= 0 && y < this.layers[layer].height)
         {
-            this.layers[this.currentLayer].data[y][x] = index;
+            this.layers[layer].data[y][x] = index;
         }
 
         this.dirty = true;


### PR DESCRIPTION
Pull request relating to issue #183.

Tilemap was using the current layer even if a layer was specified as a
parameter in getTile/setTile. Changed it to use the user layer if one is
specified.

 Not sure is this change screws up any of the Tilemap loading, however. I checked the tilemap examples and they all stilled seemed to work, but I'm not familiar with the Tilemap loading code in detail.
