### PR TITLE
Remove additional argument from bitmapData factory

### DIFF
--- a/examples/display/bitmapdata wobble.js
+++ b/examples/display/bitmapdata wobble.js
@@ -17,7 +17,7 @@ var waveDataCounter;
 function create() {
 
 	//	Create our BitmapData object at a size of 32x64
-	bmd = game.add.bitmapData('ball', 32, 64);
+	bmd = game.add.bitmapData(32, 64);
 
     //  And apply it to 100 randomly positioned sprites
     for (var i = 0; i < 100; i++)


### PR DESCRIPTION
Per the [comment by jcd-as](https://github.com/photonstorm/phaser/issues/235#issuecomment-29544957), I've removed the first argument of the Bitmapdata Wobble example to resolve the bug described in #235.
