### PR TITLE
Fix Phaser.Line.intersectsPoints for floating point inaccuracy.

### DIFF
--- a/src/geom/Line.js
+++ b/src/geom/Line.js
@@ -375,8 +375,13 @@ Phaser.Line.intersectsPoints = function (a, b, e, f, asSegment, result) {
         return null;
     }
 
-    result.x = ((b1 * c2) - (b2 * c1)) / denom;
-    result.y = ((a2 * c1) - (a1 * c2)) / denom;
+    /*
+     Round to 3 decimals here, due to javascript floating point is 'broken'
+     http://stackoverflow.com/questions/11832914/round-to-at-most-2-decimal-places-in-javascript
+     See workaround explanation there in accepted answer there..
+     */
+    result.x = Math.round( ((((b1 * c2) - (b2 * c1)) / denom)+0.00001)*1000 ) / 1000;
+    result.y = Math.round( ((((a2 * c1) - (a1 * c2)) / denom)+0.00001)*1000 ) / 1000;
 
     if (asSegment)
     {


### PR DESCRIPTION
This rounds the intersection result to 3 decimals. Should be accurate enough.
See: http://www.html5gamedevs.com/topic/6840-phaserlineintersects-does-not-work-for-floats/
