### PR TITLE
Check parent exists on Group.destroy before calling removeChild

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -1561,7 +1561,9 @@ Phaser.Group.prototype.destroy = function (destroyChildren, soft) {
 
     if (!soft)
     {
-        this.parent.removeChild(this);
+        if (this.parent){
+            this.parent.removeChild(this);
+        }
 
         this.game = null;
 


### PR DESCRIPTION
I do not know if this is a valid change, at least with TypeScript defs I cannot really break anything :P 

This solved all my destroy/shutdown problems.
