### PR TITLE
Remove tile fix

### DIFF
--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -1063,15 +1063,16 @@ Phaser.Tilemap.prototype = {
         {
             if (this.hasTile(x, y, layer))
             {
-                var tile = this.layers[layer].data[y][x];
+                var tileCopy = new Phaser.Tile();
+                tileCopy.copy(this.layers[layer].data[y][x]);
 
-                this.layers[layer].data[y][x] = null;
+                this.layers[layer].data[y][x].index = -1;
 
                 this.layers[layer].dirty = true;
 
                 this.calculateFaces(layer);
 
-                return tile;
+                return tileCopy;
             }
         }
 


### PR DESCRIPTION
When using removeTile(), this previously set the tile to null, which meant later when you called getTile() on the same tile, it caused problems. This instead set's the index of the tile to -1, effectively making it blank, and returns a copy of the original tile so as not to break anything that might rely on the return value of removeTile().
