### PR TITLE
Phaser.Timer#stop 

### DIFF
--- a/src/time/Timer.js
+++ b/src/time/Timer.js
@@ -327,7 +327,7 @@ Phaser.Timer.prototype = {
         {
             this._i = 0;
 
-            while (this._i < this._len)
+            while (this._i < this._len && this.running)
             {
                 if (this._now >= this.events[this._i].tick)
                 {


### PR DESCRIPTION
Timer checks now for "this.running" inside the while loop condition. Any event which causes a call to Timer#stop is now safe.
It seems duplicate to check again for running inside the condition of the while loop. But this ensures that you can call Phaser.Timer#stop within a callstack which originates in a Phaser.TimerEvent.

I can perfectly reproduce an error with the following script:

```
var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', {create: create});

function create() {
    game.time.events.add(Phaser.Timer.SECOND + 100, other, this);
    game.time.events.add(Phaser.Timer.SECOND + 250, stoppingEvent, this);

    //A: causes error. Needs to have the same delay as the stopping event to cause an error
    game.time.events.add(Phaser.Timer.SECOND + 250, other, this);

    //B: keep another event in the future. Without this you get no error with (A)
    //as the counter is decrementing and invalidating the inner while loop
    game.time.events.add(Phaser.Timer.SECOND + 400, other, this);
}

function stoppingEvent() {
  //stop the timer. This will cause an error in the next timer update call.
  //Error: Uncaught TypeError: Cannot read property 'tick' of undefined 
  //in Line 332:  if (this._now >= this.events[this._i].tick)
  game.time.events.stop()
  console.log("Timer stopped")
}
function other() {
  //some other stuff
}
```

This code example is modified and  taken from my last comment in this issue https://github.com/photonstorm/phaser/issues/360. 
With the commited fix everything works fine. I do not know if this has any side effects. I guess not as the timer is stopping anyhow and therefore clearing the events array.
