### PR TITLE
Fixed bug in group.next when cursor is at the last child.

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -363,7 +363,7 @@ Phaser.Group.prototype.next = function () {
     if (this.cursor)
     {
         //  Wrap the cursor?
-        if (this._cache[8] === this.children.length - 1)
+        if (this._cache[8] >= this.children.length - 1)
         {
             this._cache[8] = 0;
         }


### PR DESCRIPTION
When the cursor index was at the end of the children array, and group.next was called, it would set the cursor to undefined. This even made it impossible for the cursor to recover since all checks are === null.
In the case where the cursor is on the last index of the children array and group.remove is called on the last child (which subsequently calls group.next), the cursor index would be larger than the (children.length - 1) and therefore increment instead of reset to 0.
