### PR TITLE
fix p2 elapsed time bug

### DIFF
--- a/src/time/Time.js
+++ b/src/time/Time.js
@@ -234,7 +234,9 @@ Phaser.Time.prototype = {
         this.timeToCall = this.game.math.max(0, 16 - (time - this.lastTime));
 
         this.elapsed = this.now - this.time;
-        this.physicsElapsed = this.elapsed / 1000;
+
+        //calculate physics elapsed, ensure it's > 0, use 1/60 as a fallback
+        this.physicsElapsed = this.elapsed / 1000 || 1/60;
 
         if (this.deltaCap > 0 && this.physicsElapsed > this.deltaCap)
         {


### PR DESCRIPTION
Ensure that `physicsElapsed` is larger than zero. I used 1/60 as a fallback. 
Whenever you pause the whole game by using game.paused = true and resume it you get a physicsElapsed value of 0. This breaks at least the joint constraints of p2 for me. Other things seems not to be affected by that small value.
This should also fix the bug mentioned here (even if the OP did not provide any details on the cause)
http://www.html5gamedevs.com/topic/5903-infinity-appearing-in-p2-physics/#entry35429

Regards George
