### PR TITLE
Warn about missing textures and show the key that the author was trying to use.

### DIFF
--- a/src/gameobjects/Image.js
+++ b/src/gameobjects/Image.js
@@ -266,6 +266,7 @@ Phaser.Image.prototype.loadTexture = function (key, frame) {
         }
         else if (typeof key === 'string' && !this.game.cache.checkImageKey(key))
         {
+            console.warn("Texture with key '" + key + "' not found.");
             this.key = '__missing';
             this.setTexture(PIXI.TextureCache[this.key]);
         }

--- a/src/gameobjects/Sprite.js
+++ b/src/gameobjects/Sprite.js
@@ -386,6 +386,7 @@ Phaser.Sprite.prototype.loadTexture = function (key, frame) {
         }
         else if (typeof key === 'string' && !this.game.cache.checkImageKey(key))
         {
+            console.warn("Texture with key '" + key + "' not found.");
             this.key = '__missing';
             this.setTexture(PIXI.TextureCache[this.key]);
         }

--- a/src/gameobjects/TileSprite.js
+++ b/src/gameobjects/TileSprite.js
@@ -358,6 +358,7 @@ Phaser.TileSprite.prototype.loadTexture = function (key, frame) {
         }
         else if (typeof key === 'string' && !this.game.cache.checkImageKey(key))
         {
+            console.warn("Texture with key '" + key + "' not found.");
             this.key = '__missing';
             this.setTexture(PIXI.TextureCache[this.key]);
         }


### PR DESCRIPTION
It can be very helpful for debugging which image a sprite was trying to load exactly.
