### PR TITLE
Update phaser.d.ts

### DIFF
--- a/build/phaser.d.ts
+++ b/build/phaser.d.ts
@@ -845,6 +845,7 @@ declare module Phaser {
         visible: boolean;
         renderable: boolean;
         width: number;
+        height: number;
         health: number;
         damage(amount: number): Phaser.Sprite;
     }


### PR DESCRIPTION
atlasJSONArray, atlasJSONHash should have optional parameters when it comes to URL/Object? Please disregard this if this is incorrect.

Edited: Yeah, after this change, my project worked as expected, before I was getting a NULL texture error as I was forced to load both a URL and an Object.

Updated: Sprite was missing height property. 
