### PR TITLE
Remove duplicate signature for Timer.create

### DIFF
--- a/build/phaser.d.ts
+++ b/build/phaser.d.ts
@@ -1357,7 +1357,6 @@ declare module Phaser {
         create(delay: number, loop: boolean, repeatCount: number, callback: any, callbackContext: any, ...args: any[]): Phaser.TimerEvent;
         add(delay: number, callback: any, callbackContext: any, ...args: any[]): Phaser.TimerEvent;
         repeat(delay: number, repeatCount: number, callback: any, callbackContext: any, ...args: any[]): Phaser.TimerEvent;
-        create(delay: number, loop: boolean, repeatCount: number, callback: any, callbackContext: any, ...args: any[]): Phaser.TimerEvent;
         loop(delay: number, callback: any, callbackContext: any, ...args: any[]): Phaser.TimerEvent;
         start(): void;
         stop(): void;


### PR DESCRIPTION
Addresses compile error "Duplicate overload signature for 'create'." when
compiling under TypeScript 0.9
