### PR TITLE
Device detection of Node-Webkit

### DIFF
--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -45,6 +45,12 @@ Phaser.Device = function (game) {
     this.cordova = false;
     
     /**
+    * @property {boolean} node - Is the game running under Node.js?
+    * @default
+    */
+    this.node = false;
+    
+    /**
     * @property {boolean} nodeWebkit - Is the game running under Node-Webkit?
     * @default
     */
@@ -640,7 +646,16 @@ Phaser.Device.prototype = {
         
         if(typeof process !== "undefined" && typeof require !== "undefined")
         {
-            this.nodeWebkit = true;
+            this.node = true;
+        }
+        
+        if(this.node)
+        {
+            try {
+                this.nodeWebkit = (typeof require('nw.gui') !== "undefined");
+            } catch(error) {
+                this.nodeWebkit = false;
+            }
         }
         
         if (navigator['isCocoonJS'])


### PR DESCRIPTION
Because the user-agent string can be [easily changed](https://github.com/rogerwang/node-webkit/wiki/Manifest-format#user-agent), one of the few ways to detect Node-Webkit is to look for the 'process' object and require() function. If they exist, Node support was enabled and 'process.version' will have the version of Node.js used to create the project.

However, if Node is [disabled](https://github.com/rogerwang/node-webkit/wiki/Manifest-format#nodejs), the 'process' object won't exist at all and the project will be executed as if it was in a single instance of a browser anyway. 

So, basically, this is checking to see if Node.js is running within the same context as the game.
