### PR TITLE
Added options to disable horizontal and vertical world wrapping individually

### DIFF
--- a/src/core/World.js
+++ b/src/core/World.js
@@ -112,28 +112,32 @@ Phaser.World.prototype.shutdown = function () {
 * @param {Phaser.Sprite|Phaser.Image|Phaser.TileSprite|Phaser.Text} sprite - The object you wish to wrap around the world bounds.
 * @param {number} [padding=0] - Extra padding added equally to the sprite.x and y coordinates before checking if within the world bounds. Ignored if useBounds is true.
 * @param {boolean} [useBounds=false] - If useBounds is false wrap checks the object.x/y coordinates. If true it does a more accurate bounds check, which is more expensive.
+* @param {boolean} [horizontal=true] - If horizontal is false, wrap will not wrap the object.x coordinates horizontally.
+* @param {boolean} [vertical=true] - If vertical is false, wrap will not wrap the object.y coordinates vertically.
 */
-Phaser.World.prototype.wrap = function (sprite, padding, useBounds) {
+Phaser.World.prototype.wrap = function (sprite, padding, useBounds, horizontal, vertical) {
 
     if (typeof padding === 'undefined') { padding = 0; }
     if (typeof useBounds === 'undefined') { useBounds = false; }
+    if (typeof horizontal === 'undefined') { horizontal = true; }
+    if (typeof vertical === 'undefined') { vertical = true; }
 
     if (!useBounds)
     {
-        if (sprite.x + padding < this.bounds.x)
+        if (horizontal && sprite.x + padding < this.bounds.x)
         {
             sprite.x = this.bounds.right + padding;
         }
-        else if (sprite.x - padding > this.bounds.right)
+        else if (horizontal && sprite.x - padding > this.bounds.right)
         {
             sprite.x = this.bounds.left - padding;
         }
 
-        if (sprite.y + padding < this.bounds.top)
+        if (vertical && sprite.y + padding < this.bounds.top)
         {
             sprite.y = this.bounds.bottom + padding;
         }
-        else if (sprite.y - padding > this.bounds.bottom)
+        else if (vertical && sprite.y - padding > this.bounds.bottom)
         {
             sprite.y = this.bounds.top - padding;
         }
@@ -142,20 +146,20 @@ Phaser.World.prototype.wrap = function (sprite, padding, useBounds) {
     {
         sprite.getBounds();
 
-        if (sprite._currentBounds.right < this.bounds.x)
+        if (horizontal && sprite._currentBounds.right < this.bounds.x)
         {
             sprite.x = this.bounds.right;
         }
-        else if (sprite._currentBounds.x > this.bounds.right)
+        else if (horizontal && sprite._currentBounds.x > this.bounds.right)
         {
             sprite.x = this.bounds.left;
         }
 
-        if (sprite._currentBounds.bottom < this.bounds.top)
+        if (vertical && sprite._currentBounds.bottom < this.bounds.top)
         {
             sprite.y = this.bounds.bottom;
         }
-        else if (sprite._currentBounds.top > this.bounds.bottom)
+        else if (vertical && sprite._currentBounds.top > this.bounds.bottom)
         {
             sprite.y = this.bounds.top;
         }


### PR DESCRIPTION
I recently found myself having to rewrite the wrapping checks manually to handle this situation. This is a backwards compatible change. Just a convenience, it can be nice to separate how the sprite wraps.

Feel free to edit the implementation. I considered new helper methods such as `world.wrapX()` and `world.wrapY()`, but thought it would add too much code.
