### PR TITLE
Fix pointOnLine

### DIFF
--- a/src/geom/Line.js
+++ b/src/geom/Line.js
@@ -104,7 +104,7 @@ Phaser.Line.prototype = {
     */
     pointOnLine: function (x, y) {
 
-        return ((x - this.start.x) * (this.end.y - this.end.y) === (this.end.x - this.start.x) * (y - this.end.y));
+        return ((x - this.start.x) * (this.end.y - this.start.y) === (this.end.x - this.start.x) * (y - this.start.y));
 
     },
 


### PR DESCRIPTION
Corrected algorithm via: http://stackoverflow.com/questions/11907947/how-to-check-if-a-point-lays-on-a-line-between-2-provided-points

I noticed it contained a this.end.y - this.end.y which would always result to 0 in the code, then looked up correct algorithm.

This does not fix #760 (the reason I was looking into this), but maybe Phaser.Line.intersectsPoints should be using the pointOnLine functions etc to determine if the point is on the segments. Or at least the same algorithm.
