### PR TITLE
swapped argument order of Rectangle.containsRect - fixes #1095

### DIFF
--- a/src/geom/Rectangle.js
+++ b/src/geom/Rectangle.js
@@ -206,7 +206,7 @@ Phaser.Rectangle.prototype = {
     */
     containsRect: function (b) {
 
-        return Phaser.Rectangle.containsRect(this, b);
+        return Phaser.Rectangle.containsRect(b, this);
 
     },
 


### PR DESCRIPTION
Swapped the arguments so that `rect1.contains(rect2)` actually tells you if `rect2` is inside `rect1`, rather than the other way around.
