### PR TITLE
Fixed: randomDataGenerator bug in parseConfig

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -377,10 +377,18 @@ Phaser.Game.prototype = {
             this.physicsConfig = config['physicsConfig'];
         }
 
+        var seed = null;
+        
         if (config['seed'])
         {
-            this.rnd = new Phaser.RandomDataGenerator(config['seed']);
+            seed = config['seed'];
         }
+        else
+        {
+            seed = [(Date.now() * Math.random()).toString()];
+        }
+        
+        this.rnd = new Phaser.RandomDataGenerator(seed);
 
         var state = null;
 


### PR DESCRIPTION
If a Phaser.Game is created using a config object Phaser.Game.rnd will only be set if the 'seed' parameter is defined in the config object.
Otherwise Phaser.Game.rnd will remain null.
This proposed change is adding an else conditional that will ensure Phaser.Game.rnd is being set.
I tried to write this with the same code style that the 'state' conditional is using.
I set the default option in the else conditional and not at the declaration of var seed to avoid doing unnecessary Math if config['seed'] has already been set.
