### PR TITLE
TileMap update performance

### DIFF
--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -892,7 +892,7 @@ Phaser.Tilemap.prototype = {
     * @param {boolean} if true it will put the recalculation on hold.
     */
     setPreventRecalculate: function (value) {
-        if((value===true)&&(this.preventingRecalculate===false)){
+        if((value===true)&&(this.preventingRecalculate!==true)){
             this.preventingRecalculate = true;
             this.needToRecalculate = {};
         }


### PR DESCRIPTION
Discussion: http://www.html5gamedevs.com/topic/7409-tilemaps-changing/

It should remove the problem of updating stuff in a 100x100 tilemap making the engine recalculate every single update.(390 tiles changed in that map makes it a 100x100x390 loop.
Would make the recalculate parameter in the setCollision functions unnecessary as well.
