### PR TITLE
Tilemap removeTile sets tiles to null

### DIFF
--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -1080,7 +1080,7 @@ Phaser.Tilemap.prototype = {
             {
                 var tile = this.layers[layer].data[y][x];
 
-                this.layers[layer].data[y][x] = null;
+                this.layers[layer].data[y][x] = new Phaser.Tile(this.layers[layer], -1, x, y, this.tileWidth, this.tileHeight);
 
                 this.layers[layer].dirty = true;
 


### PR DESCRIPTION
Tileset.removeTile used to set a null tile, causing a bug when trying to get the tile with getTile (and probably others) which assumes tiles are not null. Fixed by setting a new tile of index -1 instead.
