### PR TITLE
Added Gestures; support for four initial gestures at the canvas level

### DIFF
--- a/src/input/Gestures.js
+++ b/src/input/Gestures.js
@@ -1,0 +1,661 @@
+/**
+* @author       Antony Woods <antony@teamwoods.org>
+* @copyright    2013 Photon Storm Ltd.
+* @license      {@link https://github.com/photonstorm/phaser/blob/master/license.txt|MIT License}
+*/
+
+/**
+* Phaser - Gestures constructor.
+*
+* @class Phaser.Gestures
+* @classdesc An object for controlling the detection of global gestures.
+* @constructor
+* @param {Phaser.Game} game - A reference to the currently running game.
+*/
+Phaser.Gestures = function (game) {
+
+    /**
+    * @property {Phaser.Game} game - A reference to the currently running game.
+    */
+    this.game = game;
+    
+    /**
+    * @property {boolean} active - If true, the Gestures class will attempt to detect gestures
+    * @default
+    */
+    this.active = true;
+    
+    /**
+    * @property {Array} _gestures - A list of gestures that we're currently tracking.
+    * @default
+    */
+    this._gestures = [];
+    
+    /**
+    * @property {Array} _pointers - A list of of pointers that are in the process of being detected
+    * @default
+    */
+    this._pointers = [];
+    
+    /**
+    * Update pointer state
+    */
+    this.game.input.setMoveCallback(function (pointer) {
+
+        if (this.active)
+        {
+           this._updatePointerState(pointer);
+        }
+    }, this);
+};
+
+Phaser.Gestures.prototype = {
+
+    /**
+    * Add a new pointer and gesture type to the detection system
+    * @method Phaser.Gestures#add
+    * @param {Phaser.Gestures} gesture - a gesture that we wish to detect (i.e. Phaser.Gestures.SwipeLeft)
+    * @param {function} onGestureUpdated - a callback for when the gesture updates (returns with valid data)
+    */
+    add: function (gesture, onGestureUpdated) {
+
+        this.add(gesture, onGestureUpdated, null, null);
+    },
+    
+    /**
+    * Add a new pointer and gesture type to the detection system
+    * @method Phaser.Gestures#add
+    * @param {Phaser.Gestures} gesture - a gesture that we wish to detect (i.e. Phaser.Gestures.SwipeLeft)
+    * @param {function} onGestureUpdated - a callback for when the gesture updates (returns with valid data)
+    * @param {function} onGestureStarted - a callback for when the gesture starts (begins detection)
+    * @param {function} onGestureStopped - a callback for when the gesture stops (ends detection)
+    */
+    add: function (gesture, onGestureUpdated, onGestureStarted, onGestureStopped) {
+
+        var gestureObject = {
+            gesture: new gesture(),
+            hasStarted: false,
+            onGestureStarted: onGestureStarted,
+            onGestureUpdated: onGestureUpdated,
+            onGestureStopped: onGestureStopped,
+        }
+        
+        this._gestures.push(gestureObject);       
+    },
+    
+    /**
+    * Remove a pointer and gesture combination from the detection system
+    * @method Phaser.Gestures#remove
+    * @param {Phaser.Gestures} gesture - a gesture that we no longer wish to detect (i.e. Phaser.Gestures.SwipeLeft)
+    */
+    remove: function (gesture) {
+
+        for(var i = this._gestures.length - 1; i >= 0; --i)
+        {
+            if(this._gestures[i].gesture.name == new gesture().name)
+            {
+                delete this._gestures[i];
+            }
+        }       
+        this._gestures = this._gestures.filter(function(a){return typeof a !== 'undefined';});
+    },
+    
+    /**
+    * Update function, called whenever a pointer triggers an event.
+    * @method Phaser.Gestures#update
+    */
+    update: function () {
+    
+        if(this.active && this._pointers.length > 0)
+        {   
+            var hasPointers = this._pointers.filter(function(p){return p.isDown;}).length > 0;
+            for(var i = this._gestures.length - 1; i >= 0; --i)
+            {
+                if(!this._gestures[i].hasStarted)
+                {
+                    this._gestures[i].hasStarted = true;
+                    this._gestures[i].gesture.start(this._pointers);
+                    if(this._gestures[i].onGestureStarted != null)
+                    {
+                        this._gestures[i].onGestureStarted();
+                    }
+                }
+                else
+                {
+                    var result = this._gestures[i].gesture.update(this._pointers);
+                    if(result){
+                        var data = this._gestures[i].gesture.getData();
+                        if(this._gestures[i].onGestureUpdated != null)
+                        {
+                            this._gestures[i].onGestureUpdated(data);
+                        }
+                    }
+                    if(!hasPointers)
+                    {
+                        this._gestures[i].gesture.stop(this._pointers);
+                        this._gestures[i].hasStarted = false;
+                        if(this._gestures[i].onGestureStopped != null)
+                        {
+                            this._gestures[i].onGestureStopped();
+                        }
+                    }
+                }               
+            }
+
+            this._pointers = this._pointers.filter(function(p){return p.isDown;});
+        }
+    },
+    
+    /**
+    * Updates internal pointer state
+    * @method Phaser.Gestures#update
+    * @param {Phaser.Pointer} pointer - the pointer that triggered this update
+    */
+    _updatePointerState: function (pointer) {
+    
+        var pointerObject = null;
+        for(var i = this._pointers.length - 1; i >= 0; --i)
+        {
+            if(this._pointers[i].pointer == pointer)
+            {
+                pointerObject = this._pointers[i];
+                break;
+            }
+        }
+
+        if(pointerObject == null && pointer.isDown)
+        {
+            pointerObject = {
+                pointer:pointer,
+                justPressed:true,
+                isUp:false,
+                isDown:true
+            }
+            this._pointers.push(pointerObject);
+        } 
+        else if(pointerObject != null)
+        {
+            pointerObject.justPressed = false;
+            pointerObject.isDown = pointer.isDown;
+            pointerObject.isUp = pointer.isUp;
+        }
+    }
+};
+
+Phaser.Gestures.prototype.constructor = Phaser.Gestures;
+
+/* ---------------------------------------- */
+
+Phaser.Gestures.Helpers = {
+
+    /**
+    * Finds or creates a local 'pointer' object from a given array
+    *
+    * @method Phaser.Gestures.Helpers#createOrFindPointerData 
+    * @param {Array} - an array of objects that expose 'pointer' as a field.
+    * @param {Phaser.Point} - the pointer object we're attempting to find.
+    */
+    createOrFindPointerData: function(pointerArray, pointer) {
+
+        var pointerObject = null;
+        for(var i = pointerArray.length - 1; i >= 0; --i)
+        {
+            if(pointerArray[i].pointer == pointer)
+            {
+                pointerObject = pointerArray[i];
+                break;
+            }
+        }
+        if(pointerObject == null)
+        {
+            pointerObject = {
+                pointer:pointer,
+                isNew: true
+            }
+            pointerArray.push(pointerObject);
+        } 
+        return pointerObject;
+    }
+};
+
+/* ---------------------------------------- */
+
+/**
+* Swipe-Left detection
+*
+* @class Phaser.Gestures.SwipeLeft
+*/
+Phaser.Gestures.SwipeLeft = function(game) {
+
+    /**
+    * @property {Phaser.Game} game - A reference to the currently running game. 
+    */
+    this.game = game;
+    
+    /**
+    * @property {String} - the name of the gesture
+    * @default
+    */
+    this.name = "SwipeLeft";
+    
+    /**
+    * @property {Array} _deltaXPerPointer - A list of delta X value for each pointer.
+    * @default
+    */
+    this._pointerData = [];
+};
+
+Phaser.Gestures.SwipeLeft.prototype = {
+
+    /** 
+    * Find a pointer data object using the helper
+    *
+    * @method Phaser.Gestures.SwipeLeft#_createOrFindPointerData 
+    * @param {Phaser.Pointer} - the pointer for which we want to retrieve data
+    */
+    _createOrFindPointerData: function(pointer){
+        var ptrObject = Phaser.Gestures.Helpers.createOrFindPointerData(this._pointerData, pointer);
+        if(ptrObject.isNew)
+        {
+            ptrObject.isNew = false;
+            ptrObject.lastX = pointer.pointer.x;
+            ptrObject.lastY = pointer.pointer.y;
+            ptrObject.hasTriggered = false;
+        }
+        return ptrObject;
+    },
+
+    /**
+    * Start detection process for gesture, called when a pointer touches the screen
+    *
+    * @method Phaser.Gestures.SwipeLeft#update 
+    * @param {Array} - an array to all the current pointers
+    */
+    start: function ( pointers ) {
+    
+        for(var i = pointers.length - 1; i >=0; --i)
+        {
+            this._createOrFindPointerData(pointers[i]);
+        }
+    },
+    
+    /**
+    * Update during the detection of a gesture, called when a pointer moves
+    *
+    * @method Phaser.Gestures.SwipeLeft#update 
+    * @param {Array} - an array to all the current pointers
+    * @returns {boolean} True, if the gesture has been detected and can return some tangible information.
+    */
+    update: function ( pointers ) {
+        for(var i = pointers.length - 1; i >=0; --i)
+        {
+            var ptrObject = this._createOrFindPointerData(pointers[i]);
+            if(ptrObject.pointer.isDown && !ptrObject.hasTriggered)
+            {
+                var currentX = pointers[i].pointer.x;
+                var deltaX = ptrObject.lastX - currentX;
+                ptrObject.lastX = currentX;
+                if(deltaX > 100){
+                    ptrObject.hasTriggered = true;
+                    return true;
+                }
+            }
+        }
+        
+        return false
+    },
+    
+    /**
+    * Stop detection process for gesture, called when a pointer leaves the screen
+    *
+    * @method Phaser.Gestures.SwipeLeft#update 
+    * @param {Array} - an array to all the current pointers
+   */
+    stop: function ( pointers ) {
+        this._pointerData = [];
+    },
+    
+    /**
+    * Fetches the current relevant data for this gesture
+    *
+    * @method Phaser.Gestures.SwipeLeft#getData 
+    * @returns {object} an object with data relating to the current state of this gesture
+   */
+    getData: function ( ) {
+        return { didSwipe: true };
+    }
+}
+
+Phaser.Gestures.SwipeLeft.prototype.constructor = Phaser.Gestures.SwipeLeft;
+    
+/* ---------------------------------------- */
+
+/**
+* Swipe-Right detection
+*
+* @class Phaser.Gestures.SwipeRight
+*/
+Phaser.Gestures.SwipeRight = function(game) {
+
+    /**
+    * @property {Phaser.Game} game - A reference to the currently running game. 
+    */
+    this.game = game;
+    
+    /**
+    * @property {String} - the name of the gesture
+    * @default
+    */
+    this.name = "SwipeRight";
+    
+    /**
+    * @property {Array} _deltaXPerPointer - A list of delta X value for each pointer.
+    * @default
+    */
+    this._pointerData = [];
+};
+
+Phaser.Gestures.SwipeRight.prototype = {
+
+    /** 
+    * Find a pointer data object using the helper
+    *
+    * @method Phaser.Gestures.SwipeRight#_createOrFindPointerData 
+    * @param {Phaser.Pointer} - the pointer for which we want to retrieve data
+    */
+    _createOrFindPointerData: function(pointer){
+        var ptrObject = Phaser.Gestures.Helpers.createOrFindPointerData(this._pointerData, pointer);
+        if(ptrObject.isNew)
+        {
+            ptrObject.isNew = false;
+            ptrObject.lastX = pointer.pointer.x;
+            ptrObject.lastY = pointer.pointer.y;
+            ptrObject.hasTriggered = false;
+        }
+        return ptrObject;
+    },
+
+    /**
+    * Start detection process for gesture, called when a pointer touches the screen
+    *
+    * @method Phaser.Gestures.SwipeRight#update 
+    * @param {Array} - an array to all the current pointers
+    */
+    start: function ( pointers ) {
+    
+        for(var i = pointers.length - 1; i >=0; --i)
+        {
+            this._createOrFindPointerData(pointers[i]);
+        }
+    },
+    
+    /**
+    * Update during the detection of a gesture, called when a pointer moves
+    *
+    * @method Phaser.Gestures.SwipeRight#update 
+    * @param {Array} - an array to all the current pointers
+    * @returns {boolean} True, if the gesture has been detected and can return some tangible information.
+    */
+    update: function ( pointers ) {
+        for(var i = pointers.length - 1; i >=0; --i)
+        {
+            var ptrObject = this._createOrFindPointerData(pointers[i]);
+            if(ptrObject.pointer.isDown && !ptrObject.hasTriggered)
+            {
+                var currentX = pointers[i].pointer.x;
+                var deltaX = ptrObject.lastX - currentX;
+                ptrObject.lastX = currentX;
+                if(deltaX < -100){
+                    ptrObject.hasTriggered = true;
+                    return true;
+                }
+            }
+        }
+        
+        return false
+    },
+    
+    /**
+    * Stop detection process for gesture, called when a pointer leaves the screen
+    *
+    * @method Phaser.Gestures.SwipeRight#update 
+    * @param {Array} - an array to all the current pointers
+   */
+    stop: function ( pointers ) {
+        this._pointerData = [];
+    },
+    
+    /**
+    * Fetches the current relevant data for this gesture
+    *
+    * @method Phaser.Gestures.SwipeRight#getData 
+    * @returns {object} an object with data relating to the current state of this gesture
+   */
+    getData: function ( ) {
+        return { didSwipe: true };
+    }
+}
+
+Phaser.Gestures.SwipeRight.prototype.constructor = Phaser.Gestures.SwipeRight;
+    
+/* ---------------------------------------- */
+
+/**
+* Swipe-Down detection
+*
+* @class Phaser.Gestures.SwipeDown
+*/
+Phaser.Gestures.SwipeDown = function(game) {
+
+    /**
+    * @property {Phaser.Game} game - A reference to the currently running game. 
+    */
+    this.game = game;
+    
+    /**
+    * @property {String} - the name of the gesture
+    * @default
+    */
+    this.name = "SwipeDown";
+    
+    /**
+    * @property {Array} _deltaXPerPointer - A list of delta X value for each pointer.
+    * @default
+    */
+    this._pointerData = [];
+};
+
+Phaser.Gestures.SwipeDown.prototype = {
+
+    /** 
+    * Find a pointer data object using the helper
+    *
+    * @method Phaser.Gestures.SwipeDown#_createOrFindPointerData 
+    * @param {Phaser.Pointer} - the pointer for which we want to retrieve data
+    */
+    _createOrFindPointerData: function(pointer){
+        var ptrObject = Phaser.Gestures.Helpers.createOrFindPointerData(this._pointerData, pointer);
+        if(ptrObject.isNew)
+        {
+            ptrObject.isNew = false;
+            ptrObject.lastX = pointer.pointer.x;
+            ptrObject.lastY = pointer.pointer.y;
+            ptrObject.hasTriggered = false;
+        }
+        return ptrObject;
+    },
+
+    /**
+    * Start detection process for gesture, called when a pointer touches the screen
+    *
+    * @method Phaser.Gestures.SwipeDown#update 
+    * @param {Array} - an array to all the current pointers
+    */
+    start: function ( pointers ) {
+    
+        for(var i = pointers.length - 1; i >=0; --i)
+        {
+            this._createOrFindPointerData(pointers[i]);
+        }
+    },
+    
+    /**
+    * Update during the detection of a gesture, called when a pointer moves
+    *
+    * @method Phaser.Gestures.SwipeDown#update 
+    * @param {Array} - an array to all the current pointers
+    * @returns {boolean} True, if the gesture has been detected and can return some tangible information.
+    */
+    update: function ( pointers ) {
+        for(var i = pointers.length - 1; i >=0; --i)
+        {
+            var ptrObject = this._createOrFindPointerData(pointers[i]);
+            if(ptrObject.pointer.isDown && !ptrObject.hasTriggered)
+            {
+                var currentY = pointers[i].pointer.y;
+                var deltaY = ptrObject.lastY - currentY;
+                ptrObject.lastY = currentY;
+                if(deltaY < -100){
+                    ptrObject.hasTriggered = true;
+                    return true;
+                }
+            }
+        }
+        
+        return false
+    },
+    
+    /**
+    * Stop detection process for gesture, called when a pointer leaves the screen
+    *
+    * @method Phaser.Gestures.SwipeDown#update 
+    * @param {Array} - an array to all the current pointers
+   */
+    stop: function ( pointers ) {
+        this._pointerData = [];
+    },
+    
+    /**
+    * Fetches the current relevant data for this gesture
+    *
+    * @method Phaser.Gestures.SwipeDown#getData 
+    * @returns {object} an object with data relating to the current state of this gesture
+   */
+    getData: function ( ) {
+        return { didSwipe: true };
+    }
+}
+
+Phaser.Gestures.SwipeDown.prototype.constructor = Phaser.Gestures.SwipeDown;
+
+/* ---------------------------------------- */
+
+/**
+* Swipe-Up detection
+*
+* @class Phaser.Gestures.SwipeUp
+*/
+Phaser.Gestures.SwipeUp = function(game) {
+
+    /**
+    * @property {Phaser.Game} game - A reference to the currently running game. 
+    */
+    this.game = game;
+    
+    /**
+    * @property {String} - the name of the gesture
+    * @default
+    */
+    this.name = "SwipeUp";
+    
+    /**
+    * @property {Array} _deltaXPerPointer - A list of delta X value for each pointer.
+    * @default
+    */
+    this._pointerData = [];
+};
+
+Phaser.Gestures.SwipeUp.prototype = {
+
+    /** 
+    * Find a pointer data object using the helper
+    *
+    * @method Phaser.Gestures.SwipeUp#_createOrFindPointerData 
+    * @param {Phaser.Pointer} - the pointer for which we want to retrieve data
+    */
+    _createOrFindPointerData: function(pointer){
+        var ptrObject = Phaser.Gestures.Helpers.createOrFindPointerData(this._pointerData, pointer);
+        if(ptrObject.isNew)
+        {
+            ptrObject.isNew = false;
+            ptrObject.lastX = pointer.pointer.x;
+            ptrObject.lastY = pointer.pointer.y;
+            ptrObject.hasTriggered = false;
+        }
+        return ptrObject;
+    },
+
+    /**
+    * Start detection process for gesture, called when a pointer touches the screen
+    *
+    * @method Phaser.Gestures.SwipeUp#update 
+    * @param {Array} - an array to all the current pointers
+    */
+    start: function ( pointers ) {
+    
+        for(var i = pointers.length - 1; i >=0; --i)
+        {
+            this._createOrFindPointerData(pointers[i]);
+        }
+    },
+    
+    /**
+    * Update during the detection of a gesture, called when a pointer moves
+    *
+    * @method Phaser.Gestures.SwipeUp#update 
+    * @param {Array} - an array to all the current pointers
+    * @returns {boolean} True, if the gesture has been detected and can return some tangible information.
+    */
+    update: function ( pointers ) {
+        for(var i = pointers.length - 1; i >=0; --i)
+        {
+            var ptrObject = this._createOrFindPointerData(pointers[i]);
+            if(ptrObject.pointer.isDown && !ptrObject.hasTriggered)
+            {
+                var currentY = pointers[i].pointer.y;
+                var deltaY = ptrObject.lastY - currentY;
+                ptrObject.lastY = currentY;
+                if(deltaY > 100){
+                    ptrObject.hasTriggered = true;
+                    return true;
+                }
+            }
+        }
+        
+        return false
+    },
+    
+    /**
+    * Stop detection process for gesture, called when a pointer leaves the screen
+    *
+    * @method Phaser.Gestures.SwipeUp#update 
+    * @param {Array} - an array to all the current pointers
+   */
+    stop: function ( pointers ) {
+        this._pointerData = [];
+    },
+    
+    /**
+    * Fetches the current relevant data for this gesture
+    *
+    * @method Phaser.Gestures.SwipeUp#getData 
+    * @returns {object} an object with data relating to the current state of this gesture
+   */
+    getData: function ( ) {
+        return { didSwipe: true };
+    }
+}
+
+Phaser.Gestures.SwipeUp.prototype.constructor = Phaser.Gestures.SwipeUp;
+
+/* ---------------------------------------- */

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -322,6 +322,13 @@ Phaser.Input.prototype = {
      * @default
      */
     gamepad: null,
+	
+	/**
+     * The Gestures manager.
+     * @property {Phaser.Gestures} gestures - The Gestures manager.
+     * @default
+     */
+    gestures: null,
 
     /**
     * A Signal that is dispatched each time a pointer is pressed down.
@@ -373,6 +380,7 @@ Phaser.Input.prototype = {
         this.touch = new Phaser.Touch(this.game);
         this.mspointer = new Phaser.MSPointer(this.game);
         this.gamepad = new Phaser.Gamepad(this.game);
+		this.gestures = new Phaser.Gestures(this.game);
 
         this.onDown = new Phaser.Signal();
         this.onUp = new Phaser.Signal();
@@ -413,6 +421,7 @@ Phaser.Input.prototype = {
         this.touch.stop();
         this.mspointer.stop();
         this.gamepad.stop();
+		this.gestures.stop();
 
         this.moveCallback = null;
 
@@ -496,6 +505,8 @@ Phaser.Input.prototype = {
         if (this.pointer8) { this.pointer8.update(); }
         if (this.pointer9) { this.pointer9.update(); }
         if (this.pointer10) { this.pointer10.update(); }
+		
+		this.gestures.update();
 
         this._pollCounter = 0;
     },


### PR DESCRIPTION
Not sure who else is interested in this, but I've added some boilerplate for detecting generic gestures at the canvas level, starting with SwipeLeft, SwipeRight, SwipeUp, SwipeDown. Very similar to Hammer.js but still primitive and 'Phaser'-ized.

```
game.input.gestures.add(Phaser.Gestures.SwipeLeft, function() { console.log("Swiped left"); });
game.input.gestures.add(Phaser.Gestures.SwipeRight, function() { console.log("Swiped right"); });
game.input.gestures.add(Phaser.Gestures.SwipeUp, function() { console.log("Swiped up"); });
game.input.gestures.add(Phaser.Gestures.SwipeDown, function() { console.log("Swiped down"); });
```

There's still tons of room for improvement here, but it's a start. Also, this is my first contrib to a JavaScript project so any amendments to style and form are encouraged.

Thanks :)
