### PR TITLE
Fixes #1153

### DIFF
--- a/build/phaser.d.ts
+++ b/build/phaser.d.ts
@@ -2614,7 +2614,7 @@ declare module Phaser {
         event: Object;
         game: Phaser.Game;
         lastChar: string;
-        lastKey: string;
+        lastKey: Phaser.Key;
         onDownCallback: Function;
         onPressCallback: Function;
         onUpCallback: Function;


### PR DESCRIPTION
Previously the `Phaser.Keyboard` module's `lastKey` property was of type
`string` in the TypeScript definition file, but it is actually a
`Phaser.Key` object, so `build/phaser.d.ts` has been updated to reflect
that.
### P.S.

Considering that you want pull requests against the `dev` branch, it'd be convenient to make that the default branch for this repo on GitHub.
