### PR TITLE
replaceColor fix

### DIFF
--- a/src/utils/Color.js
+++ b/src/utils/Color.js
@@ -22,31 +22,31 @@ Phaser.Color = {
     * @param {number} g - The green color component, in the range 0 - 255.
     * @param {number} b - The blue color component, in the range 0 - 255.
     * @param {number} a - The alpha color component, in the range 0 - 255.
-    * @return {number} The packed color
+    * @return {number} The packed color as uint32
     */
     packPixel: function (r, g, b, a) {
 
         if (Phaser.Device.LITTLE_ENDIAN)
         {
-            return (a << 24) | (b << 16) | (g <<  8) | r;
+            return ( (a << 24) | (b << 16) | (g <<  8) | r ) >>> 0;
         }
         else
         {
-            return (r << 24) | (g << 16) | (b <<  8) | a;
+            return ( (r << 24) | (g << 16) | (b <<  8) | a ) >>> 0;
         }
 
     },
 
     /**
     * Unpacks the r, g, b, a components into the specified color object, or a new
-    * object, for use with Int32Array. If little endian, then ABGR order is used when 
+    * object, for use with Int32Array. If little endian, then ABGR order is used when
     * unpacking, otherwise, RGBA order is used. The resulting color object has the
     * `r, g, b, a` properties which are unrelated to endianness.
     *
     * Note that the integer is assumed to be packed in the correct endianness. On little-endian
     * the format is 0xAABBGGRR and on big-endian the format is 0xRRGGBBAA. If you want a
     * endian-independent method, use fromRGBA(rgba) and toRGBA(r, g, b, a).
-    * 
+    *
     * @author Matt DesLauriers (@mattdesl)
     * @method Phaser.Color.unpackPixel
     * @static
@@ -76,7 +76,7 @@ Phaser.Color = {
             out.b = ((rgba & 0x0000ff00) >>> 8);
             out.a = ((rgba & 0x000000ff));
         }
-        
+
         out.color = rgba;
         out.rgba = 'rgba(' + out.r + ',' + out.g + ',' + out.b + ',' + (out.a / 255) + ')';
 
@@ -673,7 +673,7 @@ Phaser.Color = {
 
     /**
     * Interpolates the two given colours based on the supplied step and currentStep properties.
-    * 
+    *
     * @method Phaser.Color.interpolateColorWithRGB
     * @static
     * @param {number} color - The first color value.


### PR DESCRIPTION
Hey

I had a problem with BitmapData.replaceColor, it worked sometimes and sometimes not.

I figured out that the problem was the different representation of the pixel data types.

The Uint32Array pixel[] value is compared to the return value of a packPixel() call.
Phaser.Color.packPixel(0,0,0,255) = -16777216
The same bits interpreted as uint32 are 4278190080.
The color comparisation will fail even if the color is the same.

This example does not work for me also:
http://examples.phaser.io/_site/view_full.html?d=display&f=bitmapdata+replace+color.js&t=bitmapdata%20replace%20color

I used this hack from stackoverflow to directly fix the packPixel() function.
http://stackoverflow.com/questions/22335853/hack-to-convert-javascript-number-to-uint32

The function Phaser.Color.toRGBA() still implements the "old" behaviour which can result in negative numbers.

Greetings
-- Phaiax
