### PR TITLE
Updated to set rndFrame to frames

### DIFF
--- a/src/particles/arcade/Emitter.js
+++ b/src/particles/arcade/Emitter.js
@@ -297,7 +297,7 @@ Phaser.Particles.Arcade.Emitter.prototype.makeParticles = function (keys, frames
     var particle;
     var i = 0;
     var rndKey = keys;
-    var rndFrame = 0;
+    var rndFrame = frames;
 
     while (i < quantity)
     {


### PR DESCRIPTION
When passing number as the frames parameter to the makeParticle function the value was not set.

set the rndFrame value to frames to make this work
