### PR TITLE
Redundant "if" in StateManager.preUpdate method

### DIFF
--- a/src/core/StateManager.js
+++ b/src/core/StateManager.js
@@ -337,10 +337,7 @@ Phaser.StateManager.prototype = {
                 this.loadComplete();
             }
 
-            if (this.current === this._pendingState)
-            {
-                this._pendingState = null;
-            }
+            this._pendingState = null;
         }
 
     },


### PR DESCRIPTION
The `current` property will always be identical to `_pendingState` because of the this.setCurrentState(this._pendingState) call.
