### PR TITLE
inputEnabled fix for Phaser.Image

### DIFF
--- a/src/gameobjects/Image.js
+++ b/src/gameobjects/Image.js
@@ -683,7 +683,7 @@ Object.defineProperty(Phaser.Image.prototype, "inputEnabled", {
 
         if (value)
         {
-            if (this.input === null)
+            if (!this.input)
             {
                 this.input = new Phaser.InputHandler(this);
                 this.input.start();


### PR DESCRIPTION
I noticed that if I disabled a button via setting the inputEnabled flag to false, the renabled it by setting it back to true, the button remained disabled. This fixes that.
