### PR TITLE
Loop count infinite

### DIFF
--- a/src/animation/Animation.js
+++ b/src/animation/Animation.js
@@ -394,6 +394,10 @@ Phaser.Animation.prototype = {
                         this.onLoop.dispatch(this._parent, this);
                     }
                 }
+                else
+                {
+                    this.complete();
+                }
             }
 
             this.currentFrame = this._frameData.getFrame(this._frames[this._frameIndex]);


### PR DESCRIPTION
Instead of only using ‘Animation.loop' variable as a bool, check to see if it’s a number and loop N times.
Call ‘complete’ after all loops are done.
