### PR TITLE
Frame data guards

### DIFF
--- a/src/animation/Animation.js
+++ b/src/animation/Animation.js
@@ -510,7 +510,7 @@ Phaser.Animation.prototype = {
     updateFrameData: function (frameData) {
 
         this._frameData = frameData;
-        this.currentFrame = this._frameData.getFrame(this._frames[this._frameIndex]);
+        this.currentFrame = this._frameData ? this._frameData.getFrame(this._frames[this._frameIndex % this._frames.length]) : null;
 
     },
 


### PR DESCRIPTION
Sometimes, this._frameData is null. Guard against it.
Sometimes, we transfer to an animation that contains fewer frames.
Guard against it.
