### PR TITLE
Fixed bug where move up and move down method in groups did not work.

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -476,7 +476,7 @@ Phaser.Group.prototype.moveUp = function (child) {
 
         if (b)
         {
-            this.swap(a, b);
+            this.swap(child, b);
         }
     }
 
@@ -500,7 +500,7 @@ Phaser.Group.prototype.moveDown = function (child) {
 
         if (b)
         {
-            this.swap(a, b);
+            this.swap(child, b);
         }
     }
 


### PR DESCRIPTION
The moveUp and moveDown methods in the Group class were swapping an index and a child instead of the two children.
