### PR TITLE
Support asset revving at the Loader level

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -126,7 +126,7 @@ Phaser.Loader = function (game) {
     this.onLoadComplete = new Phaser.Signal();
 
     /**
-     * If you supplied, you can provide a mapping between original URLs and their new location. This is useful when a game's assets are revved by a hash of their contents, to allow for browsers to cache non-changing assets between versions. The mapping should be from the original url to the new url i.e.
+     * If supplied, you can provide a mapping between original URLs and their new location. This is useful when a game's assets are revved by a hash of their contents, to allow for browsers to cache non-changing assets between versions. The mapping should be from the original url to the new url i.e.
      * revvingMapping['audio/music/default.mp3'] = 'revved/audio/music/default.abc123ef.mp3';
      * When hosting games on third party distributor sites, they may request that your game supports revved assets, and provide you with a mapping of original files to their revved locations, and these can be set here.
      * @property {object} revvingMapping - If defined, this mapping is used to convert any urls requested to a revved alternative. {@link http://stackoverflow.com/questions/15891855/what-are-the-advantages-of-revving-files-with-a-hash-over-a-version-or-date|Stack Overflow on revving by file hashes}


### PR DESCRIPTION
http://www.html5gamedevs.com/topic/7128-phaser-and-asset-revving/ - Adding the ability to specify an asset revving mapping to phaser, so that the content is automatically mapped to revved versions of the assets if supplied, and if it isn't supplied, then to fall back to existing behaviour. If a mapping is provided, but the mapping for the given url cannot be found, then fall back to existing behaviour.
