### PR TITLE
Unbundled p2. Load in a separate script tag.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,6 @@ module.exports = function (grunt) {
     compile_dir: 'dist',
     src: {
       phaser: [
-        'build/p2.js',
         'src/Intro.js',
         'src/pixi/Pixi.js',
         'src/Phaser.js',


### PR DESCRIPTION
This is the kind of crap that people get when you bundle libraries. We should move away from bundling for 1.2: https://github.com/schteppe/p2.js/commit/3c4840f943f91cfd30050033c6c9b2d45f4bd22a
