### PR TITLE
Dispatch onMarkerComplete signal when sound completes playing a marker

### DIFF
--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -366,6 +366,7 @@ Phaser.Sound.prototype = {
                     {
                         // console.log('stopping, no loop for marker');
                         this.stop();
+                        this.onMarkerComplete.dispatch(this);
                     }
                 }
                 else
@@ -378,6 +379,7 @@ Phaser.Sound.prototype = {
                     else
                     {
                         this.stop();
+                        this.onMarkerComplete.dispatch(this);
                     }
                 }
             }


### PR DESCRIPTION
Hi,

The onMarkerComplete signal was never dispatched. I searched through the issues on here and wasn't able to find anything about it. Example [here](http://jsbin.com/nelawagu/18/).

Please let me know if I did anything incorrectly. 

Thanks
