### PR TITLE
Slope map in arcade physics

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -667,8 +667,7 @@ Phaser.Physics.Arcade.prototype = {
             return;
         }
 
-        var _slope, slopeFunction;
-        for (var i = 0, tile; i < this._mapData.length; i++)
+        for (var i = 0, tile, _slope, slopeFunction; i < this._mapData.length; i++)
         {
             tile = this._mapData[i];
 


### PR DESCRIPTION
I have added 3 types of slopes for now, the classic full square, HalfTriangleBottomLeft  and HalfTriangleBottomRight

Here is a code demo.

In your create method;

``` javascript
    // map init
    var map = this.add.tilemap('main');
    map.addTilesetImage('Kenney 32x32', 'kenney32x32');

    // set the collisions, in my map 
    map.layers.forEach(function(l){
        var layer=map.createLayer(l.name);

        if(l.name==='collision'){
            var firstgid=map.tilesets[map.getTilesetIndex('collision')].firstgid;

            l.data.forEach(function(e){
                e.forEach(function(t){
                    if (t.index < 0) {
                        // none
                    } else if (t.index - firstgid === 1) {
                        // full square is by default
                    } else if (t.index - firstgid === 15) {
                        t.slope = 'HALF_TRIANGLE_BOTTOM_LEFT';
                    } else if (t.index - firstgid === 17) {
                        t.slope = 'HALF_TRIANGLE_BOTTOM_RIGHT';
                    }
                    // you could also add custom collide function;
                    // t.slopeFunction = function (i, body, tile) { custom code }
                });
            });

            var collisionTiles = [];
            for(var i=firstgid;i<firstgid+18; i += 1){
                collisionTiles.push(i);
            }
            map.setCollision(collisionTiles, true, layer);

            this.tilesCollision=layer;
            //console.log(layer);
        }

        layer.resizeWorld();
    }, this);
```

The in your update method;

``` javascript
    this.physics.arcade.collideSpriteVsTilemapLayer(this.player, this.tilesCollision);
```
