### PR TITLE
Add movement data for pointerlocked mouse

### DIFF
--- a/src/input/Pointer.js
+++ b/src/input/Pointer.js
@@ -385,7 +385,7 @@ Phaser.Pointer.prototype = {
         this.screenX = event.screenX;
         this.screenY = event.screenY;
 
-        if (this.isMouse && !fromClick) {
+        if (this.isMouse && this.game.input.mouse.locked && !fromClick) {
             this.rawMovementX = event.movementX || event.mozMovementX || event.webkitMovementX || 0;
             this.rawMovementY = event.movementY || event.mozMovementY || event.webkitMovementY || 0;
 


### PR DESCRIPTION
This adds movementX and movementY data for use with a pointerlocked mouse. 
Based on: http://www.html5gamedevs.com/topic/6064-pointer-lock/
See demo: http://connected.dnd.utwente.nl/~wouter/phasermap/ (arrow keys move, mouse rotate after pointerlock)
