### PR TITLE
Fix copyright year

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 Richard Davey, Photon Storm Ltd.
+Copyright (c) 2013-2014 Richard Davey, Photon Storm Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Fix outdated copyright year (update to 2014)
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
