### PR TITLE
CocoonJS doesn't support mouse wheel

### DIFF
--- a/src/input/Mouse.js
+++ b/src/input/Mouse.js
@@ -222,13 +222,13 @@ Phaser.Mouse.prototype = {
         this.game.canvas.addEventListener('mousedown', this._onMouseDown, true);
         this.game.canvas.addEventListener('mousemove', this._onMouseMove, true);
         this.game.canvas.addEventListener('mouseup', this._onMouseUp, true);
-        this.game.canvas.addEventListener('mousewheel', this._onMouseWheel, true);
-        this.game.canvas.addEventListener('DOMMouseScroll', this._onMouseWheel, true);
 
         if (!this.game.device.cocoonJS)
         {
             this.game.canvas.addEventListener('mouseover', this._onMouseOver, true);
             this.game.canvas.addEventListener('mouseout', this._onMouseOut, true);
+            this.game.canvas.addEventListener('mousewheel', this._onMouseWheel, true);
+            this.game.canvas.addEventListener('DOMMouseScroll', this._onMouseWheel, true);
         }
 
     },


### PR DESCRIPTION
CocoonJS hasn't implemented the "DOMMouseScroll" and "mousewheel" events.

Without putting them under the device check, they throw warnings.
