### PR TITLE
Added a warning when the tile set image has not the expected dimensions.

### DIFF
--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -319,6 +319,10 @@ Phaser.TilemapParser = {
             newSet.columns = (set.imagewidth - set.margin) / (set.tilewidth + set.spacing);
             newSet.total = newSet.rows * newSet.columns;
 
+            if (newSet.rows % 1 !== 0 || newSet.columns % 1 !== 0) {
+                console.warn('TileSet image dimensions do not match expected dimensions.');
+            }
+
             tilesets.push(newSet);
         }
 


### PR DESCRIPTION
I wanted to use a tilesheet I found on the internet to create a map with tiled. All went fine, but when i tried to load the map in phaser no map was shown, but no errors or warnings popped up.

After a long debugging session I found out that the TilemapParser relies on the fact that the tilesheet image must have dimensions with multiples of the width / height of the tiles (+ margins and spacing) and will calculate nonsense values for x in the "super tileset index".

That would not be a problem when Tiled would fail as well, but as it turns out, Tiled worked like a charm with the tilesheet.

I added a check for that case which will simply spit out a warning so that other newbies like me wont have to debug half day long to find out what they did wrong. :-)

Tilesheet which caused the problem:
https://f.cloud.github.com/assets/177877/2112074/6e37b296-9019-11e3-9944-2b206d4cc171.png
