### PR TITLE
issue#661 update state before values are cleared

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -614,11 +614,11 @@ Phaser.Game.prototype = {
             this.plugins.preUpdate();
             this.stage.preUpdate();
 
+            this.state.update();
             this.stage.update();
             this.tweens.update();
             this.sound.update();
             this.input.update();
-            this.state.update();
             this.physics.update();
             this.particles.update();
             this.plugins.update();


### PR DESCRIPTION
resolve #661
this prevent loosing state values related to physics bodys
and inputs before `state.update` is called.
