### PR TITLE
Fix getPixel for pixels with zero red value.

### DIFF
--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -686,13 +686,10 @@ Phaser.BitmapData.prototype = {
 
         index *= 4;
 
-        if (this.data[index])
-        {
-            out.r = this.data[index];
-            out.g = this.data[++index];
-            out.b = this.data[++index];
-            out.a = this.data[++index];
-        }
+        out.r = this.data[index];
+        out.g = this.data[++index];
+        out.b = this.data[++index];
+        out.a = this.data[++index];
 
         return out;
 


### PR DESCRIPTION
Remove an erroneous `if` that causes `getPixel()` to fail if the red value of the pixel is zero.

I'm not sure what the original intent of the if check was, and I have made no attempt to preserve that intent. It is possible that it wanted to avoid out-of-bounds access, in which case a `try/catch` would probably be better.

Fiddle with bug: http://jsfiddle.net/FxjL8/11/
Fiddle after fixing the bug: http://jsfiddle.net/FxjL8/13/

In the first fiddle, clicking on green, blue or cyan will return a blank color object. In the second fiddle, it works for all colors.

Fixes #881.
