### PR TITLE
Ability to drag while the camera is moving.

### DIFF
--- a/src/input/InputHandler.js
+++ b/src/input/InputHandler.js
@@ -1012,12 +1012,12 @@ Phaser.InputHandler.prototype = {
         {
             if (this.allowHorizontalDrag)
             {
-                this.sprite.x = pointer.x + this._dragPoint.x + this.dragOffset.x;
+                this.sprite.x = pointer.x + this._dragPoint.x + this.game.camera.x + this.dragOffset.x;
             }
 
             if (this.allowVerticalDrag)
             {
-                this.sprite.y = pointer.y + this._dragPoint.y + this.dragOffset.y;
+                this.sprite.y = pointer.y + this._dragPoint.y + this.game.camera.y + this.dragOffset.y;
             }
 
             if (this.boundsRect)
@@ -1233,11 +1233,11 @@ Phaser.InputHandler.prototype = {
                 var bounds = this.sprite.getBounds();
                 this.sprite.x = pointer.x + (this.sprite.x - bounds.centerX);
                 this.sprite.y = pointer.y + (this.sprite.y - bounds.centerY);
-                this._dragPoint.setTo(this.sprite.x - pointer.x, this.sprite.y - pointer.y);
+                this._dragPoint.setTo(this.sprite.x - pointer.x - this.game.camera.x, this.sprite.y - pointer.y - this.game.camera.y);
             }
             else
             {
-                this._dragPoint.setTo(this.sprite.x - pointer.x, this.sprite.y - pointer.y);
+                this._dragPoint.setTo(this.sprite.x - pointer.x - this.game.camera.x, this.sprite.y - pointer.y - this.game.camera.y);
             }
         }
 


### PR DESCRIPTION
Right now  when you drag a sprite, and the camera moves, the position gets messy.

For example, if your camera moves when you're near the edge, now you can do that while dragging a sprite.

However, a drag update still requires a mousemove, so there probably should be an update when the camera moves.. I didn't make this change yet as I'm not sure on the best approach.

What I did, might not have been the best approach either, so please review it.. its a small change.