### PR TITLE
correct Tilemap.hasTile(...) parameter typing

### DIFF
--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -996,6 +996,8 @@ Phaser.Tilemap.prototype = {
     */
     hasTile: function (x, y, layer) {
 
+        layer = this.getLayer(layer);
+
         return (this.layers[layer].data[y] !== null && this.layers[layer].data[y][x] !== null);
 
     },


### PR DESCRIPTION
Member methods of Tilemap which take a layer parameter use getLayer on that parameter to allow passing int, string, and TilemapLayer objects. Tilemap.hasTile(...) should do so as well.

I've never made a pull request on GitHub before. My apologies if I've done something wrong.
