### PR TITLE
CocoonJSApp 'onSuspended' and 'onActivated' events

### DIFF
--- a/src/core/Stage.js
+++ b/src/core/Stage.js
@@ -298,6 +298,18 @@ Phaser.Stage.prototype.checkVisibility = function () {
 
     window.onblur = this._onChange;
     window.onfocus = this._onChange;
+    
+    var _this = this;
+	
+    if(this.game.device.cocoonJSApp)
+    {
+        CocoonJS.App.onSuspended.addEventListener(function () {
+            Phaser.Stage.prototype.visibilityChange.call(_this, {type: "pause"});
+        });
+        CocoonJS.App.onActivated.addEventListener(function () {
+            Phaser.Stage.prototype.visibilityChange.call(_this, {type: "resume"});
+        });
+    }
 
 };
 
@@ -328,7 +340,7 @@ Phaser.Stage.prototype.visibilityChange = function (event) {
         return;
     }
 
-    if (document.hidden || document.mozHidden || document.msHidden || document.webkitHidden)
+    if (document.hidden || document.mozHidden || document.msHidden || document.webkitHidden || event.type === "pause")
     {
         this.game.gamePaused(event);
     }


### PR DESCRIPTION
This PR depends on [#1150](https://github.com/photonstorm/phaser/pull/1150)!

(I apologize for all the different pull requests in a short time period. I finally got some time to do some development tonight and have been making my way through many of my TODO items.)

This adds support for CocoonJS.App's 'onSuspended' and 'onActivated' events, making it so that the timers and sounds are stopped/started and muted/unmuted when the user swaps an app from the background to the fore or the reverse.

Because neither ['onActivated'](http://doc.ludei.com/2.0.2/CocoonJS_App/symbols/CocoonJS.App.html#.event:onActivated) nor ['onSuspended'](http://doc.ludei.com/2.0.2/CocoonJS_App/symbols/CocoonJS.App.html#.event:onSuspended) send an Event object themselves, this patch fakes sending an object by creating one during the function call and giving it a 'type' property for visibilityChange() to check against.
