### PR TITLE
Guard against crop width/height being 0

### DIFF
--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -308,7 +308,7 @@ PIXI.Sprite.prototype._renderWebGL = function(renderSession)
 PIXI.Sprite.prototype._renderCanvas = function(renderSession)
 {
     // If the sprite is not visible or the alpha is 0 then no need to render this element
-    if (this.visible === false || this.alpha === 0) return;
+    if (this.visible === false || this.alpha === 0 || texture.crop.width <= 0 || texture.crop.height <= 0) return;
     
     if (this.blendMode !== renderSession.currentBlendMode)
     {


### PR DESCRIPTION
Otherwise this causes errors in IE 11.
The way this gets used is for a loading bar for instance.
