### PR TITLE
Don’t test self-collisions

### DIFF
--- a/src/physics/arcade/ArcadePhysics.js
+++ b/src/physics/arcade/ArcadePhysics.js
@@ -750,9 +750,12 @@ Phaser.Physics.Arcade.prototype = {
     * @returns {boolean} Returns true if the bodies were separated, otherwise false.
     */
     separate: function (body1, body2) {
-
-        this._result = (this.separateX(body1, body2) || this.separateY(body1, body2));
-
+        if(body1 !== body2)
+        {
+            this._result = (this.separateX(body1, body2) || this.separateY(body1, body2));    
+        } else {
+            this._result = false;
+        }
     },
 
     /**


### PR DESCRIPTION
A useful technique in Flixel is to have a group of objects, and perform collision between them like this:

var actors = game.add.group();
...
game.physics.collide(actors, actors);
This resolves collisions within the group. Phaser currently collides objects within the group against themselves, which limits the usefulness of this approach.

I've attached a simple fix, although I don't know if the performance cost is worth it.

I also don't know if thats sufficient when you can have TileLayers within groups, for example. (I'm not familiar with using Tilemaps)
