### PR TITLE
Allow fullscreen to work from iframe

### DIFF
--- a/examples/sideview.html
+++ b/examples/sideview.html
@@ -23,7 +23,7 @@
             <p><a href="index.html">Switch to Full View</a></p>
         </div>
 
-        <iframe id="viewer"></iframe>
+        <iframe id="viewer" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true"></iframe>
 
 </body>
 </html>


### PR DESCRIPTION
Was fixing some examples when I saw you were actively changing the things that were breaking, so here's a small tweak instead. Need to explicitly allow fullscreen from the iframe in sideview otherwise it will just silently fail.
