### PR TITLE
Removing tilemap layer retrieval for object layers in convertCollisionObjects()

### DIFF
--- a/src/physics/p2/World.js
+++ b/src/physics/p2/World.js
@@ -1396,8 +1396,6 @@ Phaser.Physics.P2.prototype = {
 
         if (typeof addToWorld === 'undefined') { addToWorld = true; }
 
-        layer = map.getLayer(layer);
-
         var output = [];
 
         for (var i = 0, len = map.collision[layer].length; i < len; i++)


### PR DESCRIPTION
This was causing the convertCollisionObjects() method to fail because object layers don't get added to the map layers collection by the parser, they instead get added to the collision collection.
