### PR TITLE
Do not invert (physics) shape size data for circle, rectangle, capsuel & line

### DIFF
--- a/src/physics/Body.js
+++ b/src/physics/Body.js
@@ -713,7 +713,7 @@ Phaser.Physics.Body.prototype = {
     */
     addCircle: function (radius, offsetX, offsetY, rotation) {
 
-        var shape = new p2.Circle(this.px2p(radius));
+        var shape = new p2.Circle(this.px2p(-radius));
 
         return this.addShape(shape, offsetX, offsetY, rotation);
 
@@ -732,7 +732,7 @@ Phaser.Physics.Body.prototype = {
     */
     addRectangle: function (width, height, offsetX, offsetY, rotation) {
 
-        var shape = new p2.Rectangle(this.px2p(width), this.px2p(height));
+        var shape = new p2.Rectangle(-this.px2p(width), -this.px2p(height));
 
         return this.addShape(shape, offsetX, offsetY, rotation);
 
@@ -786,7 +786,7 @@ Phaser.Physics.Body.prototype = {
     */
     addLine: function (length, offsetX, offsetY, rotation) {
 
-        var shape = new p2.Line(this.px2p(length));
+        var shape = new p2.Line(-this.px2p(length));
 
         return this.addShape(shape, offsetX, offsetY, rotation);
 
@@ -806,7 +806,7 @@ Phaser.Physics.Body.prototype = {
     */
     addCapsule: function (length, radius, offsetX, offsetY, rotation) {
 
-        var shape = new p2.Capsule(this.px2p(length), radius);
+        var shape = new p2.Capsule(-this.px2p(length), radius);
 
         return this.addShape(shape, offsetX, offsetY, rotation);
 


### PR DESCRIPTION
Phaser.Physics.Body#px2p inverts and scales a number. The inverting is used to flip the position. When this method is used with dimensions, the dimensions will be flipped into a negative value. That's actually wrong. 

Although it is working with rectangle shapes (even it makes no sense) it's causing wrong or no collisions with circles and maybe other shapes. I fixed all shapes with dimensions by flipping the value again (circle, rectangle, capsuel & line).
