### PR TITLE
Detect CocoonJS.App

### DIFF
--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -672,7 +672,7 @@ Phaser.Device.prototype = {
         if(this.cocoonJS)
         {
             try {
-                this.cocoonJSApp = (typeof CocoonJS.App !== "undefined");
+                this.cocoonJSApp = (typeof CocoonJS !== "undefined");
             } catch(error) {
                 this.cocoonJSApp = false;
             }


### PR DESCRIPTION
There's a bit of a story behind this, but I'll try to keep it short.

While I've been working on a patch to detect Cordova's 'pause' and 'resume' events for Phaser.Stage's checkVisibility(), I came across this [thread](http://www.html5gamedevs.com/topic/8834-cocoonjs-pause-game-on-app-switch/) over on the forum. My hope, at the time, was that someone else would come along and write this patch and I could use their work to finish my own code. But, since that hasn't happened yet (and might never), I'm sending in this PR first for the check that establishes a 'game.device.cocoonJSApp' boolean that I plan to use later.

Basically, this sets up the check for the 'CocoonJS.App' global object for the later use of the two following functions:

```
CocoonJS.App.onSuspended.addEventListener();
CocoonJS.App.onActivated.addEventListener();
```

The next PR (the one that actually uses this check) may or may not come in the next few days depending on my own schedule. However, I wanted to send in the research and set it up so that if I don't get to it in time for Phaser 2.1, someone else could finish it.
