### PR TITLE
scaleManager initialize _check var

### DIFF
--- a/src/core/ScaleManager.js
+++ b/src/core/ScaleManager.js
@@ -218,6 +218,8 @@ Phaser.ScaleManager = function (game, width, height) {
     */
     this._height = 0;
 
+    this._check=null;	//holds interval later for setScreenSize.  must be initialized to null to allow === null check later.
+
     var _this = this;
 
     window.addEventListener('orientationchange', function (event) {


### PR DESCRIPTION
Since === null is now being used for the this._check comparison instead
of ==, it needs to be initialized to null or setScreenSize will never
be called
