### PR TITLE
Cordova 'deviceready' event check

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -321,6 +321,10 @@ Phaser.Game = function (width, height, renderer, parent, state, transparent, ant
     {
         window.setTimeout(this._onBoot, 0);
     }
+    else if(typeof window.cordova !== "undefined")
+    {
+        document.addEventListener('deviceready', this._onBoot, false);
+    }
     else
     {
         document.addEventListener('DOMContentLoaded', this._onBoot, false);


### PR DESCRIPTION
A slightly obnoxious but necessary hack to prevent a race condition between the loading of Apache Cordova and Phaser itself. 

Without waiting for the 'deviceready' event, Phaser can often load first, preventing any console messages from appearing to the user. Because Cordova writes to the platform's console (via CordovaLog), it must first be loaded and signal its own 'deviceready' event before console or plugin usage can occur. Otherwise, all messages and functionality is ignored.
