### PR TITLE
move TilemapLayer positioning/rendering to postUpdate to be in line with...

### DIFF
--- a/src/core/World.js
+++ b/src/core/World.js
@@ -113,6 +113,8 @@ Phaser.World.prototype.update = function () {
 */
 Phaser.World.prototype.postUpdate = function () {
 
+    this.camera.update();
+
     if (this.game.stage._stage.first._iNext)
     {
         var currentNode = this.game.stage._stage.first._iNext;
@@ -128,8 +130,6 @@ Phaser.World.prototype.postUpdate = function () {
         }
         while (currentNode != this.game.stage._stage.last._iNext)
     }
-
-    this.camera.update();
 }
 
 /**

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -279,13 +279,15 @@ Phaser.TilemapLayer.prototype = Phaser.Utils.extend(true, Phaser.TilemapLayer.pr
 Phaser.TilemapLayer.prototype.constructor = Phaser.TilemapLayer;
 
 /**
-* Automatically called by World.preUpdate. Handles cache updates.
+* Automatically called by World.postUpdate. Handles cache updates.
 *
-* @method Phaser.TilemapLayer#update
+* @method Phaser.TilemapLayer#postUpdate
 * @memberof Phaser.TilemapLayer
 */
-Phaser.TilemapLayer.prototype.update = function () {
+Phaser.TilemapLayer.prototype.postUpdate = function () {
 
+	Phaser.Sprite.prototype.postUpdate.call( this );
+	
     this.scrollX = this.game.camera.x * this.scrollFactorX;
     this.scrollY = this.game.camera.y * this.scrollFactorY;
 


### PR DESCRIPTION
... ‘normal’ Sprites.

reverts e91d40b9fcee53c453f8d94253b6fea8014a1087 - fix was incorrect & regressed fixedToCamera Sprites’ & TilemapLayer positioning.
Fixes #237
