### PR TITLE
Fixed that wrong time event will be removed if the callback has added a new time event

### DIFF
--- a/src/time/Timer.js
+++ b/src/time/Timer.js
@@ -387,9 +387,13 @@ Phaser.Timer.prototype = {
                     }
                     else
                     {
-                        this.events[this._i].callback.apply(this.events[this._i].callbackContext, this.events[this._i].args);
+                        var callback = this.events[this._i].callback;
+                        var context = this.events[this._i].callbackContext;
+                        var args = this.events[this._i].args;
+
                         this.events.splice(this._i, 1);
                         this._len--;
+                        callback.apply(context, args);
                     }
 
                     this._i++;


### PR DESCRIPTION
Sorry for my poor grammar.

Live example for explaining the issue : http://jsfiddle.net/ALcb9/
Here is the expected issue:  
![untitled](https://cloud.githubusercontent.com/assets/798943/2689278/04940be0-c2f6-11e3-9391-2353dc569f71.jpg)

When the new time event has been added, the array index also will reordered, 
which means `this._i` is no longer representing the index of the event should be removed if the callback(which will add a new time event) called before the deletion. So the event must be removed before calling the callback.
