### PR TITLE
Added missing onPackComplete Signal

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -95,6 +95,11 @@ Phaser.Loader = function (game) {
     this.onLoadComplete = new Phaser.Signal();
 
     /**
+    * @property {Phaser.Signal} onPackComplete - This event is dispatched when an asset pack has either loaded or failed. 
+    */
+    this.onPackComplete = new Phaser.Signal();
+    
+    /**
     * @property {array} _packList - Contains all the assets packs.
     * @private
     */
@@ -1101,7 +1106,7 @@ Phaser.Loader.prototype = {
 
         console.warn("Phaser.Loader error loading pack file: " + this._packList[index].key + ' from URL ' + this._packList[index].url);
 
-        this.nextPack(index, true);
+        this.nextPack(index, false);
 
     },
 


### PR DESCRIPTION
The asset pack loader references a missing "onPackComplete" Signal.  The loader fails when it attempts to dispatch the event.  This bug is currently reproduced in the [Asset Pack Example](http://examples.phaser.io/_site/view_full.html?d=loader&f=asset+pack.js&t=asset%20pack).

I've also updated "packError" to correctly send `false` to "nextPack" when a pack has failed to load.
