### PR TITLE
Skip preupdate/update for PIXI hierarchies in which an ancestor doesn't exist

### DIFF
--- a/src/core/World.js
+++ b/src/core/World.js
@@ -72,24 +72,31 @@ Phaser.World.prototype.boot = function () {
 Phaser.World.prototype.update = function () {
 
 	this.currentRenderOrderID = 0;
-
+    
 	if (this.game.stage._stage.first._iNext)
 	{
 		var currentNode = this.game.stage._stage.first._iNext;
+        var skipChildren = false;
 		
 		do
 		{
 			if (currentNode['preUpdate'])
 			{
-				currentNode.preUpdate();
+				skipChildren = (currentNode.preUpdate() == false);
 			}
 
 			if (currentNode['update'])
 			{
-				currentNode.update();
+				skipChildren = (currentNode.update() == false) || skipChildren;
 			}
 			
-			currentNode = currentNode._iNext;
+            if(skipChildren)
+            {
+                currentNode = currentNode.last._iNext;
+            } else {
+                currentNode = currentNode._iNext;    
+            }
+			
 		}
 		while (currentNode != this.game.stage._stage.last._iNext)
 	}

--- a/src/gameobjects/Sprite.js
+++ b/src/gameobjects/Sprite.js
@@ -361,7 +361,9 @@ Phaser.Sprite.prototype.preUpdate = function() {
     if (!this.exists || (this.group && !this.group.exists))
     {
         this.renderOrderID = -1;
-        return;
+        
+        // Skip children if not exists
+        return false;
     }
 
     if (this.lifespan > 0)
@@ -371,7 +373,7 @@ Phaser.Sprite.prototype.preUpdate = function() {
         if (this.lifespan <= 0)
         {
             this.kill();
-            return;
+            return false;
         }
     }
 
@@ -398,6 +400,8 @@ Phaser.Sprite.prototype.preUpdate = function() {
     {
         this.body.preUpdate();
     }
+
+    return true;
 
 };
 


### PR DESCRIPTION
In a similar vein to the recent "skip updates if the group doesn't exist", this PR does the same thing
but using the PIXI hierarchy.

I use addChild to make sprites with subsprites that move in step. This commit skips updating the subsprites if the parent doesn't exist.

The check with `==false` is to ensure that not returning (aka returning undefined) maintains the old behaviour.
