### PR TITLE
OritentationSprite fix, not using PIXI.TextureCache anymore

### DIFF
--- a/src/core/ScaleManager.js
+++ b/src/core/ScaleManager.js
@@ -396,7 +396,7 @@ Phaser.ScaleManager.prototype = {
                 orientationImage = '__default';
             }
 
-            this.orientationSprite = new Phaser.Image(this.game, this.game.width / 2, this.game.height / 2, PIXI.TextureCache[orientationImage]);
+            this.orientationSprite = new Phaser.Image(this.game, this.game.width / 2, this.game.height / 2, orientationImage);
             this.orientationSprite.anchor.set(0.5);
 
             this.checkOrientationState();


### PR DESCRIPTION
A simple fix for orientation sprite which didn't work anymore.
