### PR TITLE
codePaused should be set if manually called

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -857,23 +857,23 @@ Object.defineProperty(Phaser.Game.prototype, "paused", {
             if (this._paused === false)
             {
                 this._paused = true;
-                this._codePaused = true;
                 this.sound.setMute();
                 this.time.gamePaused();
                 this.onPause.dispatch(this);
             }
+            this._codePaused = true;
         }
         else
         {
             if (this._paused)
             {
                 this._paused = false;
-                this._codePaused = false;
                 this.input.reset();
                 this.sound.unsetMute();
                 this.time.gameResumed();
                 this.onResume.dispatch(this);
             }
+            this._codePaused = false;
         }
 
     }


### PR DESCRIPTION
If pause is called manually, codePaused should be set regardless of whether the game is currently paused or not. This would fix issues where a developer might not want the game to automatically resume when the screen regains focus.

codePaused issue, I wrote a forum post here:
http://www.html5gamedevs.com/topic/6719-codepaused-property/
