### PR TITLE
Removed implicit 'any' typed from typescript file

### DIFF
--- a/build/phaser.d.ts
+++ b/build/phaser.d.ts
@@ -116,7 +116,7 @@ declare module PIXI {
 
         constructor(url: string, crossorigin: any): any;
 
-        load();
+        load() : any;
     }
 
     export interface ITintMethod {
@@ -713,7 +713,7 @@ declare module PIXI {
         constructor(texture: Texture, points: Point[]);
 
         refresh(): void;
-        setTexture(texture: Texture);
+        setTexture(texture: Texture): any;
 
     }
 
@@ -740,7 +740,7 @@ declare module PIXI {
 
         createSprite(slot: any, descriptor: string): Sprite;
 
-        load();
+        load() : any;
     }
 
     export class SpineLoader extends EventTarget {
@@ -791,7 +791,7 @@ declare module PIXI {
 
         constructor(url: string, crossorigin?: any);
 
-        load();
+        load(): any;
     }
 
     export class Stage extends DisplayObjectContainer {
@@ -943,7 +943,7 @@ declare module PIXI {
         initShaderBuffers(): void;
         pushFilter(filterBlock: IFilterBlock): void;
         popFilter(): void;
-        setContext(gl: any);
+        setContext(gl: any) : any;
 
     }
 
@@ -959,7 +959,7 @@ declare module PIXI {
         pushMask(maskData: any[], renderSession: IRenderSession): void;
         popMask(renderSession: IRenderSession): void;
         setBlendMode(blendMode: number): void;
-        setContext(gl: any);
+        setContext(gl: any) : any;
 
     }
 
@@ -995,7 +995,7 @@ declare module PIXI {
         deactivatePrimitiveShader(): void;
         destroy(): void;
         setAttribs(attribs: IShaderAttribute[]): void;
-        setContext(gl: any, transparent: boolean);
+        setContext(gl: any, transparent: boolean): any;
 
     }
 
@@ -1152,7 +1152,7 @@ declare module Phaser {
         next(quantity?: number): void;
         play(name: string, frameRate?: number, loop?: boolean, killOnComplete?: boolean): Phaser.Animation;
         previous(quantity?: number): void;
-        refreshFrame();
+        refreshFrame() :any;
         stop(name?: string, resetFrame?: boolean): void;
         update(): boolean;
         validateFrames(frames: Phaser.Frame[], useNumericIndex?: boolean): boolean;
@@ -1177,7 +1177,7 @@ declare module Phaser {
         total: number;
 
         add(child: Object): Object;
-        callAll(callback: Function, ...parameters: any[]);
+        callAll(callback: Function, ...parameters: any[]) :any;
         exists(child: Object): boolean;
         getIndex(child: Object): number;
         remove(child: Object): Object;
@@ -1908,7 +1908,7 @@ declare module Phaser {
 
         destroy(): void;
         init(...args: any[]): void;
-        setResolution(width: number, height: number);
+        setResolution(width: number, height: number) :any;
         update(pointer?: Phaser.Pointer): void;
 
     }
@@ -2216,7 +2216,7 @@ declare module Phaser {
         processButtonDown(value: number): void;
         processButtonFloat(value: number): void;
         processButtonUp(value: number): void;
-        reset();
+        reset() :any;
     }
 
     class Graphics extends PIXI.Graphics {
@@ -3245,7 +3245,7 @@ declare module Phaser {
             collide(object1: any, object2: any, collideCallback?: Function, processCallback?: Function, callbackContext?: Object): boolean;
             convertTilemap(map: Phaser.Tilemap, layer?: any, slopeMap?: Object): Phaser.Physics.Ninja.Tile[];
             enableAABB(object: any, children?: boolean): void;
-            enableCircle(object: any, radius: number, children?: boolean);
+            enableCircle(object: any, radius: number, children?: boolean) :any;
             enableTile(object: any, id: number, children?: boolean): void;
             enable(object: any, type?: number, id?: number, radius?: number, children?: boolean): void;
             enableBody(object: any, type?: number, id?: number, radius?: number): void;
@@ -3396,7 +3396,7 @@ declare module Phaser {
                 collideWorldBounds(): void;
                 destroy(): void;
                 integrate(): void;
-                reportCollisionVsWorld(px: number, py: number, dx: number, dy: number, obj: Object);
+                reportCollisionVsWorld(px: number, py: number, dx: number, dy: number, obj: Object) :any;
                 setType(id: number): number;
 
             }
@@ -3483,7 +3483,7 @@ declare module Phaser {
             removeBody(body: Phaser.Physics.P2.Body): Phaser.Physics.P2.Body;
             removeBodyNextStep(body: Phaser.Physics.P2.Body): void;
             removeConstraint(constraint: any): any;
-            removeContactMaterial(material: Phaser.Physics.P2.ContactMaterial);
+            removeContactMaterial(material: Phaser.Physics.P2.ContactMaterial) :any;
             removeSpring(spring: Phaser.Physics.P2.Spring): Phaser.Physics.P2.Spring;
             resume(): void;
             setBounds(x: number, y: number, width: number, height: number, left?: Boolean, right?: boolean, top?: boolean, bottom?: boolean, setCollisionGroup?: boolean): void;
@@ -3860,7 +3860,7 @@ declare module Phaser {
 
             constructor(game: Phaser.Game, parent: any);
 
-            addSprite(sprite: Phaser.Sprite);
+            addSprite(sprite: Phaser.Sprite) :any;
             update(): void;
 
         }
@@ -4723,7 +4723,7 @@ declare module Phaser {
         x: number;
         y: number;
 
-        copy(tile): Phaser.Tile;
+        copy(tile: Phaser.Tile): Phaser.Tile;
         containsPoint(x: number, y: number): boolean;
         destroy(): void;
         intersects(x: number, y: number, right: number, bottom: number): boolean;
@@ -5008,7 +5008,7 @@ declare module Phaser {
 
     class TimerEvent {
 
-        constructor(timer: Phaser.Timer, delay: number, tick: number, repeatCount: number, loop: boolean, callback: Function, callbackContext, Object, args: any[]);
+        constructor(timer: Phaser.Timer, delay: number, tick: number, repeatCount: number, loop: boolean, callback: Function, callbackContext: any, Object: any, args: any[]);
 
         args: any[];
         callback: Function;
@@ -5143,7 +5143,7 @@ declare module Phaser {
             geom(object: any, color?: string, fiiled?: boolean, forceType?: number): void;
             inputInfo(x: number, y: number, color?: string): void;
             lineInfo(line: Phaser.Line, x: number, y: number, color?: string): void;
-            key(key: Phaser.Key, x?: number, y?: number, color?: string);
+            key(key: Phaser.Key, x?: number, y?: number, color?: string): any;
             line(): void;
             preUpdate(): void;
             pixel(x: number, y: number, color?: string, size?: number): void;


### PR DESCRIPTION
I Fixed the problem described in Issue #1086.

---

_Copy of the Issue-Description:_

there are around 20 compile errors in the typescript definition file `/build/phaser.d.ts`.

The TS compiler doesn't show them with the default configuration. But one can activate the `--noimplicitany`-option to prevent the _implicit 'any'_ type, which results in the 20 errors. 

From a first glimpse at `/build/phaser.d.ts`, it looked like only `:any` has to be added 20 times...

In Visual Studio this stops the whole compiling process.
In both, Eclipse and VS, the error-view is flooded with annoying error messages, which detract from finding bugs in the actual game code.
