### PR TITLE
Fixed pixel perfect dragging

### DIFF
--- a/src/input/InputHandler.js
+++ b/src/input/InputHandler.js
@@ -1133,7 +1133,7 @@ Phaser.InputHandler.prototype = {
         this.dragOffset = new Phaser.Point();
         this.dragFromCenter = lockCenter;
 
-        this.pixelPerfect = pixelPerfect;
+        this.pixelPerfectClick = pixelPerfect;
         this.pixelPerfectAlpha = alphaThreshold;
 
         if (boundsRect)


### PR DESCRIPTION
Pixel perfect dragging was still using the old `pixelPerfect` property, instead of the new `pixelPerfectClick`.
