### PR TITLE
Allow Text.style to be any type

### DIFF
--- a/build/phaser.d.ts
+++ b/build/phaser.d.ts
@@ -799,7 +799,7 @@ declare module Phaser {
     }
 
     class Text {
-        constructor(game: Phaser.Game, x: number, y: number, text: string, style: string);
+        constructor(game: Phaser.Game, x: number, y: number, text: string, style: any);
         exists: boolean;
         alive: boolean;
         group: Phaser.Group;
@@ -809,7 +809,7 @@ declare module Phaser {
         type: number;
         text: string;
         angle: number;
-        style: string;
+        style: any;
         visible: boolean;
         position: Phaser.Point;
         anchor: Phaser.Point;


### PR DESCRIPTION
To allow a configuration object to be used rather than a string
