### PR TITLE
PIXI + Phaser Definitions

### DIFF
--- a/build/phaser.d.ts
+++ b/build/phaser.d.ts
@@ -71,6 +71,1007 @@ declare module SAT {
     }
 }
 
+// Type definitions for PIXI 1.5.1
+// Project: https://github.com/GoodBoyDigital/pixi.js/
+// Original 1.3 by: xperiments <http://github.com/xperiments> 
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module PIXI {
+
+    /* CONSTANTS */
+    export var WEBGL_RENDERER: number;
+    export var CANVAS_RENDERER: number;
+    export var VERSION: string;
+
+    export enum blendModes {
+
+        NORMAL,
+        ADD,
+        MULTIPLY,
+        SCREEN,
+        OVERLAY,
+        DARKEN,
+        LIGHTEN,
+        COLOR_DODGE,
+        COLOR_BURN,
+        HARD_LIGHT,
+        SOFT_LIGHT,
+        DIFFERENCE,
+        EXCLUSION,
+        HUE,
+        SATURATION,
+        COLOR,
+        LUMINOSITY
+
+    }
+
+    export enum scaleModes {
+
+        DEFAULT,
+        LINEAR,
+        NEAREST
+
+    }
+
+    export var INTERACTION_FREQUENCY: number;
+    export var AUTO_PREVENT_DEFAULT: boolean;
+    export var RAD_TO_DEG: number;
+    export var DEG_TO_RAD: number;
+
+    /* MODULE FUNCTIONS */
+    export function autoDetectRenderer(width: number, height: number, view?: HTMLCanvasElement, transparent?: boolean, antialias?: boolean): IPixiRenderer;
+    export function AjaxRequest(): XMLHttpRequest;
+    export function canUseNewCanvasBlendModes(): boolean;
+    export function getNextPowerOfTwo(): number;
+    export function rgb2hex(rgb: any): number;
+    export function hex2rgb(hex: number): any;
+
+    /*INTERFACES*/
+    export interface IBasicCallback {
+        (): void
+    }
+
+    export interface IEventCallback {
+        (e?: IEvent): void
+    }
+
+    export interface IEvent {
+        type: string;
+        content: any;
+    }
+
+    export interface IHitArea {
+        contains(x: number, y: number): boolean;
+    }
+
+    export interface IInteractionDataCallback {
+        (interactionData: InteractionData): void
+    }
+
+    export interface IPixiRenderer {
+        view: HTMLCanvasElement;
+        render(stage: Stage): void;
+    }
+
+    export interface IBitmapTextStyle {
+        font?: string;
+        align?: string;
+        tint?: string;
+    }
+
+    export interface ITextStyle {
+        font?: string;
+        stroke?: string;
+        fill?: string;
+        align?: string;
+        strokeThickness?: number;
+        wordWrap?: boolean;
+        wordWrapWidth?: number;
+    }
+
+    export interface IUniform {
+        type: string;
+        value: any;
+    }
+
+    export interface ILoader {
+
+        constructor(url: string, crossorigin: boolean);
+
+        load();
+    }
+
+    export interface ITintMethod {
+        (texture: Texture, color: number, canvas: HTMLCanvasElement): void;
+    }
+
+    export interface IMaskData {
+        alpha: number;
+        worldTransform: number[];
+    }
+
+    export interface IRenderSession // unclear; Taken from DisplayObjectContainer:152
+    {
+        context: CanvasRenderingContext2D;
+        maskManager: CanvasMaskManager;
+        scaleMode: scaleModes;
+        smoothProperty: string;
+    }
+
+    export interface IShaderAttribute {
+        // TODO: Find signature of shader attributes
+    }
+
+    export interface IFilterBlock {
+        // TODO: Find signature of filterBlock
+    }
+
+    export interface IMatrix {
+        // TODO: Find signature of Matrix
+    }
+
+    /* CLASSES */
+
+    export class AbstractFilter {
+
+        passes: AbstractFilter[];
+        shaders: PixiShader[];
+        dirty: boolean;
+        padding: number;
+        uniforms: { [name: string]: IUniform };
+        fragmentSrc: any[];
+
+    }
+
+    export class AlphaMaskFilter extends AbstractFilter {
+
+        map: Texture;
+
+        constructor(texture: Texture);
+
+        onTextureLoaded(): void;
+
+    }
+
+    export class AssetLoader extends EventTarget {
+
+        assetURLs: string[];
+        crossorigin: boolean;
+        loadersByType: { [key: string]: ILoader };
+
+        constructor(assetURLs: string[], crossorigin: boolean);
+
+        load(): void;
+
+    }
+
+    export class AtlasLoader extends EventTarget {
+
+        url: string;
+        baseUrl: string;
+        crossorigin: boolean;
+        loaded: boolean;
+
+        constructor(url: string, crossorigin: boolean);
+
+        load(): void;
+
+    }
+
+    export class BaseTexture extends EventTarget {
+
+        id: number;
+        height: number;
+        width: number;
+        source: HTMLImageElement;
+        scaleMode: scaleModes;
+        hasLoaded: boolean;
+
+        constructor(source: HTMLImageElement, scaleMode: scaleModes);
+        constructor(source: HTMLCanvasElement, scaleMode: scaleModes);
+
+        destroy(): void;
+        updateSourceImage(newSrc: string): void;
+
+        static fromImage(imageUrl: string, crossorigin: boolean, scaleMode: scaleModes): BaseTexture;
+        static fromCanvas(canvas: HTMLCanvasElement, scaleMode: scaleModes): BaseTexture;
+
+    }
+
+    export class BitmapFontLoader extends EventTarget {
+
+        baseUrl: string;
+        crossorigin: boolean;
+        texture: Texture;
+        url: string;
+
+        constructor(url: string, crossorigin: boolean);
+
+        load(): void;
+
+    }
+
+    export class BitmapText extends DisplayObjectContainer {
+
+        width: number;
+        height: number;
+        fontName: string;
+        fontSize: number;
+        tint: number;
+        textWidth: number;
+        textHeight: number;
+
+        constructor(text: string, style: IBitmapTextStyle);
+
+        setText(text: string): void;
+        setStyle(style: IBitmapTextStyle): void;
+
+    }
+
+    export class BlurFilter extends AbstractFilter {
+
+        blur: number;
+        blurX: number;
+        blurY: number;
+
+    }
+
+    export class BlurXFilter extends AbstractFilter {
+
+        blur: number;
+
+    }
+
+    export class BlurYFilter extends AbstractFilter {
+
+        blur: number;
+
+    }
+
+    export class CanvasMaskManager {
+
+        pushMask(maskData: IMaskData, context: CanvasRenderingContext2D): void;
+        popMask(context: CanvasRenderingContext2D): void;
+
+    }
+
+    export class CanvasRenderer implements IPixiRenderer {
+
+        type: number;
+        clearBeforeRender: boolean;
+        roundPixels: boolean;
+        transparent: boolean;
+        width: number;
+        height: number;
+        view: HTMLCanvasElement;
+        context: CanvasRenderingContext2D;
+        refresh: boolean;
+        count: number;
+        maskManager: CanvasMaskManager;
+        renderSession: IRenderSession;
+
+        constructor(width: number, height: number, view?: HTMLCanvasElement, transparent?: boolean);
+
+        render(stage: Stage): void;
+        resize(width: number, height: number): void;
+
+    }
+
+    export class CanvasTinter {
+
+        canvas: HTMLCanvasElement;
+
+        getTintedTexture(sprite: Sprite, color: number): HTMLCanvasElement;
+        tintWithMultiply(texture: Texture, color: number, canvas: HTMLCanvasElement): void;
+        tintWithOverlay(texture: Texture, color: number, canvas: HTMLCanvasElement): void;
+        tintWithPerPixel(texture: Texture, color: number, canvas: HTMLCanvasElement): void;
+
+        static cacheStepsPerColorChannel: number;
+        static convertTintToImage: boolean;
+        static canUseMultiply: boolean;
+        static tintMethod: ITintMethod;
+
+        static roundColor(color: number): number;
+
+    }
+
+    export class Circle implements IHitArea {
+
+        x: number;
+        y: number;
+        radius: number;
+
+        constructor(x: number, y: number, radius: number);
+
+        clone(): Circle;
+        contains(x: number, y: number): boolean;
+
+    }
+
+    export class ColorMatrixFilter extends AbstractFilter {
+
+        matrix: number[];
+
+    }
+
+    export class ColorStepFilter extends AbstractFilter {
+
+        step: number;
+
+    }
+
+    export class CrossHatchFilter extends AbstractFilter {
+
+        blur: number;
+
+    }
+
+    export class DisplacementFilter extends AbstractFilter {
+
+        map: Texture;
+        offset: Point;
+        scale: Point;
+
+        constructor(texture: Texture);
+
+    }
+
+    export class DotScreenFilter extends AbstractFilter {
+
+        scale: Point;
+        angle: number;
+
+    }
+
+    export class DisplayObject {
+
+        alpha: number;
+        buttonMode: boolean;
+        defaultCursor: string;
+        filterArea: Rectangle;
+        filters: AbstractFilter[];
+        hitArea: IHitArea;
+        interactive: boolean;
+        mask: Graphics;
+        parent: DisplayObjectContainer;
+        pivot: Point;
+        position: Point;
+        renderable: boolean;
+        rotation: number;
+        scale: Point;
+        stage: Stage;
+        visible: boolean;
+        worldAlpha: number;
+        worldVisible: boolean;
+        worldTransform: IMatrix;
+        x: number;
+        y: number;
+
+        click(e: InteractionData): void;
+        getBounds(matrix?: IMatrix): Rectangle;
+        getLocalBounds(): Rectangle;
+        generateTexture(renderer: PIXI.IPixiRenderer): RenderTexture;
+        mousedown(e: InteractionData): void;
+        mouseout(e: InteractionData): void;
+        mouseover(e: InteractionData): void;
+        mouseup(e: InteractionData): void;
+        mouseupoutside(e: InteractionData): void;
+        setStageReference(stage: Stage): void;
+        tap(e: InteractionData): void;
+        touchend(e: InteractionData): void;
+        touchendoutside(e: InteractionData): void;
+        touchstart(e: InteractionData): void;
+
+    }
+
+    export class DisplayObjectContainer extends PIXI.DisplayObject {
+
+        height: number;
+        width: number;
+        children: DisplayObject[];
+
+        addChild(child: DisplayObject): void;
+        addChildAt(child: DisplayObject, index: number): void;
+        getChildAt(index: number): DisplayObject;
+        removeChild(child: DisplayObject): void;
+        removeStageReference(): void;
+
+    }
+
+    export class Ellipse implements IHitArea {
+
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+
+        constructor(x: number, y: number, width: number, height: number);
+
+        clone(): Ellipse;
+        contains(x: number, y: number): boolean;
+        getBounds(): Rectangle;
+    }
+
+    export class EventTarget {
+
+        listeners: { [key: string]: IEventCallback[] };
+
+        addEventListener(type: string, listener: IEventCallback): void;
+        dispatchEvent(event: IEvent): void;
+        removeAllEventListeners(type: string): void;
+        removeEventListener(type: string, listener: IEventCallback): void;
+
+    }
+
+    export class FilterBlock {
+
+        visible: boolean;
+        renderable: boolean;
+
+    }
+
+    export class FilterTexture {
+
+        fragmentSrc: string[];
+        gl: any;
+        program: any;
+
+        constructor(gl: any, width: number, height: number);
+        clear(): void;
+        resize(width: number, height: number): void;
+        destroy(): void;
+
+    }
+
+    export class Graphics extends Texture {
+
+        blendMode: blendModes;
+        bounds: Rectangle;
+        boundsPadding: number;
+        fillAlpha: number;
+        isMask: boolean;
+        lineColor: string;
+        lineWidth: number;
+        renderable: boolean;
+        tint: number;
+
+        beginFill(color: number, alpha: number): void;
+        clear(): void;
+        drawCircle(x: number, y: number, radius: number): void;
+        drawEllipse(x: number, y: number, width: number, height: number): void;
+        drawRect(x: number, y: number, width: number, height: number): void;
+        endFill(): void;
+        generateTexture(): Texture;
+        getBounds(): Rectangle;
+        lineStyle(lineWidth: number, color: number, alpha: number): void;
+        lineTo(x: number, y: number): void;
+        moveTo(x: number, y: number): void;
+        updateBounds(): void;
+
+    }
+
+    export class GrayFilter extends AbstractFilter {
+
+        gray: number;
+
+    }
+
+    export class ImageLoader extends EventTarget {
+
+        texture: Texture;
+
+        constructor(url: string, crossorigin?: boolean);
+        load(): void;
+        loadFramedSpriteSheet(frameWidth: number, frameHeight: number, textureName: string): void;
+
+    }
+
+    export class InteractionData {
+
+        global: Point;
+        target: Sprite;
+        originalEvent: Event;
+
+        getLocalPosition(displayObject: DisplayObject): Point;
+
+    }
+
+    export class InteractionManager {
+
+        currentCursorStyle: string;
+        mouse: InteractionData;
+        mouseOut: boolean;
+        mouseoverEnabled: boolean;
+        pool: InteractionData[];
+        stage: Stage;
+        touchs: { [id: string]: InteractionData };
+
+        constructor(stage: Stage);
+
+        removeEvents(): void;
+    }
+
+    export class InvertFilter {
+
+        invert: number;
+
+    }
+
+    export class JsonLoader extends EventTarget {
+
+        baseUrl: string;
+        crossorigin: boolean;
+        loaded: boolean;
+        url: string;
+
+        constructor(url: string, crossorigin?: boolean);
+
+        load(): void;
+
+    }
+
+    export class MovieClip extends Sprite {
+
+        animationSpeed: number;
+        currentFrame: number;
+        loop: boolean;
+        playing: boolean;
+        textures: Texture[];
+        totalFrames: number;
+
+        constructor(textures: Texture[]);
+
+        onComplete: IBasicCallback;
+
+        gotoAndPlay(frameNumber: number): void;
+        gotoAndStop(frameNumber: number): void;
+        play(): void;
+        stop(): void;
+
+    }
+
+    export class NormalMapFilter extends AbstractFilter {
+
+        map: Texture;
+        offset: Point;
+        scale: Point;
+
+    }
+
+    export class PixelateFilter extends AbstractFilter {
+
+        size: number;
+
+    }
+
+    export class PixiFastShader {
+
+        gl: any;
+        fragmentSrc: string[];
+        program: any;
+        textureCount: number;
+        vertexSrc: string[];
+
+        constructor(gl: any);
+
+        destroy(): void;
+        init(): void;
+
+    }
+
+    export class PixiShader {
+
+        defaultVertexSrc: string;
+        fragmentSrc: string[];
+        gl: any;
+        program: any;
+        textureCount: number;
+        attributes: IShaderAttribute[];
+        defaultVertexSr: string;
+
+        constructor(gl: any);
+
+        destroy(): void;
+        init(): void;
+        initSampler2D(): void;
+        initUniforms(): void;
+        syncUniforms(): void;
+
+    }
+
+    export class Point {
+
+        x: number;
+        y: number;
+
+        constructor(x?: number, y?: number);
+
+        clone(): Point;
+        set(x: number, y: number): void;
+
+    }
+
+    export class Polygon implements IHitArea {
+
+        points: Point[];
+
+        constructor(points: Point[]);
+        constructor(points: number[]);
+        constructor(...points: Point[]);
+        constructor(...points: number[]);
+
+        clone(): Polygon;
+        contains(x: number, y: number): boolean;
+
+    }
+
+    export class PrimitiveShader {
+
+        gl: any;
+        program: any;
+        fragmentSrc: string[];
+        vertextSrc: string[];
+
+        destroy(): void;
+        init(): void;
+
+    }
+
+    export class Rectangle implements IHitArea {
+
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+
+        constructor(x?: number, y?: number, width?: number, height?: number);
+
+        clone(): Rectangle;
+        contains(x: number, y: number): boolean;
+
+    }
+
+    export class RenderTexture extends Texture {
+
+        width: number;
+        height: number;
+        frame: Rectangle;
+        baseTexture: BaseTexture;
+
+        constructor(width: number, height: number, renderer: IPixiRenderer);
+
+        resize(width: number, height: number): void;
+
+    }
+
+    export class RGBSplitFilter extends AbstractFilter {
+
+        angle: number;
+
+    }
+
+    export class Rope {
+
+        points: Point[];
+        vertices: Float32Array;
+        uvs: Float32Array;
+        colors: Float32Array;
+        indices: Uint16Array;
+
+        constructor(texture: Texture, points: Point[]);
+
+        refresh(): void;
+        setTexture(texture: Texture);
+
+    }
+
+    export class SepiaFilter {
+
+        sepia: number;
+
+    }
+
+    export class SmartBlurFilter {
+
+        blur: number;
+
+    }
+
+    export class Spine {
+
+        url: string;
+        crossorigin: boolean;
+        loaded: boolean;
+
+        constructor(url: string);
+
+        createSprite(slot: any, descriptor: string): Sprite;
+
+        load();
+    }
+
+    export class SpineLoader extends EventTarget {
+
+        url: string;
+        crossorigin: boolean;
+        loaded: boolean;
+
+        constructor(url: string, crossorigin?: boolean);
+
+        load(): void;
+
+    }
+
+    export class Sprite extends DisplayObjectContainer {
+
+        anchor: Point;
+        blendMode: number;
+        texture: Texture;
+        height: number;
+        width: number;
+        tint: number;
+
+        constructor(texture: Texture);
+
+        getBounds(matrix?: IMatrix): Rectangle;
+        setTexture(texture: Texture): void;
+
+        static fromFrame(frameId: string): Sprite;
+        static fromImage(url: string): Sprite;
+
+    }
+
+    export class SpriteBatch {
+
+        constructor(texture: Texture);
+
+    }
+
+    /* TODO determine type of frames */
+    export class SpriteSheetLoader extends EventTarget {
+
+        url: string;
+        crossorigin: boolean;
+        baseUrl: string;
+        texture: Texture;
+        frames: Object;
+
+        constructor(url: string, crossorigin?: boolean);
+
+        load();
+    }
+
+    export class Stage extends DisplayObjectContainer {
+
+        interactive: boolean;
+        interactionManager: InteractionManager;
+        worldTransform: IMatrix;
+
+        constructor(backgroundColor: number);
+
+        getMousePosition(): Point;
+        setBackgroundColor(backgroundColor: number): void;
+        setInteractionDelegate(domElement: HTMLElement): void;
+
+    }
+
+    export class Strip extends DisplayObjectContainer {
+
+        constructor(texture: Texture, width: number, height: number);
+
+    }
+
+    export class StripShader {
+
+        program: any;
+        fragmentSrc: string[];
+        vertexSrc: string[];
+
+        init(): void;
+
+    }
+
+    export class Text extends Sprite {
+
+        canvas: HTMLCanvasElement;
+        context: CanvasRenderingContext2D;
+
+        constructor(text: string, style: ITextStyle);
+
+        destroy(destroyTexture: boolean): void;
+        setText(text: string): void;
+        setStyle(style: ITextStyle): void;
+
+    }
+
+    export class Texture extends EventTarget {
+
+        baseTexture: BaseTexture;
+        frame: Rectangle;
+        trim: Point;
+        width: number;
+        height: number;
+
+        constructor(baseTexture: BaseTexture, frame?: Rectangle);
+
+        destroy(destroyBase?: boolean): void;
+        setFrame(frame: Rectangle): void;
+        render(displayObject: DisplayObject, position: Point, clear: boolean): void;
+
+        static fromImage(imageUrl: string, crossorigin: boolean, scaleMode: scaleModes): Texture;
+        static fromFrame(frameId: string): Texture;
+        static fromCanvas(canvas: HTMLCanvasElement, scaleMode: scaleModes): Texture;
+        static addTextureToCache(texture: Texture, id: string): void;
+        static removeTextureFromCache(id: string): Texture;
+
+    }
+
+    export class TilingSprite extends DisplayObjectContainer {
+
+        width: number;
+        height: number;
+        renderable: boolean;
+        texture: Texture;
+        tint: number;
+        tilePosition: Point;
+        tileScale: Point;
+        tileScaleOffset: Point;
+        blendMode: blendModes;
+
+        constructor(texture: Texture, width: number, height: number);
+
+        generateTilingTexture(forcePowerOfTwo: boolean): void;
+
+    }
+
+    export class TwistFilter extends AbstractFilter {
+
+        size: Point;
+        angle: number;
+        radius: number;
+
+    }
+
+    export class WebGLFastSpriteBatch {
+
+        vertSize: number;
+        maxSize: number;
+        size: number;
+        vertices: Float32Array;
+        indices: Uint16Array;
+        vertextBuffer: any;
+        indexBuffer: any;
+        lastIndexCount: number;
+        drawing: boolean;
+        currentBatchSize: number;
+        currentBaseTexture: Texture;
+        currentBlendMode: number;
+        renderSession: any;
+        shader: any;
+        matrix: any;
+
+        begin(spriteBatch: any, renderSession: any): void;
+        end(): void;
+        flush(): void;
+        render(spriteBatch: any): void;
+        renderSprite(sprite: any): void;
+        stop(): void;
+        start(): void;
+        setContext(gl: any): void;
+        setBlendMode(blendMode: PIXI.blendModes): void;
+
+    }
+
+    export class WebGLFilterManager {
+
+        filterStack: AbstractFilter[];
+        transparent: boolean;
+        offsetX: number;
+        offsetY: number;
+
+        constructor(gl: any, transparent: boolean);
+
+        applyFilterPass(filter: AbstractFilter, filterArea: Texture, width: number, height: number): void;
+        begin(renderSession: IRenderSession, buffer: ArrayBuffer): void;
+        destroy(): void;
+        initShaderBuffers(): void;
+        pushFilter(filterBlock: IFilterBlock): void;
+        popFilter(): void;
+        setContext(gl: any);
+
+    }
+
+    export class WebGLGraphics {
+
+    }
+
+    export class WebGLMaskManager {
+
+        constructor(gl: any);
+
+        destroy(): void;
+        pushMask(maskData: any[], renderSession: IRenderSession): void;
+        popMask(renderSession: IRenderSession): void;
+        setContext(gl: any);
+
+    }
+
+    export class WebGLRenderer implements IPixiRenderer {
+
+        contextLost: boolean;
+        width: number;
+        height: number;
+        transparent: boolean;
+        view: HTMLCanvasElement;
+
+        constructor(width: number, height: number, view?: HTMLCanvasElement, transparent?: boolean, antialias?: boolean);
+
+        destroy(): void;
+        render(stage: Stage): void;
+        renderDisplayObject(displayObject: DisplayObject, projection: Point, buffer: any): void;
+        resize(width: number, height: number): void;
+
+        static createWebGLTexture(texture: Texture, gl: any): void;
+
+    }
+
+    export class WebGLShaderManager {
+
+        activatePrimitiveShader(): void;
+        activateShader(shader: PixiShader): void;
+        deactivatePrimitiveShader(): void;
+        destroy(): void;
+        setAttribs(attribs: IShaderAttribute[]): void;
+        setContext(gl: any, transparent: boolean);
+
+    }
+
+    export class WebGLShaderUtils {
+
+
+
+    }
+
+    export class WebGLSpriteBatch {
+
+        currentBatchSize: number;
+        currentBaseTexture: any;
+        drawing: boolean;
+        indices: Uint16Array;
+        lastIndexCount: number;
+        size: number;
+        vertices: Float32Array;
+        vertSize: number;
+
+        constructor(gl: any);
+
+        begin(renderSession: IRenderSession): void;
+        flush(): void;
+        end(): void;
+        destroy(): void;
+        render(sprite: Sprite): void;
+        renderTilingSprite(sprite: TilingSprite): void;
+        setBlendMode(blendMode: blendModes): void;
+        setContext(gl: any): void;
+        start(): void;
+        stop(): void;
+
+    }
+}
+
+declare module PIXI.PolyK {
+
+    export function Triangulate(p: number[]): number[];
+
+}
+
+declare function canUseNewCanvasBlendModes(): boolean;
+declare function getBounds(): Phaser.Rectangle;
+declare function getNextPowerOfTwo(value: number): number;
+declare function hex2rgb(hex: number): number[];
+declare function hitText(displayObject: any): boolean;
+declare function rgb2hex(rgb: number[]): number;
+
 declare class Phaser {
 
     static VERSION: string;
@@ -113,8 +1114,7 @@ declare module Phaser {
 
     class Animation {
         //constructor
-        constructor(game: Phaser.Game, parent: Phaser.Sprite, name: string, frameData: Phaser.FrameData, frames: string[], delay: number, looped: boolean);
-        constructor(game: Phaser.Game, parent: Phaser.Sprite, name: string, frameData: Phaser.FrameData, frames: number[], delay: number, looped: boolean);
+        constructor(game: Phaser.Game, parent: Phaser.Sprite, name: string, frameData: Phaser.FrameData, frames: any[], delay: number, looped: boolean);
         //properties
         currentFrame: Phaser.Frame;
         delay: number;
@@ -154,8 +1154,7 @@ declare module Phaser {
         sprite: Phaser.Sprite;
         updateIfVisible: boolean;
         //methods
-        add(name: string, frames?: number[], frameRate?: number, loop?: boolean, useNumericIndex?: boolean): Phaser.Animation;
-        add(name: string, frames?: string[], frameRate?: number, loop?: boolean, useNumericIndex?: boolean): Phaser.Animation;
+        add(name: string, frames?: any[], frameRate?: number, loop?: boolean, useNumericIndex?: boolean): Phaser.Animation;
         destroy(): void;
         getAnimation(name: string): Phaser.Animation;
         loadFrameData(frameData: Phaser.FrameData): void;
@@ -176,14 +1175,16 @@ declare module Phaser {
 
     class BitmapData {
         //constructor
-        constructor(game: Phaser.Game, width?: number, height?: number);
+        constructor(game: Phaser.Game, key: string, width?: number, height?: number);
         //members
         baseTexture: any;
         canvas: HTMLCanvasElement;
         context: CanvasRenderingContext2D;
+        ctx: CanvasRenderingContext2D;
         game: Phaser.Game;
         height: number;
         imageData: any[];
+        key: string;
         name: string;
         pixels: number;
         texture: any;
@@ -191,82 +1192,92 @@ declare module Phaser {
         type: number;
         width: number;
         //methods
-        add(sprite: Phaser.Sprite): void;
-        addTo(sprites: Phaser.Sprite[]): void;
-        arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, anticlockwise?: boolean):Phaser.BitmapData;
-        arcTo(x1: number, y1: number, x2: number, y2: number): Phaser.BitmapData;
-        beginFill(color: string): Phaser.BitmapData;
-        beginLinearGradientFill(colors: string[], ratios: number[], x0: number, y0: number, x1: number, y1: number): Phaser.BitmapData;
-        beginPath(): Phaser.BitmapData;
-        beginRadialGradientStroke(colors: string[], ratios: number[], x0: number, y0: number, r0: number, x1: number, y1: number, r1: number): Phaser.BitmapData;
-        beginStoke(color: string): Phaser.BitmapData;
-        bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): Phaser.BitmapData;
-        circle(x: number, y: number, radius: number): Phaser.BitmapData;
+        add(object: any): void;
         clear(): void;
-        clearRect(x: number, y: number, width: number, height: number): Phaser.BitmapData;
-        clip(): Phaser.BitmapData;
-        closePath(): Phaser.BitmapData;
-        createLinearGradient(x: number, y: number, width: number, height: number): CanvasGradient;
-        createRadialGradient(x0: number, y0: number, r0: number, x1: number, y1: number, r1: number): CanvasGradient;
-        ellipse(x: number, y: number, w: number, h: number): Phaser.BitmapData;
-        fill(): Phaser.BitmapData;
-        fllRect(x: number, y: number, width: number, height: number): Phaser.BitmapData;
-        fillStyle(color: string): Phaser.BitmapData;
-        font(font: any): Phaser.BitmapData;
         getPixel(x: number, y: number): number;
         getPixel32(x: number, y: number): number;
         getPixels(rect: Phaser.Rectangle): number[];
-        globalAlpha(alpha: number): Phaser.BitmapData;
-        globalCompositeOperation(operation: any): Phaser.BitmapData;
-        lineCap(style: any): Phaser.BitmapData;
-        lineDashOffset(offset: number): Phaser.BitmapData;
-        lineJoin(join: any): Phaser.BitmapData;
-        lineTo(x: number, y: number): Phaser.BitmapData;
-        lineWidth(width: number): Phaser.BitmapData;
-        miterLimit(limit: number): Phaser.BitmapData;
-        moveTo(x: number, y: number): Phaser.BitmapData;
-        quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): Phaser.BitmapData;
-        rect(x: number, y: number, width: number, height: number): Phaser.BitmapData;
+        refreshBuffer(): void;
         render(): void;
-        restore(): Phaser.BitmapData;
-        rotate(angle: number): void;
-        save(): Phaser.BitmapData;
-        scale(x: number, y: number): Phaser.BitmapData;
-        scrollPathIntoView(): Phaser.BitmapData;
+        resize(): void;
         setPixel(x: number, y: number, red: number, green: number, blue: number): void;
         setPixel32(x: number, y: number, red: number, green: number, blue: number, alpha: number): void;
-        setStrokeStyle(thickness: number, caps?: string, joints?: string, miterLimit?: number, ignoreScale?: boolean): Phaser.BitmapData;
-        setStrokeStyle(thickness: number, caps?: number, joints?: number, miterLimit?: number, ignoreScale?: boolean): Phaser.BitmapData;
-        stroke(): Phaser.BitmapData;
-        strokeRect(x: number, y: number, width: number, height: number): Phaser.BitmapData;
-        strokeStyle(style: string): Phaser.BitmapData;
     }
 
-    class BitmapText extends Phaser.Text {
+    class BitmapFont extends Phaser.RenderTexture {
         //constructor
-        constructor(game: Phaser.Game, x?: number, y?: number, text?: string, style?: Object);
+        constructor(game: Phaser.Game, key: string, characterWidth: number, characterHeight: number, chars: string, charsPerRow: number, xSpacing?: number, ySpacing?: number, xOffset?: number, yOffset?: number);
+        //static members
+        static ALIGN_CENTER: string;
+        static ALIGN_LEFT: string;
+        static ALIGN_RIGHT: string;
+        static TEXT_SET1: string;
+        static TEXT_SET2: string;
+        static TEXT_SET3: string;
+        static TEXT_SET4: string;
+        static TEXT_SET5: string;
+        static TEXT_SET6: string;
+        static TEXT_SET7: string;
+        static TEXT_SET8: string;
+        static TEXT_SET9: string;
+        static TEXT_SET10: string;
+        static TEXT_SET11: string;
         //members
-        alive: boolean;
-        anchor: Phaser.Point;
-        angle: number;
-        exists: boolean;
+        align: string;
+        autoUpperCase: boolean;
+        characterHeight: number;
+        characterPerRow: number;
+        characterSpacingX: number;
+        characterSpacingY: number;
+        characterWidth: number;
+        customSpacingX: number;
+        customSpacingY: number;
+        fixedWidth: number;
+        fontSet: HTMLImageElement;
         game: Phaser.Game;
-        group: Phaser.Group;
-        name: string;
-        scale: Phaser.Point;
+        key: string;
+        multiLine: boolean;
+        offsetX: number;
+        offsetY: number;
         type: number;
-        x: number;
-        y: number;
-        //still valid member? It is not in the JS
-        renderable: boolean;
         //methods
+        buildBitmapFontText(): void;
+        getLongestLine(): number;
+        removeUnsupportedCharacters(stripCR?: boolean): string;
+        resize(): void;
+        setFixedWidth(width: number, lineAlignment?: string): void;
+        setText(content: string, multiLine?: boolean, characterSpacing?: number, lineSpacing?: number, lineAlignment?: string, allowLowerCase?: boolean): void;
+    }
+
+    export class BitmapText extends PIXI.BitmapText {
+        //constructor
+        constructor(game: Phaser.Game, x: number, y: number, font: string, text?: string, size?: number);
+        //members
+        align: string;
+        angle: number;
+        cameraOffset: Phaser.Point;
+        events: Phaser.Events;
+        exists: boolean;
+        fixedToCamera: boolean;
+        font: string;
+        game: Phaser.Game;
+        input: Phaser.InputHandler;
+        inputEnabled: boolean;
+        name: string;
+        text: string;
+        tint: number;
+        type: number;
+        world: Phaser.Point;
+        //methods
+        destroy(): void;
+        postUpdate(): void;
+        preUpdate(): void;
         update(): void;
     }
 
-    class Button extends Phaser.Sprite {
+    class Button extends Phaser.Image {
         //constructor
-        constructor(game: Phaser.Game, x?: number, y?: number, key?: string, callback?: Function, callbackContext?: Object, overFrame?: string, outFrame?: string, downFrame?: string, upFrame?: string);
-        constructor(game: Phaser.Game, x?: number, y?: number, key?: string, callback?: Function, callbackContext?: Object, overFrame?: number, outFrame?: number, downFrame?: number, upFrame?: number);
+        constructor(game: Phaser.Game, x?: number, y?: number, key?: string, callback?: Function, callbackContext?: Object, overFrame?: any, outFrame?: any, downFrame?: any, upFrame?: any);
         //members
         forceOut: boolean;
         freezeFrames: boolean;
@@ -286,23 +1297,35 @@ declare module Phaser {
         //methods
         clearFrames(): void;
         setDownSound(sound: Phaser.Sound, marker?: string): void;
-        setFrames(overFrame?: string, outFrame?: string, downFrame?: string, upFrame?: string): void;
-        setFrames(overFrame?: number, outFrame?: number, downFrame?: number, upFrame?: number): void;
+        setFrames(overFrame?: any, outFrame?: any, downFrame?: any, upFrame?: any): void;
         setOutSound(sound: Phaser.Sound, marker?: string): void;
         setOverSound(sound: Phaser.Sound, marker?: string): void;
         setSounds(overSound?: Phaser.Sound, overMarker?: string, downSound?: Phaser.Sound, downMarker?: string, outSound?: Phaser.Sound, outMarker?: string, upSound?: Phaser.Sound, upMarker?: string): void;
+        setUpSound(sound: Phaser.Sound, marker?: string): void;
     }
 
     class Cache {
         //constructor
         constructor(game: Phaser.Game);
+        //static members
+        static BINARY: number;
+        static BITMAPDATA: number;
+        static BITMAPFONT: number;
+        static CANVAS: number;
+        static IMAGE: number;
+        static PHYSICS: number;
+        static SOUND: number;
+        static TEXT: number;
+        static TEXTURE: number;
+        static TILEMAP: number;
         //members
         game: Phaser.Game;
         onSoundUnlock: Phaser.Signal;
         //methods
         addBinary(key: string, binaryData: Object): void;
         addBitmapData(key: string, bitmapData: Phaser.BitmapData): Phaser.BitmapData;
-        addBitmapFont(key: string, url: string, data: Object, xmlData: Object): void;
+        addBitmapFont(key: string, text:Phaser.BitmapFont): void;
+        addBitmapFont(key: string, url: string, data: Object, xmlData: Object, xSpacing?: number, ySpacing?: number): void;
         addCanvas(key: string, canvas: HTMLCanvasElement, context: CanvasRenderingContext2D): void;
         addDefaultImage(): void;
         addImage(key: string, url: string, data: Object): void;
@@ -318,6 +1341,7 @@ declare module Phaser {
         destroy(): void;
         getBinary(key: string): Object;
         getBitmapData(key: string): Phaser.BitmapData;
+        getBitmapFont(key: string): Phaser.BitmapFont;
         getCanvas(key: string): Object;
         getFrame(key: string): Phaser.Frame;
         getFrameByIndex(key: string, frame: string): Phaser.Frame;
@@ -326,23 +1350,29 @@ declare module Phaser {
         getImage(key: string): Object;
         getImageKeys(): string[];
         getKeys(array: string[]): string[];
+        getPhysicsData(key: string, object?: string): Object;
         getSound(key: string): Phaser.Sound;
         getSoundData(key: string): Object;
-        getSoundKeys(): string[];
         getText(key: string): Object;
         getTextKeys(): string[];
         getTexture(key: string): Phaser.RenderTexture;
         getTextureFrame(key: string): Phaser.Frame;
-        getTilemap(key: string): Phaser.Tilemap;
+        getTilemap(key: string): Object;
         isSoundDecoded(key: string): boolean;
         isSoundReady(key: string): boolean;
         isSpriteSheet(key: string): boolean;
         reloadSound(key: string): void;
         reloadSoundComplete(key: string): void;
+        removeBinary(key: string): void;
+        removeBitmapData(key: string): void;
+        removeBitmapFont(key: string): void;
         removeCanvas(key: string): void;
         removeImage(key: string): void;
+        removePhysics(key: string): void;
         removeSound(key: string): void;
         removeText(key: string): void;
+        removeTilemap(key: string): void;
+        updateFrameData(key: string, frameData: number): void;
         updateSound(key: string, property: string, value: Phaser.Sound): void;
     }
 
@@ -375,6 +1405,7 @@ declare module Phaser {
         focusOn(displayObject: any): void;
         focusOnXY(x: number, y: number): void;
         follow(target: Phaser.Sprite, style?: number): void;
+        reset();
         setBoundsToWorld(): void;
         setPosition(x: number, y: number): void;
         setSize(width: number, height: number): void;
@@ -597,6 +1628,30 @@ declare module Phaser {
         }
     }
 
+    class Ellipse {
+        //constructor
+        constructor(x?: number, y?: number, width?: number, height?: number);
+        //members
+        bottom: number;
+        empty: boolean;
+        height: number;
+        left: number;
+        right: number;
+        top: number;
+        width: number;
+        x: number;
+        y: number;
+        //static methods
+        static constains(a: Phaser.Ellipse, x: number, y: number): boolean;
+        //methods
+        clone(out: Phaser.Ellipse): Phaser.Ellipse;
+        contains(x: number, y: number): boolean;
+        copyFrom(source: any): Phaser.Ellipse;
+        copyTo(dest: any): Object;
+        setTo(x: number, y: number, width: number, height: number): Phaser.Ellipse;
+        toString(): string;
+    }
+
     class Events {
         //constuctor
         constructor(sprite: Phaser.Sprite);
@@ -630,7 +1685,7 @@ declare module Phaser {
         height: number;
         padding: number;
         type: number;
-        uniform: Object;
+        uniforms: Object;
         width: number;
         //methods
         destroy(): void;
@@ -663,6 +1718,7 @@ declare module Phaser {
         x: number;
         y: number;
         //methods      
+        getRect(out?: Phaser.Rectangle): Phaser.Rectangle;
         setTrim(trimmed: boolean, actualWidth: number, actualHeight: number, destX: number, destY: number, destWidth: number, destHeight: number): void;
     }
 
@@ -677,14 +1733,12 @@ declare module Phaser {
         getFrameIndexes(frames: number[], useNumericIndex?: boolean, output?: number[]): number[]
         getFrameRange(start: number, end: number, output: Phaser.Frame[]): Phaser.Frame[];
         getFrames(frames: number[], useNumericIndex?: boolean, output?: Phaser.Frame[]): Phaser.Frame[];
-        //this method no longer exists and can be deleted?
-        checkFrame(name: string): boolean;
     }
 
     class Game {
         //constructor
-        constructor(width?: number, height?: number, renderer?: number, parent?: string, state?: Object, transparent?: boolean, antialias?: boolean);
-        constructor(width?: number, height?: number, renderer?: number, parent?: HTMLElement, state?: Object, transparent?: boolean, antialias?: boolean);
+        constructor(width?: number, height?: number, renderer?: number, parent?: string, state?: Object, transparent?: boolean, antialias?: boolean, physicsConfig?: Object);
+        constructor(width?: number, height?: number, renderer?: number, parent?: HTMLElement, state?: Object, transparent?: boolean, antialias?: boolean, physicsConfig?: Object);
         //members
         add: Phaser.GameObjectFactory;
         antialias: boolean;
@@ -707,7 +1761,8 @@ declare module Phaser {
         particles: Phaser.Particles;
         paused: boolean;
         pendingStep: boolean;
-        physics: Phaser.Physics.Arcade
+        physics: Phaser.Physics.Arcade;
+        physicsConfig: Object;
         raf: Phaser.RequestAnimationFrame;
         renderer: number;
         renderType: number;
@@ -744,21 +1799,23 @@ declare module Phaser {
         world: Phaser.World;
         //methods
         audio(key: string, volume?: number, loop?: boolean, connect?: boolean): Phaser.Sound;
-        bitmapData(width?: number, height?: number): Phaser.BitmapData;
-        bitmapText(x: number, y: number, text: string, style: Object, group?: Phaser.Group): Phaser.BitmapText;
+        bitmapData(width?: number, height?: number, key?: string, addToCache?: boolean): Phaser.BitmapData;
+        bitmapFont(font: string, characterWidth: number, characterHeight: number, chars: String, charsPerRow: number, xSpacing?: number, ySpacing?: number, xOffset?: number, yOffset?: number): Phaser.BitmapFont;
+        bitmapText(x: number, y: number, font: string, text?: string, number?: number, group?: Phaser.Group): Phaser.BitmapText;
         button(x?: number, y?: number, key?: string, callback?: Function, callbackContext?: Object, overFrame?: any, outFrame?: any, downFrame?: any, upFrame?: any, group?: Phaser.Group): Phaser.Button;
-        child(parent: any, x: number, y: number, key?: any, frame?: any): Phaser.Sprite;
         emitter(x?: number, y?: number, maxParticles?: number): Phaser.Particles.Arcade.Emitter;
         existing(object: any): any;
         filter(filer: string, args: any): Phaser.Filter;
         graphics(x: number, y: number, group?: Phaser.Group): Phaser.Graphics;
-        group(parent?: any, name?: string): Phaser.Group;
-        renderTexture(key: string, width: number, height: number): Phaser.RenderTexture;
+        group(parent?: any, name?: string, addToStage?: boolean): Phaser.Group;
+        image(x: number, y: number, key: any, frame?: any, group?: Phaser.Group): Phaser.Image;
+        renderTexture(width?: number, height?: number, key?: string, addToCache?: boolean): Phaser.RenderTexture;
         sound(key: string, volume?: number, loop?: number, connect?: boolean): Phaser.Sound; 
         sprite(x: number, y: number, key?: any, frame?: any, group?: Phaser.Group): Phaser.Sprite;
+        spriteBatch(parent: any, name?: string, addToStage?: boolean): Phaser.Group;
         text(x: number, y: number, text: string, style: any, group?: Phaser.Group): Phaser.Text;
         tilemap(key: string, tilesets: any): Phaser.Tilemap;
-        tileSprite(x: number, y: number, width: number, height: number, key?: any, group?: Phaser.Group): Phaser.TileSprite;
+        tileSprite(x: number, y: number, width: number, height: number, key?: any, frame?: any, group?: Phaser.Group): Phaser.TileSprite;
         tween(obj: Object): Phaser.Tween;
     }
 
@@ -768,7 +1825,7 @@ declare module Phaser {
         //members
         active: boolean;
         callbackContext: Object;
-        disable: boolean;
+        disabled: boolean;
         game: Phaser.Game;
         onAxisCallBack: Function;
         onConnectCallback: Function;
@@ -786,6 +1843,7 @@ declare module Phaser {
         addCallbacks(context: Object, callbacks: Object): void;
         isDown(buttonCode: number): boolean;
         justPressed(buttonCode: number, duration?: number): boolean;
+        justReleased(buttonCode: number, duration?: number): boolean;
         reset(): void;
         setDeadZones(): void;
         start();
@@ -810,37 +1868,31 @@ declare module Phaser {
         value: number;
         //methods
         justPressed(duration?: number): boolean;
+        justReleased(duration?: number): boolean;
         processButtonDown(value: Object): void;
         processButtonFloat(value: Object): void;
         processButtonUp(value: Object): void;
     }
 
-    // Actually extends PIXI.Graphics but we skip the abstraction here, since pixi is "part" of phaser
-    // PIXI.Graphics extends PIXI.DisplayObjectContainer extends DisplayObject
-    class Graphics extends Phaser.Sprite {
+    class Graphics extends PIXI.Graphics {
         //constructor
         constructor(game: Phaser.Game, x: number, y: number);
         //members
+        alpha: number;
         angle: number;
-        x: number;
-        y: number;
-        //methods
-        lineStyle(lineWidth: number, color?: number, alpha?: number): void;
-        moveTo(x: number, y: number): void;
-        lineTo(x: number, y: number): void;
-        beginFill(color: number, alpha?: number): void;
-        endFill(): void;
-        drawRect(x: number, y: number, width: number, height: number): void;
-        drawCircle(x: number, y: number, radius: number): void;
-        drawElipse(x: number, y: number, width: number, height: number): void;
-        clear(): void;
-        updateFilterBounds(): void;
+        cameraOffset: Phaser.Point;
+        exists: boolean;
+        fixedToCamera: boolean;
+        game: Phaser.Game;
+        height: number;
+        name: string;
+        type: number;
+        width: number;
     }
 
-    // Wraps a PIXI.DisplayObjectContainer
-    class Group {
+    class Group extends PIXI.DisplayObjectContainer {
         //constructor
-        constructor(game: Phaser.Game, parent?: any, name?: string, useStage?: boolean);
+        constructor(game: Phaser.Game, parent?: any, name?: string, addToStage?: boolean);
         //static members
         static RETURN_CHILD: number;
         static RETURN_NONE: number;
@@ -851,13 +1903,14 @@ declare module Phaser {
         alive: boolean;
         alpha: number;
         angle: number;
+        cameraOffset: Phaser.Point;
         cursor: any;
         exists: boolean;
         game: Phaser.Game;
         group: Phaser.Group;
         length: number;
         name: string;
-        pivot: Phaser.Point;
+        position: Phaser.Point;
         rotation: number;
         scale: Phaser.Point;
         total: number;
@@ -870,10 +1923,9 @@ declare module Phaser {
         addAll(property: string, amount: number, checkAlive: boolean, checkVisible: boolean): void
         addAt(child: any, index: number): any;
         bringToTop(child: any): any;
-        callAll(callback: string, callbackContext?: Object, parameter?: any): void;
-        callAllExists(callback: Function, callbackContext: Object, existsValue: boolean): void;
+        callAll(callback: string, callbackContext?: Object, ...parameters: any[]): void;
+        callAllExists(callback: Function, callbackContext: Object, existsValue: boolean, ...parameters: any[]): void;
         callbackFromArray(child: Object, callback: Function, callbackContext: Object, length: number): void;
-        childTest(): void;
         countDead(): number;
         countLiving(): number;
         create(x: number, y: number, key: string, frame?: any, exists?: boolean): Phaser.Sprite;
@@ -903,7 +1955,51 @@ declare module Phaser {
         sort(index?: string, order?: number): void;
         subAll(property: string, amount: number, checkAlive: boolean, checkVisible: boolean): void;
         swap(child1: any, child2: any): boolean;
-        swapIndex();
+    }
+
+    class Image {
+        //constructor
+        constructor(game: Phaser.Game, x: number, y: number, key: any, frame: any);
+        //members
+        alpha: number;
+        anchor: Phaser.Point;
+        angle: number;
+        autoCull: boolean;
+        cameraOffset: Phaser.Point;
+        deltaX: number;
+        deltaY: number;
+        deltaZ: number;
+        events: Phaser.Events;
+        exists: boolean;
+        fixedToCamera: boolean;
+        frame: number;
+        frameName: string;
+        game: Phaser.Game;
+        height: number;
+        inCamera: boolean;
+        input: Phaser.InputHandler;
+        inputEnabled: boolean;
+        inWorld: boolean;
+        key: any;
+        name: string;
+        renderOrderID: number;
+        scale: Phaser.Point;
+        type: number;
+        world: Phaser.Point;
+        width: number;
+        x: number;
+        y: number;
+        //methods
+        bringToTop(): Phaser.Image;
+        crop(rect: Phaser.Rectangle): void;
+        destroy(): void;
+        kill(): Phaser.Image;
+        loadTexture(key: any, frame: any): void;
+        postUpdate(): void;
+        preUpdate(): void;
+        reset(x: number, y: number): Phaser.Image;
+        revive(): Phaser.Image;
+        update(): void;
     }
 
     class Input {
@@ -969,15 +2065,16 @@ declare module Phaser {
         addPointer(): Phaser.Pointer;
         boot(): void;
         destroy(): void;
+        getLocalPosition(displayObject: any, pointer: Phaser.Pointer): Phaser.Point;
         getPointer(state: boolean): Phaser.Pointer;
         getPointerFromIdentifier(identifier: number): Phaser.Pointer;
         reset(hard?: boolean): void;
         resetSpeed(x: number, y: number): void;
         setMoveCallback(callBack: Function, callbackContext: Object): void;
-        startPointer(event: Event): Phaser.Pointer;
-        stopPointer(event: Event): Phaser.Pointer;
+        startPointer(event: any): Phaser.Pointer;
+        stopPointer(event: any): Phaser.Pointer;
         update(): void;
-        updatePointer(event: Event): Phaser.Pointer;
+        updatePointer(event: any): Phaser.Pointer;
     }
 
     class InputHandler extends Phaser.LinkedListItem {
@@ -986,7 +2083,7 @@ declare module Phaser {
         //members
         allowHorizontalDrag: boolean;
         allowVerticalDrag: boolean;
-        boundwsRect: Phaser.Rectangle;
+        boundsRect: Phaser.Rectangle;
         boundsSprite: Phaser.Sprite;
         bringToTop: boolean;
         consumePointerEvent: boolean;
@@ -994,8 +2091,9 @@ declare module Phaser {
         enabled: boolean;
         game: Phaser.Game;
         isDragged: boolean;
-        pixelPerfect: boolean;
-        pixelPerfectAlpha: number;
+        pixelPerfectAlpha: boolean;
+        pixelPerfectClick: boolean;
+        pixelPerfectOver: boolean;
         priorityID: number;
         snapOffset: Phaser.Point;
         snapOffsetX: number;
@@ -1009,30 +2107,31 @@ declare module Phaser {
         //methods
         checkBoundsRect(): void;
         checkBoundsSprite(): void;
-        checkPixel(x: number, y: number): boolean;
-        checkPointerOver(pointer: number): boolean;
+        checkPixel(x: number, y: number, pointer?: Phaser.Pointer): boolean;
+        checkPointerDown(pointer: Phaser.Pointer): boolean;
+        checkPointerOver(pointer: Phaser.Pointer): boolean;
         destroy(): void;
         disableDrag(): void;
         disableSnap(): void;
-        downDuration(pointer: number): number;
+        downDuration(pointer: Phaser.Pointer): number;
         enableDrag(lockCenter?: boolean, bringToTop?: boolean, pixelPerfect?: boolean, alphaThreshold?: number, boundsRect?: Phaser.Rectangle, boundsSprite?: Phaser.Rectangle): void;
         enableSnap(snapX: number, snapY: number, onDrag?: boolean, onRelease?: boolean, snapOffsetX?: number, snapOffsetY?: number): void;
         justOut(pointer: number, delay: number): boolean;
         justOver(pointer: number, delay: number): boolean;
         justPressed(pointer: number, delay: number): boolean;
         justReleased(pointer: number, delay: number): boolean;
-        overDuration(pointer: number): number;
-        pointerDown(pointer: number): boolean;
-        pointerDragged(pointer: number): boolean;
-        pointerOut(pointer: number): boolean;
-        pointerOver(pointer: number): boolean;
-        pointerTimeDown(pointer: number): number;
-        pointerTimeOut(pointer: number): number;
-        pointerTimeOver(pointer: number): number;
-        pointerTimeUp(pointer: number): number;
-        pointerUp(pointer: number): boolean;
-        pointerX(pointer: number): number;
-        pointerY(pointer: number): number;
+        overDuration(pointer: Phaser.Pointer): number;
+        pointerDown(pointer: Phaser.Pointer): boolean;
+        pointerDragged(pointer: Phaser.Pointer): boolean;
+        pointerOut(pointer: Phaser.Pointer): boolean;
+        pointerOver(pointer: Phaser.Pointer): boolean;
+        pointerTimeDown(pointer: Phaser.Pointer): number;
+        pointerTimeOut(pointer: Phaser.Pointer): number;
+        pointerTimeOver(pointer: Phaser.Pointer): number;
+        pointerTimeUp(pointer: Phaser.Pointer): number;
+        pointerUp(pointer: Phaser.Pointer): boolean;
+        pointerX(pointer: Phaser.Pointer): number;
+        pointerY(pointer: Phaser.Pointer): number;
         reset(): void;
         setDragLock(allowHorizontal?: boolean, allowVertical?: boolean): void;
         start(priority: number, useHandCursor: boolean): Phaser.Sprite;
@@ -1235,6 +2334,7 @@ declare module Phaser {
         //constructor
         constructor(game: Phaser.Game);
         //static members
+        static PHYSICS_LIME_CORONA: number;
         static TEXTURE_ATLAS_JSON_ARRAY: number;
         static TEXTURE_ATLAS_JSON_HASH: number;
         static TEXTURE_ATLAS_XML_STARLING: number;
@@ -1259,7 +2359,7 @@ declare module Phaser {
         atlasXML(key: string, textureURL: string, atlasURL?: string, atlasData?: Object): Phaser.Loader;
         audio(key: string, urls: any, autoDecode?: boolean): Phaser.Loader;
         binary(key: string, url: string, callback?: Function, callbackContext?: Function): Phaser.Loader;
-        bitmapFont(key: string, textureURL: string, xmlURL?: string, xmlData?: Object): Phaser.Loader;
+        bitmapFont(key: string, textureURL: string, xmlURL?: string, xmlData?: Object, xSpacing?: number, ySpacing?: number): Phaser.Loader;
         checkKeyExists(type: string, key: string): boolean;
         csvLoadComplete(index: number): void;
         dataLoadError(index: number): void;
@@ -1267,8 +2367,8 @@ declare module Phaser {
         fileError(key: number): void;
         getAsset(type: string, key: string): any;
         image(key: string, url: string, overwrite?: boolean): Phaser.Loader;
-        json(key: string, url: string): Phaser.Loader;
         jsonLoadComplete(index: number): void;
+        physics(key: string, dataURL?: string, jsonData?: Object, format?: string): Phaser.Loader;
         removeAll(): void;
         removeFile(key: string, type: string): void;
         reset(): void;
@@ -1281,8 +2381,6 @@ declare module Phaser {
         totalLoadedFiles(): number;
         totalQueuedFiles(): number;
         xmlLoadComplete(index:number): void;
-        //members no longer used?
-        tileset(key: string, url: string, tileWidth: number, tileHeight: number, tileMargin?: number, tileSpacing?: number, rows?: number, columns?: number, limit?: number): void;
     }
 
     class LoaderParser {
@@ -1293,6 +2391,7 @@ declare module Phaser {
     class Math {
         //static methods
         static angleBetween(x1: number, y1: number, x2: number, y2: number): number;
+        static angleBetweenPoints(point1: Phaser.Point, point2: Phaser.Point): number;
         static angleLimit(angle: number, min: number, max: number): number;
         static average(...numbers: number[]): number;
         static bernstein(n: number, i: number): number;
@@ -1313,6 +2412,7 @@ declare module Phaser {
         static floorTo(value: number, place: number, base: number): number;
         static fuzzyCeil(val: number, epsilon?: number): boolean;
         static fuzzyEqual(a: number, b: number, epsilon?: number): boolean;
+        static fuzzyLessThan(a: Number, b: number, epsilon?: number): boolean;
         static fuzzyFloor(val: number, epsilon?: number): boolean;
         static fuzzyGreaterThan(a: number, b: number, epsilon?: number): boolean;
         static fuzzyLessThan(a: number, b: number, epsilon?: number): boolean;
@@ -1335,6 +2435,7 @@ declare module Phaser {
         static normalizeLatitude(lat: number): number;
         static normalizeLongitude(lng: number): number;
         static numberArray(min: number, max: number): number[];
+        static p2px(v: number): number;
         static PI2: number;
         static radToDeg(radians: number): number;
         static randomSign(): number;
@@ -1379,10 +2480,10 @@ declare module Phaser {
         mouseUpCallback: Function;
         pointerLock: Phaser.Signal;
         //methods
-        onMouseDown(): void;
-        onMouseMove(): void;
-        onMouseUp(): void;
-        pointerLockChange(): void;
+        onMouseDown(event: any): void;
+        onMouseMove(event: any): void;
+        onMouseUp(event: any): void;
+        pointerLockChange(event: any): void;
         releasePointerLock(): void;
         requestPointerLock(): void;
         start(): void;
@@ -1397,12 +2498,12 @@ declare module Phaser {
         disabled: boolean;
         game: Phaser.Game;
         //methods
-        onPointerDown(): void;
-        onPointerMove(): void;
-        onPointerUp(): void;
-        mouseDownCallback(): void;
-        mouseMoveCallback(): void;
-        mouseUpCallback(): void;
+        onPointerDown(event: any): void;
+        onPointerMove(event: any): void;
+        onPointerUp(event: any): void;
+        mouseDownCallback(event: any): void;
+        mouseMoveCallback(event: any): void;
+        mouseUpCallback(event: any): void;
         start(): void;
         stop(): void;
     }
@@ -1416,8 +2517,8 @@ declare module Phaser {
         checkDomainName(domain: string): boolean;
         decodeURI(value: string): string;
         getHostName(): string;
-        updateQueryString(key: string, value: any, redirect?: boolean, url?: string): string;
         getQueryString(parameter?: string): string;
+        updateQueryString(key: string, value: any, redirect?: boolean, url?: string): string;
     }
 
     class Particles {
@@ -1430,6 +2531,7 @@ declare module Phaser {
         //methods
         add(emitter: Phaser.Particles.Arcade.Emitter): Phaser.Particles.Arcade.Emitter;
         remove(emitter: Phaser.Particles.Arcade.Emitter): void;
+        update(): void;
     }
 
     module Particles {
@@ -1438,6 +2540,7 @@ declare module Phaser {
                 //constructor
                 constructor(game: Phaser.Game, x?: number, y?: number, maxParticles?: number);
                 //members
+                angle: number;
                 alpha: number;
                 angularDrag: number;
                 bottom: number;
@@ -1462,6 +2565,7 @@ declare module Phaser {
                 on: boolean;
                 particleClass: any;
                 particleFriction: number;
+                position: Phaser.Point;
                 right: number;
                 top: number;
                 type: number;
@@ -1469,13 +2573,11 @@ declare module Phaser {
                 width: number;
                 x: number;
                 y: number;
-                //this old and no longer used?
-                particleDrag: Phaser.Point;
                 //methods
                 at(object: any): void;
                 emitParticle(): void;
                 kill(): void;
-                makeParticles(keys: string[], frames: number[], quantity: number, collide?: boolean, collideWorldBounds?: boolean): Phaser.Particles.Arcade.Emitter;
+                makeParticles(keys: any, frames: any, quantity: number, collide?: boolean, collideWorldBounds?: boolean): Phaser.Particles.Arcade.Emitter;
                 setRotation(min?: number, max?: number): void;
                 setSize(width: number, height: number): void;
                 setXSpeed(min: number, max: number): void;
@@ -1504,13 +2606,14 @@ declare module Phaser {
             quadTree: Phaser.QuadTree;
             worldBottom: SAT.Box;
             worldLeft: SAT.Box;
-            worldPolys: SAT.Polygon;
+            worldPolys: SAT.Polygon[];
             worldRight: SAT.Box;
             worldTop: SAT.Box;
             //methods
             accelerateToObject(displayObject: any, destination: any, speed?: number, xSpeedMax?: number, ySpeedMax?: number): number;
             accelerateToPointer(displayObject: any, pointer: any, speed?: number, xSpeedMax?: number, ySpeedMax?: number): number;
             accelerateToXY(displayObject: any, x: number, y: number, speed?: number, xSpeedMax?: number, ySpeedMax?: number): number;
+            accelerateFromRotation(rotation: number, speed?: number, point?: Phaser.Point): Phaser.Point;
             angleBetween(source: any, target: any): number;
             angleToPointer(displayObject: any, pointer: number): number;
             angleToXY(displayObject: any, x: number, y: number): number;
@@ -1534,15 +2637,6 @@ declare module Phaser {
             updateMotion(body: Phaser.Physics.Arcade.Body): Phaser.Point;
             velocityFromAngle(angle: number, speed?: number, point?: any): Phaser.Point;
             velocityFromRotation(rotation: number, speed?: number, point?: any): Phaser.Point;
-            //I left these methods but I do not think they should be here?
-            collideHandler(object1: any, object2: any, collideCallback: Function, processCallback: Function, callbackContext: any, overlapOnly: boolean): boolean;
-            collideSpriteVsSprite(sprite1: Phaser.Sprite, sprite2: Phaser.Sprite, collideCallback: Function, processCallback: Function, callbackContext: any, overlapOnly: boolean): boolean;
-            collideSpriteVsGroup(sprite1: Phaser.Sprite, group: Phaser.Group, collideCallback: Function, processCallback: Function, callbackContext: any, overlapOnly: boolean): boolean;
-            collideGroupVsSelf(group: Phaser.Group, collideCallback: Function, processCallback: Function, callbackContext: any, overlapOnly: boolean): boolean;
-            collideGroupVsGroup(group: Phaser.Group, group2: Phaser.Group, collideCallback: Function, processCallback: Function, callbackContext: any, overlapOnly: boolean): boolean;
-            collideSpriteVsTilemapLayer(sprite: Phaser.Sprite, tilemapLayer: Phaser.TilemapLayer, collideCallback: Function, processCallback: Function, callbackContext: any): boolean;
-            collideGroupVsTilemapLayer(group: Phaser.Group, tilemapLayer: Phaser.TilemapLayer, collideCallback: Function, processCallback: Function, callbackContext: any): boolean;
-            distanceTo(source: Phaser.Sprite, target: Phaser.Sprite): number;
         }
 
         module Arcade {
@@ -1696,7 +2790,7 @@ declare module Phaser {
         update();
     }
 
-    class Point {
+    class Point extends PIXI.Point {
         //constructor
         constructor(x?: number, y?: number);
         //members
@@ -1715,6 +2809,7 @@ declare module Phaser {
         clamp(min: number, max: number): Phaser.Point;
         clampX(min: number, max: number): Phaser.Point;
         clampY(min: number, max: number): Phaser.Point;
+        clone(): Phaser.Point;
         clone(output: Phaser.Point): Phaser.Point;
         copyFrom(source: any): Phaser.Point;
         copyTo(dest: any): Object;
@@ -1773,7 +2868,17 @@ declare module Phaser {
         start(event: any): Phaser.Pointer;
         stop(event: any): void;
         update(): void;
-        toString(): string;
+    }
+
+    class Polygon {
+        //constructor
+        constructor(points: any[]);
+        //members
+        points: any[];
+        type: number;
+        //methods
+        clone(): Phaser.Polygon;
+        contains(x: number, y: number): boolean;
     }
 
     class QuadTree {
@@ -1808,11 +2913,6 @@ declare module Phaser {
     class RandomDataGenerator {
         //constructor
         constructor(seeds: number[]);
-        //members
-        c: number;
-        s0: number;
-        s1: number;
-        s2: number;
         //methods
         angle(): number;
         frac(): number;
@@ -1820,14 +2920,14 @@ declare module Phaser {
         integer(): number;
         integerInRange(min: number, max: number): number;
         normal(): number;
-        pick(ary: number[]): number;
+        pick(ary: number[]): any;
         real(): number;
         realInRange(min: number, max: number): number;
         rnd(): void;
         sow(seeds: any[]): void;
-        timestamp(a?: number, b?: number): number;
+        timestamp(min: number, max: number): number;
         uuid(): number;
-        weightedPick(ary: number[]): number;
+        weightedPick(ary: number[]): any;
     }
 
     class Rectangle {
@@ -1855,6 +2955,7 @@ declare module Phaser {
         static clone(a: Phaser.Rectangle, output?: Phaser.Rectangle): Phaser.Rectangle;
         static contains(a: Phaser.Rectangle, x: number, y: number): boolean;
         static containsPoint(a: Phaser.Rectangle, point: Phaser.Point): boolean;
+        static containsRaw(rx: number, ry: number, rw: number, rh: number, x: number, y: number): boolean;
         static containsRect(a: Phaser.Rectangle, b: Phaser.Rectangle): boolean;
         static equals(a: Phaser.Rectangle, b: Phaser.Rectangle): boolean;
         static inflate(a: Phaser.Rectangle, dx: number, dy: number): Phaser.Rectangle;
@@ -1885,21 +2986,15 @@ declare module Phaser {
         union(b: Phaser.Rectangle, out?: Phaser.Rectangle): Phaser.Rectangle;
     }
 
-    class RenderTexture {
+    class RenderTexture extends PIXI.RenderTexture {
         //constructor
-        constructor(game: Phaser.Game, key: string, width: number, height: number);
+        constructor(game: Phaser.Game, width?: number, height?: number, key?:string);
         //members
-        frame: any;
         game: Phaser.Game;
-        height: number;
-        indentityMatrix: any;
-        name: string;
+        key: string;
         type: number;
-        width: number;
         //methods
-        render(displayObject: any, position?: Phaser.Point, clear?: boolean, renderHidden?: boolean): void;
-        renderXY(displayObject: any, x: number, y: number, clear?: boolean, renderHidden?: boolean): void;
-        resize(): void;
+        renderXY(displayObject: PIXI.DisplayObject, x: number, y: number, clear?: boolean, renderHidden?: boolean): void;
     }
 
     class RequestAnimationFrame {
@@ -2062,104 +3157,88 @@ declare module Phaser {
         update(): void;
     }
 
-    class Sprite {
+    class Sprite extends PIXI.Sprite {
         //constructor
-        constructor(game: Phaser.Game, x?: number, y?: number, key?: any, frame?: any);
+        constructor(game: Phaser.Game, x: number, y: number, key?: any, frame?: any);
         //members
         alive: boolean;
-        anchor: Phaser.Point;
         angle: number;
+        anchor: Phaser.Point;
         animations: Phaser.AnimationManager;
         autoCull: boolean;
         body: Phaser.Physics.Arcade.Body;
-        bottomLeft: Phaser.Point;
-        bottomRight: Phaser.Point;
-        bounds: Phaser.Rectangle;
         cameraOffset: Phaser.Point;
-        center: Phaser.Point;
-        crop: Phaser.Rectangle;
-        cropEnabled: boolean;
-        currentFrame: Phaser.Frame;
+        checkWorldBounds: boolean;
         debug: boolean;
         deltaX: number;
         deltaY: number;
+        deltaZ: number;
         events: Phaser.Events;
         exists: boolean;
         fixedToCamera: boolean;
         frame: number;
         frameName: string;
         game: Phaser.Game;
-        group: Phaser.Group;
         health: number;
-        height: number;
         inCamera: boolean;
         input: Phaser.InputHandler;
         inputEnabled: boolean;
         inWorld: boolean;
-        inWorldThreshold: number;
         key: any;
         lifespan: number;
         name: string;
-        offset: Phaser.Point;
         outOfBoundsKill: boolean;
-        position: Phaser.Point;
-        renderable: boolean;
+        physicsEnabled: boolean;
         renderOrderID: number;
         scale: Phaser.Point;
-        textureRegion: Phaser.Rectangle;
-        topLeft: Phaser.Point;
-        topRight: Phaser.Point;
         type: number;
         visible: boolean;
-        width: number;
         world: Phaser.Point;
-        worldCenterX: number;
-        worldCenterY: number;
         x: number;
         y: number;
         //members
         bringToTop(): Phaser.Sprite;
-        centerOn(x: number, y: number): Phaser.Sprite;
+        crop(rect: Phaser.Rectangle): void;
         damage(amount: number): Phaser.Sprite;
         destroy(): void;
-        getLocalPosition(p: Phaser.Point, x: number, y: number): Phaser.Point;
-        getLocalUnmodifiedPosition(p: Phaser.Point, x: number, y: number): Phaser.Point;
+        drawPolygon(): void;
         kill(): Phaser.Sprite;
         loadTexture(key: any, frame: any): void;
         play(name: string, frameRate?: number, loop?: boolean, killOnComplete?: boolean): Phaser.Animation;
         postUpdate(): void;
         preUpdate(): void;
         reset(x: number, y: number, health?: number): Phaser.Sprite;
-        resetCrop(): void;
         revive(health?: number): Phaser.Sprite;
         updateAnimation(): void;
-        updateBounds(): void;
-        updateCache(): void;
-        updateCrop(): void;
-        //unknown/still applicable?
-        scrollFactor: Phaser.Point;
-        //I cannot see this in the Sprite.JS code!
-        alpha: number;
+        update(): void;
     }
 
-    class Stage {
+    class SpriteBatch extends Phaser.Group {
+        //constructor
+        constructor(game: Phaser.Game, parent: any, name?: string, addedToStage?: boolean);
+        //members
+        type: number;
+    }
+
+    class Stage extends PIXI.Stage {
         //constructor
         constructor(game: Phaser.Game, width: number, height: number);
         //members
-        aspectRatio: number;
         backgroundColor: any;
         canvas: HTMLCanvasElement;
         checkOffsetInterval: any;
         disableVisibilityChange: boolean;
-        display: any;
+        exists: boolean;
         game: Phaser.Game;
+        name: string;
         offset: Phaser.Point;
-        scale: Phaser.StageScaleMode;
         scaleMode: number;
         //methods
         parseConfig(): void;
-        boot(): void;
-        visibilityChange(event: Event): void;
+        postUpdate(): void;
+        preUpdate(): void;
+        update(): void;
+        visibilityChange(event: any): void;
     }
 
     class StageScaleMode {
@@ -2197,6 +3276,8 @@ declare module Phaser {
         pageAlignVertically: boolean;
         scaleFactor: Phaser.Point;
         scaleFactorInversed: Phaser.Point;
+        scaleMode: number;
+        sourceAspectRatio: number;
         width: number;
         //methods
         checkOrientation(event: any): void;
@@ -2268,7 +3349,6 @@ declare module Phaser {
         states: Object;
         //methods
         add(key: string, state: any, autoStart?: boolean): void;
-        boot(): void;
         checkState(key: string): boolean;
         destroy(): void;
         dummy(): void;
@@ -2284,34 +3364,47 @@ declare module Phaser {
         update(): void;
     }
 
-    class Text {
+    class Text extends PIXI.Text {
         //constructor
         constructor(game: Phaser.Game, x: number, y: number, text: string, style: any);
         //members
         alive: boolean;
-        anchor: Phaser.Point;
+        align: string;
         angle: number;
         cameraOffset: Phaser.Point;
-        content: string;
+        events: Phaser.Events;
         exists: boolean;
+        fill: Object;
         fixedToCamera: boolean;
         font: string;
+        fontSize: number;
+        fontWeight: number;
         game: Phaser.Game;
-        group: Phaser.Group;
+        input: Phaser.InputHandler;
+        inputEnabled: boolean;
+        lineSpacing: number;
         name: string;
         position: Phaser.Point;
-        renderable: boolean;
+        shadowBlur: number;
+        shadowColor: string;
+        shadowOffsetX: number;
+        shadowOffsetY: number;
+        stroke: string;
+        strokeThickness: number;
         scale: Phaser.Point;
-        type: number;
         text: string;
-        style: any;
+        type: number;
+        wordWrap: boolean;
+        wordWrapWidth: number;
         x: number;
         y: number;
         visible: boolean;
-        //is this member still used?
-        scrollFactor: Phaser.Point;
         //methods
         destroy(): void;
+        postUpdate(): void;
+        preUpdate(): void;
+        setShadow(x?: number, y?: number, color?: Object, blur?: number): void;
+        setStyle(style?: { font?: string; fill?: Object; align?: string; stroke?: string; strokeThickness?: number; wordWrap?: boolean; wordWrapWidth?: number; }): void;
         update(): void;
     }
 
@@ -2368,6 +3461,7 @@ declare module Phaser {
         static CSV: number;
         static TILED_JSON: number;
         //members
+        collision: any[];
         currentLayer: number;
         debugMap: any[];
         game: Phaser.Game;
@@ -2399,14 +3493,17 @@ declare module Phaser {
         //methods
         addTilesetImage(tileset: string, key?: string): void;
         calculateFaces(layer: number): void;
+        clearPhysicsBodies(layer?: any): void;
         copy(x: number, y: number, width: number, height: number, layer?: any): Phaser.Tile[];
         create(name: string, width: number, height: number): void;
+        createCollisionObjects(layer?: any, addToWorld?: boolean): Phaser.Physics.Arcade.Body[];
         createFromObjects(name: string, gid: number, key: string, frame?: any, exists?: boolean, autoCull?: boolean, group?: Phaser.Group): void;
         createLayer(layer: any, width?: number, height?: number, group?: Phaser.Group): Phaser.TilemapLayer;
         destroy(): void;
         dump(): void;
         fill(index: number, x: number, y: number, width: number, height: number, layer?: any): void;
         forEach(callback: number, context: any, x: number, y: Number, width: number, height: number, layer?: any): void;
+        generateCollisionData(layer?: any, addToWorld?: boolean): Phaser.Physics.Arcade.Body[];
         getImageIndex(name: string): number;
         getIndex(location: any[], name: string): number;
         getLayer(layer: any): number;
@@ -2418,7 +3515,7 @@ declare module Phaser {
         getTileLeft(layer: number, x: number, y: number): Phaser.Tile;
         getTileRight(layer: number, x: number, y: number): Phaser.Tile;
         getTilesetIndex(name: string): number;
-        getTileWorld(x: number, y: number, layer?: any): Phaser.Tile;
+        getTileWorldXY(x: number, y: number, layer?: any): Phaser.Tile;
         paste(x: number, y: number, tileblock: Phaser.Tile[], layer?: any): void;
         putTile(tile: any, x: number, y: number, layer?: any): void;
         putTileWorldXY(tile: any, x: number, y: number, tileWidth: number, tileHeight: number, layer?: any): void;
@@ -2435,18 +3532,6 @@ declare module Phaser {
         setTileLocationCallback(x: number, y: number, width: number, height: number, callback: Function, callbackContext: Object, layer?: any): void;
         shuffle(x: number, y: number, width: number, height: number, layer: any): void;
         swapTile(tileA: number, tileB: number, x: number, y: number, width: number, height: number, layer: any): void;
-        //are these methods still valid?
-        parseCSV(data: string, key: string, tileWidth: number, tileHeight: number): void;
-        parseTiledJSON(json: string, key: string): void;
-        generateTiles(quantity: number): void;
-        setCollisionRange(start: number, end: number, collision: number, resetCollisions?: boolean, separateX?: boolean, separateY?: boolean): void;
-        getTileByIndex(value: number): Tile;
-        getTileFromWorldXY(x: number, y: number, layer?: number): Tile;
-        getTileFromInputXY(layer?: number): Tile;
-        getTileOverlaps(object: Object): Array<any>;
-        collide(objectOrGroup: any, callback: Function, context: Object): boolean;
-        collideGameObject(object: Object): boolean;
-        update(): void;
     }
 
     class TilemapLayer {
@@ -2496,6 +3581,7 @@ declare module Phaser {
 
     class TilemapParser {
         //static methods
+        static getEmptyData(): Object;
         static parse(game: Phaser.Game, key: string): Phaser.Tileset;
         static parseCSV(data: string): Phaser.Tilemap;
         static parseJSON(json: Object): Phaser.Tilemap;
@@ -2525,13 +3611,13 @@ declare module Phaser {
         setSpacing(tileMargin?: number, tileSpacing?: number): void;
     }
 
-    class TileSprite extends Sprite {
+    class TileSprite extends Phaser.Sprite {
         //constructor
-        constructor(game: Phaser.Game, x: number, y: number, width: number, height: number, key?: any);
+        constructor(game: Phaser.Game, x: number, y: number, width: number, height: number, key?: any, frame?: any);
         //members
-        texture: any;
+        events: Phaser.Events;
+        texture: PIXI.Texture;
         tilePosition: Phaser.Point;
-        tileScale: Phaser.Point;
     }
 
     class Time {
@@ -2641,7 +3727,6 @@ declare module Phaser {
         onTouchMove(event: any): void;
         onTouchStart(event: any): void;
         start(): void;
-        consumeDocumentTouches(): void;
         stop(): void;
     }
 
@@ -2720,12 +3805,9 @@ declare module Phaser {
             renderPointInfo(point: Phaser.Point, x: number, y: number, color?: string): void;
             renderPolygon(polygon: any[], color?: string): void;
             renderQuadTree(quadtree: Phaser.QuadTree, color: string): void;
-            renderRectangle(rect: Phaser.Rectangle, color?: string): void;
+            renderShape(shape:any, x: number, y: number, angle: number);
             renderSoundInfo(sound: Phaser.Sound, x: number, y: number, color?: string): void;
-            renderSpriteBody(sprite: Phaser.Sprite, color?: string): void;
-            renderSpriteBounds(sprite: Phaser.Sprite, color?: string, fill?: boolean): void;
             renderSpriteCoords(line: Phaser.Sprite, x: number, y: number, color?: string): void;
-            renderSpriteCorners(sprite: Phaser.Sprite, showText?: boolean, showBounds?: boolean, color?: string): void;
             renderSpriteInfo(sprite: Phaser.Sprite, x: number, y: number, color?: string): void;
             renderSpriteInputInfo(sprite: Phaser.Sprite, x: number, y: number, color?: string): void;
             renderText(text: string, x: number, y: number, color?: string, font?: string): void;


### PR DESCRIPTION
Thanks to @natelong for Maintaining the original PIXI definitions.

Updated to 1.5.2 PIXI. 

Needs testing. May be missing updates from the dev branch of Phaser 1.2 that occurred in the last few days.  

Warning! I made Phaser.point extend PIXI.Point. It was the only way I could get this to work. 

If class property position is PIXI.Point
And you try to overlay position with Phaser.Point

I get "X cannot extend Y type mismatch" for a whole bunch of classes. Only when I extend PIXI.Point does the errors dissapear. 

Also was not sure to include PIXI in this file or a separate one.
