### PR TITLE
Fixed typo in world.setMaterial

### DIFF
--- a/src/physics/p2/World.js
+++ b/src/physics/p2/World.js
@@ -989,7 +989,7 @@ Phaser.Physics.P2.prototype = {
 
         while (i--)
         {
-            bodies.setMaterial(material);
+            bodies[i].setMaterial(material);
         }
 
     },


### PR DESCRIPTION
The function contained a typo: bodies is an Array and so bodies.setMaterial is undefined
