### PR TITLE
Adding a return to the Tween#from method

### DIFF
--- a/src/tween/Tween.js
+++ b/src/tween/Tween.js
@@ -280,7 +280,7 @@ Phaser.Tween.prototype = {
                 this._object[prop] = properties[prop];
             }
         }
-        this.to(_cache, duration, ease, autoStart, delay, repeat, yoyo);
+        return this.to(_cache, duration, ease, autoStart, delay, repeat, yoyo);
     },
 
     /**


### PR DESCRIPTION
The Tween#from was not returning a reference to the Tween object. This is a fix for Issue #975.
