### PR TITLE
TileMapLayer getTileX/Y returns number not Tile

### DIFF
--- a/build/phaser.d.ts
+++ b/build/phaser.d.ts
@@ -4794,9 +4794,9 @@ declare module Phaser {
 
         getRayCastTiles(line: Phaser.Line, stepRate?: number, collides?: boolean, interestingFace?: boolean): Phaser.Tile[];
         getTiles(x: number, y: number, width: number, height: number, collides?: boolean, interestingFace?: boolean): Phaser.Tile[];
-        getTileX(x: number): Phaser.Tile;
+        getTileX(x: number): number;
         getTileXY(x: number, y: number, point: Phaser.Point): Phaser.Point;
-        getTileY(y: number): Phaser.Tile;
+        getTileY(y: number): number;
         postUpdate(): void;
         render(): void;
         renderDebug(): void;


### PR DESCRIPTION
Fixed simple type error.

http://www.html5gamedevs.com/topic/8621-gettilex-gettiley-typescript-signature-wrong/
