### PR TITLE
Fix typo of Phaser.TweenManager#pauseAll for docs

### DIFF
--- a/src/tween/TweenManager.js
+++ b/src/tween/TweenManager.js
@@ -174,7 +174,7 @@ Phaser.TweenManager.prototype = {
     /**
     * Pauses all currently running tweens.
     *
-    * @method Phaser.TweenManager#update
+    * @method Phaser.TweenManager#pauseAll
     */
     pauseAll: function () {
 
@@ -186,7 +186,7 @@ Phaser.TweenManager.prototype = {
     },
 
     /**
-    * Pauses all currently paused tweens.
+    * Resumes all currently paused tweens.
     *
     * @method Phaser.TweenManager#resumeAll
     */


### PR DESCRIPTION
Also fixed a typo in the description of resumeAll.
