### PR TITLE
Fixes to Math and Loader

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -138,7 +138,7 @@ Phaser.Game = function (width, height, renderer, parent, state, transparent, ant
     this.load = null;
 
     /**
-	* @property {Phaser.GameMath} math - Reference to the math helper.
+	* @property {Phaser.Math} math - Reference to the math helper.
 	* @default
 	*/
     this.math = null;

--- a/src/core/State.js
+++ b/src/core/State.js
@@ -50,7 +50,7 @@ Phaser.State = function () {
     this.load = null;
     
     /**
-	* @property {Phaser.GameMath} math - Reference to the math helper.
+	* @property {Phaser.Math} math - Reference to the math helper.
 	* @default
 	*/
     this.math = null;

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -744,6 +744,10 @@ Phaser.Loader.prototype = {
 						return _this.csvLoadComplete(file.key);
 					};
 				}
+				else
+				{
+					throw new Error("Phaser.Loader. Invalid Tilemap format: " + file.format);
+				}
 
 				this._xhr.onerror = function () {
 					return _this.dataLoadError(file.key);
@@ -872,6 +876,10 @@ Phaser.Loader.prototype = {
 						this._xhr.onload = function () {
 							return _this.xmlLoadComplete(file.key);
 						};
+					}
+					else
+					{
+						throw new Error("Phaser.Loader. Invalid Texture Atlas format: " + file.format);
 					}
 
 					this._xhr.onerror = function () {

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -350,7 +350,7 @@ Phaser.Math = {
 
         if (typeof radians === "undefined") { radians = true; }
 
-        var rd = (radians) ? GameMath.PI : 180;
+        var rd = (radians) ? Math.PI : 180;
         return this.wrap(angle, rd, -rd);
         
     },


### PR DESCRIPTION
- Remove references to GameMath, it's just Math now
- Throw exceptions if wrong format given to tilemap or textureatlas. Previously, old onload remained active and error happened in the wrong (and hard to diagnose) place.
