### PR TITLE
Fixed various problems with Timer class

### DIFF
--- a/src/time/Timer.js
+++ b/src/time/Timer.js
@@ -480,6 +480,13 @@ Phaser.Timer.prototype = {
     */
     pause: function () {
 
+        if (!this.running)
+        {
+            return;
+        }
+
+        this._codePaused = true;
+
         if (this.paused)
         {
             return;
@@ -488,7 +495,6 @@ Phaser.Timer.prototype = {
         this._pauseStarted = this.game.time.now;
 
         this.paused = true;
-        this._codePaused = true;
 
     },
 
@@ -499,7 +505,7 @@ Phaser.Timer.prototype = {
     */
     _pause: function () {
 
-        if (this.paused)
+        if (this.paused || !this.running)
         {
             return;
         }


### PR DESCRIPTION
**Problem 1 :** When a timer is resumed manually (from code) after being game resumed (automatically from lost of focus), the way _pausedTotal is computed is no longer accurate since it uses the game pause time.

**Problem 2 :** If a timer is paused from code after the game has been game paused, it is not considered to be code paused.

These problems have to occur if you want to have a pause screen and display it when the game is out of focus, so that, when the user comes back, he can resume manually. In this sequence, you have to code pause your timer when the game is automatically paused. Then, the user has to close the pause screen for the timer to be resumed.
