### PR TITLE
Update LoaderParser.js (remove navigator.isCocoonJS)

### DIFF
--- a/src/loader/LoaderParser.js
+++ b/src/loader/LoaderParser.js
@@ -20,7 +20,7 @@ Phaser.LoaderParser = {
     */
     bitmapFont: function (game, xml, cacheKey, xSpacing, ySpacing) {
 
-        if (!xml || /MSIE 9/i.test(navigator.userAgent) || navigator.isCocoonJS)
+        if (!xml || /MSIE 9/i.test(navigator.userAgent))
         {
             if (typeof(window.DOMParser) === 'function')
             {


### PR DESCRIPTION
Safe to remove "navigator.isCocoonJS" here since CocoonJS doesn't have a window.DOMParser object, nor will a createElement('div') work under Accelerated Canvas/WebGL mode anyway. CocoonJS' createElement is limited to only 'img',  'image',  'audio',  'canvas', and 'screencanvas' elements.*

(Under WebView mode, there is a high likelihood of DOMParser existing too. Most browsers have it.)

*Reference: http://support.ludei.com/hc/en-us/articles/200807787-HTML5-feature-list
