### PR TITLE
Fixed bug in group.next when cursor is at the last child.

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -363,7 +363,7 @@ Phaser.Group.prototype.next = function () {
     if (this.cursor)
     {
         //  Wrap the cursor?
-        if (this._cache[8] === this.children.length)
+        if (this._cache[8] === this.children.length - 1)
         {
             this._cache[8] = 0;
         }


### PR DESCRIPTION
When the cursor index was at the end of the children array, it would set the cursor to an undefined and get stuck there.
