### PR TITLE
Fixed Phaser.Group#destroy(true)

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -1147,7 +1147,7 @@ Phaser.Group.prototype.destroy = function (destroyChildren) {
         {
             do
             {
-                if (this.children[0].group)
+                if (this.children[0].parent)
                 {
                     this.children[0].destroy();
                 }


### PR DESCRIPTION
There is an endless loop when you use Phaser.Group#destroy(true) to destroy all  the children.
I guess this is just an artefact from the old link list based Group system ?

I grepped through the sources and found another position where sprite.group is used instead of sprite.parent. Maybe this is also wrong ? See InputHandler at 
~~https://github.com/georgiee/phaser/blob/e88b10323a3acbf84e4726abda1130806ef72836/src/input/InputHandler.js#L495 and at https://github.com/georgiee/phaser/blob/e88b10323a3acbf84e4726abda1130806ef72836/src/input/InputHandler.js#L555~~

I mixed up the branches and took the outdated branch 1.2 from my fork :)
https://github.com/photonstorm/phaser/blob/34fa6ffaeb65d9b76e0d335802d5131cf6db699b/src/input/InputHandler.js#L631

Thanks!
