### PR TITLE
Fix Game.renderType docs

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -71,7 +71,7 @@ Phaser.Game = function (width, height, renderer, parent, state, transparent, ant
     this.renderer = Phaser.AUTO;
 
     /**
-    * @property {number} renderType - The Renderer this Phaser.Game will use. Either Phaser.RENDERER_AUTO, Phaser.RENDERER_CANVAS or Phaser.RENDERER_WEBGL.
+    * @property {number} renderType - The Renderer this Phaser.Game will use. Either Phaser.AUTO, Phaser.CANVAS, Phaser.WEBGL or Phaser.HEADLESS.
     */
     this.renderType = Phaser.AUTO;
 


### PR DESCRIPTION
It looks like `Phaser.RENDERER_AUTO`, `Phaser.RENDERER_CANVAS` and `Phaser.RENDERER_WEBGL` have become `Phaser._AUTO`, `Phaser.CANVAS` and `Phaser.WEBGL`. The docs for `Game.renderType` still reference the old constants.

I think these are the new definitions of the constants:
https://github.com/photonstorm/phaser/blob/37323562cde75f085de4cf35bfb2e4d831ee4163/src/Phaser.js#L16-19

The docs here still reference the old constants:
https://github.com/photonstorm/phaser/blob/37323562cde75f085de4cf35bfb2e4d831ee4163/src/core/Game.js#L73-76

My patch is only changes the docs of `Game.renderType`. I also added `Phaser.HEADLESS`, which I think is correct?

Again, I don't know how to rebuild the HTML docs, so you may want to do that after applying the patch. I could also do this patch on 1.2 if that would be better?

Furthermore, some of the TypeScript definitions seem to also reference the old constants, but I don't know Typescript.
