### PR TITLE
Web audio external node fix

### DIFF
--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -150,7 +150,7 @@ Phaser.Sound = function (game, key, volume, loop, connect) {
     this.usingAudioTag = this.game.sound.usingAudioTag;
 
     /**
-    * @property {object} externalNode - If defined this Sound won't connect to the SoundManager master gain node, but will instead connect to externalNode.input.
+    * @property {object} externalNode - If defined this Sound won't connect to the SoundManager master gain node, but will instead connect to externalNode.
     */
     this.externalNode = null;
 
@@ -524,7 +524,7 @@ Phaser.Sound.prototype = {
 
                 if (this.externalNode)
                 {
-                    this._sound.connect(this.externalNode.input);
+                    this._sound.connect(this.externalNode);
                 }
                 else
                 {
@@ -685,7 +685,7 @@ Phaser.Sound.prototype = {
 
                 if (this.externalNode)
                 {
-                    this._sound.connect(this.externalNode.input);
+                    this._sound.connect(this.externalNode);
                 }
                 else
                 {


### PR DESCRIPTION
I had troubles connecting to an external audio node (Web Audio API). It was giving this error

```
Uncaught TypeError: Failed to execute 'connect' on 'AudioNode': No function was found that matched the signature provided. 
```

By changing the Sound.play and Sound.resume functions to connect to the externalNode instead of externalNode.input seemed to fix these problems.
