### PR TITLE
typescript definition updates

### DIFF
--- a/build/phaser.d.ts
+++ b/build/phaser.d.ts
@@ -3405,7 +3405,7 @@ declare module Phaser {
             createBody(x: number, y: number, mass: number, addToWorld?: boolean, options?: any, data?: any): Phaser.Physics.P2.Body;
             createCollisionGroup(group?: Phaser.Group): Phaser.Physics.P2.CollisionGroup;
             createCollisionGroup(group?: Phaser.Sprite): Phaser.Physics.P2.CollisionGroup;
-            createContactMaterial(materialA: Phaser.Physics.P2.Material, materialB: Phaser.Physics.P2.Material, options?: object): Phaser.Physics.P2.ContactMaterial;
+            createContactMaterial(materialA: Phaser.Physics.P2.Material, materialB: Phaser.Physics.P2.Material, options?: any): Phaser.Physics.P2.ContactMaterial;
             createDistanceConstraint(bodyA: any, bodyB: any, distance: number, maxForce?: number): Phaser.Physics.P2.DistanceConstraint;
             createGearConstraint(bodyA: any, bodyB: any, angle?: number, ratio?: number): Phaser.Physics.P2.GearConstraint;
             createLockConstraint(bodyA: any, bodyB: any, offset: Float32Array, angle?: number, maxForce?: number): Phaser.Physics.P2.LockConstraint;


### PR DESCRIPTION
The first commit updated the `ScaleManager.onResize` callback to be a interfaced function (was using `function` which is not a typescript type and caused an error).

The second commit changes all "Object" types into "any". Object is not any plain object with any properties, it is strictly a base Object instance with only the base properties. This causes errors when you try to pass objects that do not match that. Or, when the return type is Object and you try to access a property that exists, but typescript thinks it does not.

I'm considering making a generator that will use the doc comments to generate this file, because I am already tired of updating it :) What doc syntax do you conform to?
