### PR TITLE
Prefer XMLHttpRequest over XDomainRequest

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1213,7 +1213,7 @@ Phaser.Loader.prototype = {
 
             case 'json':
 
-                if (window.XDomainRequest)
+                if (!"withCredentials" in this._xhr && window.XDomainRequest)
                 {
                     this._ajax = new window.XDomainRequest();
 


### PR DESCRIPTION
XDomainRequest is long deprecated and not recommended.

http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx

https://developer.mozilla.org/en-US/docs/Web/API/XDomainRequest
