### PR TITLE
Switch Camera.setBoundsToWorld to match world.bounds instead of world

### DIFF
--- a/src/core/Camera.js
+++ b/src/core/Camera.js
@@ -244,7 +244,7 @@ Phaser.Camera.prototype = {
 
     setBoundsToWorld: function () {
 
-        this.bounds.setTo(this.game.world.x, this.game.world.y, this.game.world.width, this.game.world.height);
+        this.bounds.setTo(this.game.world.bounds.x, this.game.world.bounds.y, this.game.world.bounds.width, this.game.world.bounds.height);
 
     },
 


### PR DESCRIPTION
Since the switch to moving game.world to implement scrolling, the camera bounds setup is broken.

It's not obvious unless you move the camera and _then_ set the camera bounds.
