### PR TITLE
Tilemap.swap() called twice should not flip values

### DIFF
--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -1114,7 +1114,7 @@ Phaser.Tilemap.prototype = {
     /**
     * Scans the given area for tiles with an index matching tileA and swaps them with tileB.
     *
-    * @method Phaser.Tilemap#swapTile
+    * @method Phaser.Tilemap#swap
     * @param {number} tileA - First tile index.
     * @param {number} tileB - Second tile index.
     * @param {number} x - X position of the top left of the area to operate one, given in tiles, not pixels.


### PR DESCRIPTION
Repeat calls to swap() should not affect index values a second time.
"swap(1,2); swap(1,2)" should not be the same as "swap(2,1)."

Removing the "else" in swapHandler fixes this.

(This also affects Phaser 1.1.6.) 
