### PR TITLE
Fix typo of Phaser.Graphics.prototype.destroy for docs

### DIFF
--- a/src/gameobjects/Graphics.js
+++ b/src/gameobjects/Graphics.js
@@ -36,7 +36,7 @@ Phaser.Graphics.prototype.constructor = Phaser.Graphics;
 /**
 * Destroy this Graphics instance.
 * 
-* @method Phaser.Sprite.prototype.destroy
+* @method Phaser.Graphics.prototype.destroy
 */
 Phaser.Graphics.prototype.destroy = function() {
 


### PR DESCRIPTION
The method was appearing in the wrong file in the documentation
