### PR TITLE
Fixed that the TimerEvent should flag as pendingDelete before calling the callback, because callback might trigger the reorder function

### DIFF
--- a/src/time/Timer.js
+++ b/src/time/Timer.js
@@ -408,8 +408,8 @@ Phaser.Timer.prototype = {
                     }
                     else
                     {
-                        this.events[this._i].callback.apply(this.events[this._i].callbackContext, this.events[this._i].args);
                         this.events[this._i].pendingDelete = true;
+                        this.events[this._i].callback.apply(this.events[this._i].callbackContext, this.events[this._i].args);
                     }
 
                     this._i++;


### PR DESCRIPTION
This is same issue as #710, I compiled the latest dev branch, the issue still remain : http://jsfiddle.net/ALcb9/5/

What I figured out is the point is no about when to delete the event but is when the event array will be reordered(when adding new event, the reorder function will be called).
