### PR TITLE
Update Silk UA test to avoid Safari conflict

### DIFF
--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -588,16 +588,18 @@ Phaser.Device.prototype = {
         {
             this.safari = true;
         }
-        else if (/Silk/.test(ua))
-        {
-            this.silk = true;
-        }
         else if (/Trident\/(\d+\.\d+)(.*)rv:(\d+\.\d+)/.test(ua))
         {
             this.ie = true;
             this.trident = true;
             this.tridentVersion = parseInt(RegExp.$1, 10);
             this.ieVersion = parseInt(RegExp.$3, 10);
+        }
+
+        //Silk gets its own if clause because its ua also contains 'Safari'
+        if (/Silk/.test(ua))
+        {
+            this.silk = true;
         }
 
         // WebApp mode in iOS


### PR DESCRIPTION
The Silk browser was being classified as desktop which prevented orientation events from firing on Kindle Fire devices.  This was happening because the User Agent for silk also contains 'Safari' in it so the check was never being done.  I simply moved it to its own clause and it fixed the problem.
