### PR TITLE
Fixed Group.removeBetween's default endIndex bug

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -1632,7 +1632,7 @@ Phaser.Group.prototype.removeAll = function (destroy, silent) {
 */
 Phaser.Group.prototype.removeBetween = function (startIndex, endIndex, destroy, silent) {
 
-    if (typeof endIndex === 'undefined') { endIndex = this.children.length; }
+    if (typeof endIndex === 'undefined') { endIndex = this.children.length - 1; }
     if (typeof destroy === 'undefined') { destroy = false; }
     if (typeof silent === 'undefined') { silent = false; }
 


### PR DESCRIPTION
Fixed a simple out of bound error.

http://www.html5gamedevs.com/topic/8623-groupremovebetween-has-wrong-default-endindex/
