### PR TITLE
Fix for issue #917, Physics.P2.Body#addToWorld

### DIFF
--- a/src/physics/p2/Body.js
+++ b/src/physics/p2/Body.js
@@ -719,6 +719,17 @@ Phaser.Physics.P2.Body.prototype = {
     */
     addToWorld: function () {
 
+        if (this.game.physics.p2._toRemove)
+        {
+            for (var i = 0; i < this.game.physics.p2._toRemove.length; i++)
+            {
+                if (this.game.physics.p2._toRemove[i] === this)
+                {
+                    this.game.physics.p2._toRemove.splice(i, 1);
+                }
+            }
+        }
+        
         if (this.data.world !== this.game.physics.p2.world)
         {
             this.game.physics.p2.addBody(this);


### PR DESCRIPTION
Fix for issue #917: Calling reset() on Sprite with a P2 body can result in body.data.world == null.
Calling addToWorld() would previously not check the _toRemove array, which could, if the timing were right, result in a Sprite being revived but then removed from the P2 World--the result of this being the Sprite's data would be in a mixed state causing it to appear visually but not function in the world.
