### PR TITLE
Multiple circle shapes in a body with position

### DIFF
--- a/src/physics/p2/Body.js
+++ b/src/physics/p2/Body.js
@@ -1134,14 +1134,18 @@ Phaser.Physics.P2.Body.prototype = {
       var generatedShapes = []
 
       if (fixtureData.circle){
-        //a circle has unfortunately no position in p2. pretty useless.
         var shape = new p2.Circle(this.world.pxm(fixtureData.circle.radius))
         shape.collisionGroup = fixtureData.filter.categoryBits
         shape.collisionMask = fixtureData.filter.maskBits
         shape.sensor = fixtureData.isSensor
 
-        this.data.addShape(shape);
+        var offset = p2.vec2.create();
+        offset[0] = this.world.pxmi(fixtureData.circle.position[0] - this.sprite.width/2)
+        offset[1] = this.world.pxmi(fixtureData.circle.position[1] - this.sprite.height/2)
+        
+        this.data.addShape(shape, offset);
         generatedShapes.push(shape)
+      
       }else{
         polygons = fixtureData.polygons
         var cm = p2.vec2.create();

--- a/src/physics/p2/BodyDebug.js
+++ b/src/physics/p2/BodyDebug.js
@@ -120,7 +120,7 @@ Phaser.Utils.extend(Phaser.Physics.P2.BodyDebug.prototype, {
         
                 if (child instanceof p2.Circle)
                 {
-                    this.drawCircle(sprite, offset[0] * this.ppu, -offset[1] * this.ppu, angle, child.radius * this.ppu, color, lw);
+                    this.drawCircle(sprite, offset[0] * this.ppu, offset[1] * this.ppu, angle, child.radius * this.ppu, color, lw);
                 }
                 else if (child instanceof p2.Convex)
                 {


### PR DESCRIPTION
See the old comment 'a circle has unfortunately no position in p2. pretty useless.' ? What a lie.
It works. There was only an error in the debug drawer and I did not realized that I can use offsets even for circles. That's nice! I can now place multiple circles in physics editor and they all are placed inside the body at the correct position.
