### PR TITLE
Fix wrong definition for Phaser.Point.rotate

### DIFF
--- a/build/phaser.d.ts
+++ b/build/phaser.d.ts
@@ -3367,7 +3367,7 @@ declare module Phaser {
         static divide(a: Phaser.Point, b: Phaser.Point, out?: Phaser.Point): Phaser.Point;
         static equals(a: Phaser.Point, b: Phaser.Point): boolean;
         static multiply(a: Phaser.Point, b: Phaser.Point, out?: Phaser.Point): Phaser.Point;
-        static rotate(a: Phaser.Point, x: number, y: number, angle: number, asDegrees: boolean, distance: boolean): Phaser.Point;
+        static rotate(a: Phaser.Point, x: number, y: number, angle: number, asDegrees: boolean, distance?: number): Phaser.Point;
         static subtract(a: Phaser.Point, b: Phaser.Point, out?: Phaser.Point): Phaser.Point;
 
         add(x: number, y: number): Phaser.Point;


### PR DESCRIPTION
Hi,
here is a tiny fix: "distance" arguments is an optional number, not a boolean
