### PR TITLE
fix Pixi bug (#425) - fix incorrect width property for multi-line Bitmap...

### DIFF
--- a/src/pixi/text/BitmapText.js
+++ b/src/pixi/text/BitmapText.js
@@ -135,7 +135,7 @@ PIXI.BitmapText.prototype.updateText = function()
         this.addChild(c);
     }
 
-    this.width = pos.x * scale;
+    this.width = maxLineWidth * scale;
     this.height = (pos.y + data.lineHeight) * scale;
 };
 


### PR DESCRIPTION
...Text

(Pixi has already merged the fix, so there shouldn't be issues the next time a new Pixi is picked up)
