### PR TITLE
Added undefined check processPixelRGB

### DIFF
--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -335,7 +335,7 @@ Phaser.BitmapData.prototype = {
 
                 result = callback.call(callbackContext, pixel, tx, ty);
 
-                if (result !== false && result !== null)
+                if (result !== false && result !== null && result !== undefined)
                 {
                     this.setPixel32(tx, ty, result.r, result.g, result.b, result.a, false);
                     dirty = true;


### PR DESCRIPTION
Phaser.BitmapData#processPixelRGB:

I was getting an undefined error when phaser tried to call setPixel32
using “result.r”:

![pixelprocesserror](https://cloud.githubusercontent.com/assets/1048433/2897762/8d480afe-d589-11e3-9488-d9534fc5be37.png)

With this additional undefined check the problem stopped and I’m able
to run ProcessPixelRGB with all my needed images.
