### PR TITLE
Do not overwrite PIXI.InteractionManager so I can use PIXI standalone with Phaser on the same page

### DIFF
--- a/src/Phaser.js
+++ b/src/Phaser.js
@@ -79,4 +79,4 @@ var Phaser = Phaser || {
 // however the Stage object expects a reference to it, so here is a dummy entry.
 // Ensure that an existing PIXI.InteractionManager is not overriden- in case you're using your own PIXI library.
 
-PIXI.InteractionManager = PIXI.InteractionManager || {}
+PIXI.InteractionManager = PIXI.InteractionManager || {};


### PR DESCRIPTION
I just had my fun finding this. I need to use PIXI for some sprite animations without Phaser- but I need to do it on the same page and on pages without phaser. So I decoupled phaser from pixi, created my own phaser build and included the latest pixi build as a separate file. Then it did not work. I thought it's because of requestAnimFrame or something like this. No, it's more simple. Phaser overwrites PIXI.InteractionManager with an empty object. This will cause an error whenever phaser is included and PIXI is set to interactive- which is the default.

Regards
George
