### PR TITLE
Allow audio file to be passed as a single string.

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -780,6 +780,8 @@ Phaser.Loader.prototype = {
 
     var extension;
 
+    if (typeof urls === 'string') { urls = [urls]; }
+
     for (var i = 0; i < urls.length; i++)
     {
       extension = urls[i].toLowerCase();


### PR DESCRIPTION
- Retabbed `src/loader/Loader.js` for consistency with other files.
- Added a type check on `urls` when getting audio urls.

This pull request resolves #222. If you view [the first commit](https://github.com/kevinthompson/phaser/commit/cdb071d3565eac63acc6ee5e35b548605d4cb1da) with [whitespace comparison disbled](https://github.com/kevinthompson/phaser/commit/cdb071d3565eac63acc6ee5e35b548605d4cb1da?w=1), you can see that the only changes were to he whitespace. The only real change was a single line addition in [the second commit](https://github.com/kevinthompson/phaser/commit/bc4f9da5fa48a5ddea90dc51096bef685bd27315).
