### PR TITLE
Removing filters when destroying a group.

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -1635,6 +1635,8 @@ Phaser.Group.prototype.destroy = function (destroyChildren, soft) {
         this.game = null;
         this.exists = false;
     }
+    
+    this.filters = null;
 
 };
 


### PR DESCRIPTION
When a filter is applied to the world it is not removed when the group (which it inherits the prototype from) is destroyed. This clears up the filters variable as also done in sprites.

I'm not entirely sure what is best practice in the grand scheme of things though, perhaps this is required functionality and filters should not be applied at world level.
