### PR TITLE
Added a setFrame method to Phaser.Animation

### DIFF
--- a/build/phaser.d.ts
+++ b/build/phaser.d.ts
@@ -1069,6 +1069,7 @@ declare module Phaser {
         onResume(): void;
         play(frameRate?: number, loop?: boolean, killOnComplete?: boolean): Phaser.Animation;
         restart(): void;
+        setFrame(frameId: any, useLocalFrameIndex: boolean): void;
         stop(resetFrame?: boolean, dispatchComplete?:boolean): void;
         update(): boolean;
 
@@ -1079,6 +1080,7 @@ declare module Phaser {
         constructor(sprite: Phaser.Sprite);
 
         currentFrame: Phaser.Frame;
+        currentAnim: Phaser.Animation;
         frame: number;
         frameData: Phaser.FrameData;
         frameName: string;

--- a/src/animation/Animation.js
+++ b/src/animation/Animation.js
@@ -226,6 +226,45 @@ Phaser.Animation.prototype = {
     },
 
     /**
+    * Sets this animation's playback to a given frame with the given id.
+    *
+    * @method Phaser.Animation#setFrame
+    * @memberof Phaser.Animation
+    * @param {any} [frameId] - The identifier of the frame to set. Can be the name of the frame, the sprite index of the frame, or the animation-local frame index.
+    * @param {boolean} [useLocalFrameIndex=false] - If you provide a number for frameId, should it use the numeric indexes of the frameData, or the 0-indexed frame index local to the animation.
+    */
+    setFrame: function(frameId,useLocalFrameIndex){
+        var frameIndex = undefined;
+        if (typeof useLocalFrameIndex === 'undefined') { useLocalFrameIndex = false; }
+        //Find the index to the desired frame.
+        if(typeof frameId === "string"){
+            for(var i = 0; i < this._frames.length; i++){
+                if(this._frameData.getFrame(this._frames[i]).name == frameId){
+                    frameIndex = i;
+                }
+            }
+        } else if(typeof frameId === "number"){
+            if(useLocalFrameIndex){
+                frameIndex = frameId;
+            } else {
+                for(var i = 0;i < this._frames.length; i++){
+                    if(this.frames[i] == frameIndex){
+                        frameIndex = i;
+                    }
+                }
+            }
+        }
+        if(frameIndex){
+            //Set the current frame index to the found index. Subtract 1 so that it animates to the desired frame on update.
+            this._frameIndex = frameIndex -1;
+            //Make the animation update at next update
+            this._timeNextFrame = this.game.time.now;
+            //Update
+            this.update();
+        }
+    },
+
+    /**
     * Stops playback of this animation and set it to a finished state. If a resetFrame is provided it will stop playback and set frame to the first in the animation.
     * If `dispatchComplete` is true it will dispatch the complete events, otherwise they'll be ignored.
     *

--- a/src/animation/AnimationManager.js
+++ b/src/animation/AnimationManager.js
@@ -29,6 +29,12 @@ Phaser.AnimationManager = function (sprite) {
     * @default
     */
     this.currentFrame = null;
+    
+    /**
+    * @property {Phaser.Animation} currentAnim - The currently displayed animation, if any.
+    * @default
+    */
+    this.currentAnim = null;
 
     /**
     * @property {boolean} updateIfVisible - Should the animation data continue to update even if the Sprite.visible is set to false.


### PR DESCRIPTION
Added the currentAnim property to the declaration of Phaser.AnimationManager as it was being used in code, but not declared to begin with.
Updated the .d.ts file to reflect the above changes.

My code still has the diffs from the last pull request related to generateFrameNames and spriteSourceSizeH...may need to ignore those by hand.
