### PR TITLE
Fix for previous PR #1028

### DIFF
--- a/src/physics/Physics.js
+++ b/src/physics/Physics.js
@@ -153,8 +153,6 @@ Phaser.Physics.prototype = {
             throw new Error('The Chipmunk physics system has not been implemented yet.');
         }
 
-        this.setBoundsToWorld();
-
     },
 
     /**

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -146,6 +146,9 @@ Phaser.Physics.Arcade = function (game) {
     */
     this._dy = 0;
 
+    // By default we want the bounds the same size as the world bounds
+    this.setBoundsToWorld();
+
 };
 
 Phaser.Physics.Arcade.prototype.constructor = Phaser.Physics.Arcade;

--- a/src/physics/ninja/World.js
+++ b/src/physics/ninja/World.js
@@ -64,6 +64,9 @@ Phaser.Physics.Ninja = function (game) {
     */
     this.quadTree = new Phaser.QuadTree(this.game.world.bounds.x, this.game.world.bounds.y, this.game.world.bounds.width, this.game.world.bounds.height, this.maxObjects, this.maxLevels);
 
+    // By default we want the bounds the same size as the world bounds
+    this.setBoundsToWorld();
+
 };
 
 Phaser.Physics.Ninja.prototype.constructor = Phaser.Physics.Ninja;


### PR DESCRIPTION
Fix to previous PR which I had noticed because of this thread. http://www.html5gamedevs.com/topic/8050-collideworldbounds-different-in-207/

The setBoundsToWorld call was overriding the setBoundsToWorld in the P2 constructor (line 181) which I had not noticed before. So I just copied the P2 style and added the setBoundsToWorld calls at the end of the other 2 physics systems constuctors, which makes more sense as each system now handles setting the bounds to their own systems.

On a side note, P2.setBoundsToWorld has setCollisionGroup=true, seems more intuitive to be default to false to me, if it had been false there would have been no issue. If anyone calls Physics.setBoundsToWorld() (like I had) it passes no parameters to P2.setBoundsToWorld and so will have setCollisionGroup = true, which I don't think would be most peoples intentions.
