### PR TITLE
set current animations isPlaying to false when changing animations

### DIFF
--- a/src/animation/AnimationManager.js
+++ b/src/animation/AnimationManager.js
@@ -207,7 +207,7 @@ Phaser.AnimationManager.prototype = {
             {
                 if (this.currentAnim)
                 {
-                    this.currentAnim.isPlaying = false
+                    this.currentAnim.isPlaying = false;
                 }
                 this.currentAnim = this._anims[name];
                 this.currentAnim.paused = false;


### PR DESCRIPTION
It seemed like a weird behavior to have an animation seem to continue playing after it had been superseded by another animation via an AnimationManager.  If this is the intended behavior, I'd be interested to hear why.

Use case:
//Update function
    if @cursors.left.isDown
        @goLeft()
      else if @cursors.right.isDown
        @goRight()
      else
        @idle()

//Idle function
    idle: ->
      if @body.touching.down and not @animations.getAnimation('hurt').isPlaying
        @animations.play('idle')

  //collision function...
    @animations.play('hurt')

There could be a better way to achieve the same effect, but like I said, it seems weird to have an animation's isPlaying = true when it isn't the active animation and can no longer finish
