### PR TITLE
Fixed WebGLRenderer updateGraphics bug

### DIFF
--- a/src/pixi/renderers/webgl/WebGLGraphics.js
+++ b/src/pixi/renderers/webgl/WebGLGraphics.js
@@ -110,7 +110,7 @@ PIXI.WebGLGraphics.updateGraphics = function(graphics)
         {
             PIXI.WebGLGraphics.buildRectangle(data, graphics._webGL);
         }
-        else if(data.type === PIXI.Graphics.CIRC || data.type === PIXI.Graphics.ELIP);
+        else if(data.type === PIXI.Graphics.CIRC || data.type === PIXI.Graphics.ELIP)
         {
             PIXI.WebGLGraphics.buildCircle(data, graphics._webGL);
         }


### PR DESCRIPTION
When using moveTo with the WEBGL renderer, a circle is drawn with the current lineStyle.

jsfiddle example: http://jsfiddle.net/theadam/kY9t9/

I tried to determine if this was a bug in the version of Pixi that is being used rather than in Phaser, but I couldn't figure out which version of Pixi the dev branch of Phaser is using. However, no tagged version of Pixi seems to have this problem.
