### PR TITLE
improve ejecta support

### DIFF
--- a/src/core/Stage.js
+++ b/src/core/Stage.js
@@ -32,13 +32,13 @@ Phaser.Stage = function (game, width, height) {
     * @property {Phaser.Point} offset - Get the offset values (for input and other things).
     */
     this.offset = new Phaser.Point();
-    
+
     /**
     * @property {HTMLCanvasElement} canvas - Reference to the newly created &lt;canvas&gt; element.
     */
-    this.canvas = Phaser.Canvas.create(width, height);
+    this.canvas = Phaser.Canvas.create(width, height, (game.device.ejecta) ? 'canvas' : '');
     this.canvas.style['-webkit-full-screen'] = 'width: 100%; height: 100%';
-    
+
     /**
     * @property {PIXI.Stage} _stage - The Pixi Stage which is hooked to the renderer.
     * @private

--- a/src/system/Canvas.js
+++ b/src/system/Canvas.js
@@ -26,7 +26,7 @@ Phaser.Canvas = {
         width = width || 256;
         height = height || 256;
 
-        var canvas = document.createElement('canvas');
+        var canvas = document.getElementById(id) || document.createElement('canvas');
 
         if (typeof id === 'string')
         {
@@ -90,7 +90,7 @@ Phaser.Canvas = {
         color = color || 'rgb(0,0,0)';
 
         canvas.style.backgroundColor = color;
-        
+
         return canvas;
 
     },

--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -41,6 +41,12 @@ Phaser.Device = function () {
     this.cocoonJS = false;
 
     /**
+    * @property {boolean} ejecta - Is the game running under Ejecta?
+    * @default
+    */
+    this.ejecta = false;
+
+    /**
     * @property {boolean} android - Is running on android?
     * @default
     */
@@ -126,7 +132,7 @@ Phaser.Device = function () {
     */
     this.css3D = false;
 
-    /** 
+    /**
     * @property {boolean} pointerLock - Is Pointer Lock available?
     * @default
     */
@@ -295,7 +301,7 @@ Phaser.Device = function () {
     */
     this.iPhone4 = false;
 
-    /** 
+    /**
     * @property {boolean} iPad - Is running on iPad?
     * @default
     */
@@ -320,7 +326,7 @@ Phaser.Device = function () {
     this._checkDevice();
     this._checkFeatures();
     this._checkOS();
-    
+
 };
 
 Phaser.Device.prototype = {
@@ -395,7 +401,7 @@ Phaser.Device.prototype = {
         }
 
         this.worker = !!window['Worker'];
-        
+
         if ('ontouchstart' in document.documentElement || (window.navigator.maxTouchPoints && window.navigator.maxTouchPoints > 1))
         {
             this.touch = true;
@@ -405,7 +411,7 @@ Phaser.Device.prototype = {
         {
             this.mspointer = true;
         }
-        
+
         this.pointerLock = 'pointerLockElement' in document || 'mozPointerLockElement' in document || 'webkitPointerLockElement' in document;
 
     },
@@ -478,6 +484,11 @@ Phaser.Device.prototype = {
             this.cocoonJS = true;
         }
 
+        if (typeof window.ejecta !== "undefined")
+        {
+            this.ejecta = true;
+        }
+
     },
 
     /**
@@ -494,7 +505,7 @@ Phaser.Device.prototype = {
 
         try {
             if (result = !!audioElement.canPlayType) {
-                
+
                 if (audioElement.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/, '')) {
                     this.ogg = true;
                 }
@@ -551,7 +562,7 @@ Phaser.Device.prototype = {
         }
 
         navigator.vibrate = navigator.vibrate || navigator.webkitVibrate || navigator.mozVibrate || navigator.msVibrate;
-         
+
         if (navigator.vibrate)
         {
             this.vibration = true;
@@ -587,7 +598,7 @@ Phaser.Device.prototype = {
                 has3d = window.getComputedStyle(el).getPropertyValue(transforms[t]);
             }
         }
-        
+
         document.body.removeChild(el);
         this.css3D = (has3d !== undefined && has3d.length > 0 && has3d !== "none");
 


### PR DESCRIPTION
- added device.ejecta flag, which is true when running under ejecta
- use existing '#canvas' for the stage when running on ejecta, which is the main canvas for rendering in this case

Also, I've done some little modifications on Ejecta end here: https://github.com/phoboslab/Ejecta/pull/262
It's working fine on my setup.
