### PR TITLE
Nasty bug with pauseStarted in a timer

### DIFF
--- a/src/time/Timer.js
+++ b/src/time/Timer.js
@@ -456,10 +456,12 @@ Phaser.Timer.prototype = {
     * @method Phaser.Timer#pause
     */
     pause: function () {
-
+        
+        this._pauseStarted = this.game.time.now;
+        
         if (this.running && !this.expired)
         {
-            this._pauseStarted = this.game.time.now;
+            
 
             this.paused = true;
             this._codePaused = true;


### PR DESCRIPTION
This affects the built in game timer and every other created timer. When you pause the game and you resumes it, it will happen that events - even when you added them after the game already resumed - are delayed by the amount the game LAST was paused. And that can be a lot of seconds. It first seemed to be that the events are lost but they only have a very large delay after a few toggled pause states.

Here a log with the current timer & after the fix. The value of  `diff timer/game` in the log
should always be smaller than 500 (the intended delay of the event).

This fix is a one liner. I don't think that it affects other places.

```
//current state. The first hello works, the second is delayed, the third even more as pauseStarted is not updated properly. 
game: paused
game: resumed
>>> wait for  hello
diff timer/game 467
>>> hello!

game: paused
game: resumed
>>> wait for  hello
diff timer/game 2549 //<-- wrong should be < 500
>>> hello!<-- 2.5 seconds until triggered

game: paused
game: resumed
>>> wait for  hello
diff timer/game 6717 //<-- wrong should be < 500
>>> hello! <-- 6.7 seconds until triggered


//after fix
game: paused
game: resumed
>>> wait for hello
diff timer/game 300 //<-- nice!
>>> hello!

game: paused
game: resumed
>>> wait for hello
diff timer/game 350 //<-- nice!
>>> hello! 

game: paused
game: resumed
>>> wait for hello
diff timer/game 350 //<-- nice!
>>> hello! 
```

This is the test code. I just rewrote it from coffee script so maybe it's not 100% valid.

``` javascript
game.input.onDown.add(handleClick)

handleClick: function(){
  //toggle pause
  game.paused = !game.paused
  if(game.paused){
    console.log('game: paused')  
  }else{  
    console.log('game: resumed')
  }

  //say delayed hello
  if(!game.paused){
    console.log '>>> wait for hello'
    game.time.events.add(500, function(){ console.log '>>> hello!' })
    setTimeout(debugEvents, 50) //show me whats happening
  }
}

//debug some information about the timer
debugEvents: function(){
  if (game.time.events.events.length > 0)
      event = game.time.events.events[0]
      console.log('diff timer/game', (game.time.events.nextTick - game.time.now))
    else
      console.log('no pending events')
  }
}


```
