### PR TITLE
Split world update into preUpdate and update.

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -440,14 +440,15 @@ Phaser.Game.prototype = {
         {
             this.plugins.preUpdate();
             this.physics.preUpdate();
+            this.world.preUpdate();
 
             this.stage.update();
             this.input.update();
             this.tweens.update();
             this.sound.update();
-            this.world.update();
-            this.particles.update();
             this.state.update();
+            this.world.update();
+            this.particles.update();            
             this.plugins.update();
 
             this.world.postUpdate();

--- a/src/core/World.js
+++ b/src/core/World.js
@@ -65,6 +65,33 @@ Phaser.World.prototype.boot = function () {
 * 
 * @method Phaser.World#update
 */
+Phaser.World.prototype.preUpdate = function () {
+    
+    if (this.game.stage._stage.first._iNext)
+    {
+        var currentNode = this.game.stage._stage.first._iNext;
+        
+        do
+        {
+            // If preUpdate exists, and it returns false, skip PIXI child objects
+            if (currentNode['preUpdate'] && !currentNode.preUpdate())
+            {
+                currentNode = currentNode.last._iNext;
+            } else {
+                currentNode = currentNode._iNext;
+            }
+            
+        }
+        while (currentNode != this.game.stage._stage.last._iNext)
+    }
+
+}
+
+/**
+* This is called automatically every frame, and is where main logic happens.
+* 
+* @method Phaser.World#update
+*/
 Phaser.World.prototype.update = function () {
 
     this.currentRenderOrderID = 0;
@@ -72,28 +99,14 @@ Phaser.World.prototype.update = function () {
     if (this.game.stage._stage.first._iNext)
     {
         var currentNode = this.game.stage._stage.first._iNext;
-        var skipChildren;
         
         do
         {
-            skipChildren = false;
-
-            if (currentNode['preUpdate'])
-            {
-                skipChildren = (currentNode.preUpdate() === false);
-            }
-
-            if (currentNode['update'])
-            {
-                skipChildren = (currentNode.update() === false) || skipChildren;
-            }
-            
-            if (skipChildren)
+            // If update exists, and it returns false, skip PIXI child objects
+            if (currentNode['update'] && !currentNode.update())
             {
                 currentNode = currentNode.last._iNext;
-            }
-            else
-            {
+            } else {
                 currentNode = currentNode._iNext;
             }
             


### PR DESCRIPTION
Physics.preUpdate is called before World.update, which is called before State.update.
Sprite.body.touching is reset in preUpdate, which means sprite subclasses can't test for collisions in their own update methods.

This means the following paradigm currently fails in Phaser:

```
// in MyGameState.update()
game.physics.collide(group1, group2);

// in MySpriteSubclass.update()
if(this.body.touching.up) {
    // do something
    // never gets called, as this.body.touching is reset in game.physics.preUpdate
}
```

This fails because the second call occurs before the first. That is, the sequence of events (for these purposes) boils down to:
1. Physics properties reset (in Body.preUpdate)
2. MySpriteSubclass.update()
3. MyGameState.update() <- which calls collide()

This PR moves the state.update() call to before world.update(), but _after_ preUpdate. This makes results of collisions checked in the state available to objects in their own update(), but _also_ means physics properties/bounds are properly set before calling any of the collision test methods in ArcadePhysics.
