### PR TITLE
Restore BitmapText anchor point

### DIFF
--- a/src/gameobjects/BitmapText.js
+++ b/src/gameobjects/BitmapText.js
@@ -199,8 +199,6 @@ Phaser.BitmapText.prototype.preUpdate = function () {
 */
 Phaser.BitmapText.prototype.update = function() {
 
-    console.log(this.pivot);
-
 };
 
 /**


### PR DESCRIPTION
Since Phaser 2, BitmapText lost its anchor point.

I checked the code in previous versions and just changed it a bit to fix the new version.

I was not sure if pivot correction should be made on preUpdate or postUpdate, felt like it was better in preUpdate but maybe it should be changed.
