### PR TITLE
Check if Phaser.Sprite has a group before testing group.exists

### DIFF
--- a/src/gameobjects/Sprite.js
+++ b/src/gameobjects/Sprite.js
@@ -358,7 +358,7 @@ Phaser.Sprite.prototype.constructor = Phaser.Sprite;
 */
 Phaser.Sprite.prototype.preUpdate = function() {
 
-    if (!this.exists || !this.group.exists)
+    if (!this.exists || (this.group && !this.group.exists))
     {
         this.renderOrderID = -1;
         return;


### PR DESCRIPTION
Everywhere else Phaser.Sprite makes sure group exists.

We occasionally use the PIXI addChild to parent sprites to each other, this reinstates that usage.
