### PR TITLE
Arcade physics support slopemaps

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -198,6 +198,12 @@ Phaser.Physics.Arcade.Body = function (sprite) {
     this.speed = 0;
 
     /**
+    * @property {number} speed - The speed punish of the Body used for the a inclined plane
+    * @readonly
+    */
+    this.velocityPunish = new Phaser.Point(0, 0);
+
+    /**
     * @property {number} facing - A const reference to the direction the Body is traveling or facing.
     * @default
     */

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1752,7 +1752,7 @@ Phaser.Physics.Arcade.prototype = {
 Phaser.Physics.Arcade._collisionFullSquare = function (i, body, tile) {
     var collides = this.separateTile(i, body, tile);
     if (collides) {
-        body.speedxPunish = 0;
+        body.velocityPunish.x = 0;
     }
     return collides;
 };
@@ -1761,7 +1761,7 @@ Phaser.Physics.Arcade._collisionHalfTriangleBottomLeft = function (i, body, tile
     if (body.velocity.y > 0 && (body.position.y + body.height - tile.bottom) + (body.position.x - tile.right) <= 0){
         body.y = (body.position.x - tile.right) - (body.height - tile.bottom);
         body.blocked.down = true;
-        body.speedxPunish = body.gravity.y * Math.cos(45) * 0.1;
+        body.velocityPunish.x = body.gravity.y * Math.cos(45) * 0.1;
         return false;
     }
     return true;
@@ -1771,7 +1771,7 @@ Phaser.Physics.Arcade._collisionHalfTriangleBottomRight = function (i, body, til
     if (body.velocity.y > 0 && (body.position.y + body.height - tile.top) - (body.position.x + body.width - tile.right) >= 0) {
         body.y = tile.bottom + tile.left - (body.position.x + body.width) - body.height;
         body.blocked.down = true;
-        body.speedxPunish = -body.gravity.y * Math.cos(45) * 0.1;
+        body.velocityPunish.x = -body.gravity.y * Math.cos(45) * 0.1;
         return false;
     }
 
@@ -1782,4 +1782,4 @@ Phaser.Physics.Arcade.SLOPEMAP = {
     'FULL_SQUARE': Phaser.Physics.Arcade._collisionFullSquare,
     'HALF_TRIANGLE_BOTTOM_LEFT': Phaser.Physics.Arcade._collisionHalfTriangleBottomLeft,
     'HALF_TRIANGLE_BOTTOM_RIGHT': Phaser.Physics.Arcade._collisionHalfTriangleBottomRight
-}
+};


### PR DESCRIPTION
I have added 3 types of slopes for now, the classic full square, HalfTriangleBottomLeft  and HalfTriangleBottomRight

Here is a code demo.

In your create method;

``` javascript
    // map init
    var map = this.add.tilemap('main');
    map.addTilesetImage('Kenney 32x32', 'kenney32x32');

    // set the collisions, in my map 
    map.layers.forEach(function(l){
        var layer=map.createLayer(l.name);

        if(l.name==='collision'){
            var firstgid=map.tilesets[map.getTilesetIndex('collision')].firstgid;

            l.data.forEach(function(e){
                e.forEach(function(t){
                    if (t.index < 0) {
                        // none
                    } else if (t.index - firstgid === 1) {
                        // full square is by default
                    } else if (t.index - firstgid === 15) {
                        t.slope = 'HALF_TRIANGLE_BOTTOM_LEFT';
                    } else if (t.index - firstgid === 17) {
                        t.slope = 'HALF_TRIANGLE_BOTTOM_RIGHT';
                    }
                    // you could also add custom collide function;
                    // t.slopeFunction = function (i, body, tile) { custom code }
                });
            });

            var collisionTiles = [];
            for(var i=firstgid;i<firstgid+18; i += 1){
                collisionTiles.push(i);
            }
            map.setCollision(collisionTiles, true, layer);

            this.tilesCollision=layer;
            //console.log(layer);
        }

        layer.resizeWorld();
    }, this);
```

The in your update method;

``` javascript
    this.physics.arcade.collideSpriteVsTilemapLayer(this.player, this.tilesCollision);
```
