### PR TITLE
Reset the current animation.

### DIFF
--- a/src/gameobjects/Sprite.js
+++ b/src/gameobjects/Sprite.js
@@ -401,6 +401,7 @@ Phaser.Sprite.prototype.loadTexture = function (key, frame) {
         this._frame = Phaser.Rectangle.clone(this.texture.frame);
     }
 
+    this.animations.currentAnim = undefined;
 };
 
 /**
@@ -559,7 +560,7 @@ Phaser.Sprite.prototype.updateCrop = function() {
         PIXI.WebGLRenderer.updateTextureFrame(this.texture);
     }
 
-}
+};
 
 /**
 * Brings a 'dead' Sprite back to life, optionally giving it the health value specified.


### PR DESCRIPTION
When going from an animating Sprite with multiple frames to an image
with 1 frame, the AnimationManager keeps setting invalid frames upon
the single-frame image.

This fix may not be correct for it overwrites the currentAnimation
_always_…
