### PR TITLE
Fix checkPointerDown method

### DIFF
--- a/src/input/InputHandler.js
+++ b/src/input/InputHandler.js
@@ -610,14 +610,14 @@ Phaser.InputHandler.prototype = {
     },
 
     /**
-    * Checks if the given pointer is over this Sprite and can click it.
+    * Checks if the given pointer is both down and over this Sprite.
     * @method Phaser.InputHandler#checkPointerDown
     * @param {Phaser.Pointer} pointer
     * @return {boolean} True if the pointer is down, otherwise false.
     */
     checkPointerDown: function (pointer) {
 
-        if (!this.enabled || !this.sprite || !this.sprite.parent || !this.sprite.visible || !this.sprite.parent.visible)
+        if (!pointer.isDown || !this.enabled || !this.sprite || !this.sprite.parent || !this.sprite.visible || !this.sprite.parent.visible)
         {
             return false;
         }


### PR DESCRIPTION
checkPointerDown method was a verbatim duplication of checkPointerOver - added pointer.isDown check to passed pointer and altered wording of associated docs to make it clearer what the method is doing.
