### PR TITLE
[1.2] Added Phaser.Math.setPhysicsPixelRatio()

### DIFF
--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -13,12 +13,26 @@ Phaser.Math = {
 
     /**
     * = 2 &pi;
-    * @method Phaser.Math#PI2
+    * @property Phaser.Math#PI2
     */
     PI2: Math.PI * 2,
 
     /**
     * Two number are fuzzyEqual if their difference is less than &epsilon;. 
+    * = -20 pixels
+    * @property Phaser.Math._pxRatio
+    * @protected
+    */
+    _pxRatio: -20,
+
+    /**
+    * = -0.05 physics units
+    * @property Phaser.Math._pRatio
+    * @protected
+    */
+    _pRatio: -0.05,
+
+    /**
     * @method Phaser.Math#fuzzyEqual
     * @param {number} a
     * @param {number} b
@@ -1299,7 +1313,7 @@ Phaser.Math = {
     * @return {number} The scaled value.
     */
     p2px: function (v) {
-        return v *= -20;
+        return v *= Phaser.Math._pxRatio;
     },
 
     /**
@@ -1310,7 +1324,18 @@ Phaser.Math = {
     * @return {number} The scaled value.
     */
     px2p: function (v) {
-        return v * -0.05;
+        return v * Phaser.Math._pRatio;
+    },
+
+    /**
+    * Sets the pixel / p2 physics conversion scale.
+    *
+    * @method Phaser.Math#setPhysicsPixelRatio
+    * @param {number} ratio - The number of pixels per physics distance unit.
+    */
+    setPhysicsPixelRatio: function(ratio) {
+        Phaser.Math._pxRatio = -ratio;
+        Phaser.Math._pRatio  = -1 / ratio;
     },
 
     /**

--- a/src/physics/Body.js
+++ b/src/physics/Body.js
@@ -684,7 +684,7 @@ Phaser.Physics.Body.prototype = {
     */
     p2px: function (v) {
 
-        return v *= -20;
+        return this.game.math.p2px(v);
 
     },
 
@@ -697,7 +697,7 @@ Phaser.Physics.Body.prototype = {
     */
     px2p: function (v) {
 
-        return v * -0.05;
+        return this.game.math.px2p(v);
 
     }
 


### PR DESCRIPTION
This allows you to set the pixel-physics-unit-scale, vital to support a
wide variety of physics-using games.
