### PR TITLE
add the instance to the game in the constructor in the extending sprite example

### DIFF
--- a/examples/sprites/extending sprite demo 1.js
+++ b/examples/sprites/extending sprite demo 1.js
@@ -1,11 +1,11 @@
-
 //  Here is a custom game object
 MonsterBunny = function (game, x, y, rotateSpeed) {
 
     Phaser.Sprite.call(this, game, x, y, 'bunny');
 
     this.rotateSpeed = rotateSpeed;
-
+    
+    game.add.existing(this);
 };
 
 MonsterBunny.prototype = Object.create(Phaser.Sprite.prototype);


### PR DESCRIPTION
I'm not sure why this was needed [in my case](http://www.html5gamedevs.com/topic/3868-extended-sprite-is-not-rendering/#entry24455). Couldn't get it working without that line so I thought that this might help others.
