### PR TITLE
[Enhancement] Pausable P2 World

### DIFF
--- a/src/physics/p2/World.js
+++ b/src/physics/p2/World.js
@@ -628,14 +628,14 @@ Phaser.Physics.P2.prototype = {
     },
 
     /**
-    * @method Phaser.Physics.P2#update
+    * @method Phaser.Physics.P2#pause
     */
     pause: function() {
         this.paused = true
     },
     
     /**
-    * @method Phaser.Physics.P2#update
+    * @method Phaser.Physics.P2#resume
     */
     resume: function() {
         this.paused = false


### PR DESCRIPTION
This change enables us to pause and resume the p2 engine independent from pause state of the game.

```
@game.physics.p2.pause()
@game.physics.p2.resume()
```

Pretty useful in some cases where you don't want to hold the complete game.
The arcade and ninja engine should pause if the user blocks the update from being executed, shouldn't it ?

Regards George
