### PR TITLE
Set isRunning to false when tween ends.

### DIFF
--- a/src/tween/Tween.js
+++ b/src/tween/Tween.js
@@ -585,6 +585,7 @@ Phaser.Tween.prototype = {
 
       } else {
 
+        this.isRunning = false;
         this.onComplete.dispatch(this._object);
 
         if ( this._onCompleteCallback !== null ) {


### PR DESCRIPTION
- Retabbed src/tween/Tween.js for consistency with other files.
- Set isRunning to false when non-repeating tween ends.

This pull request resolves #221. If you view the first commit with
whitespace comparison disbled, you can see that the only changes were to
he whitespace. The only real change was a single line addition in the
second commit.
