### PR TITLE
Fixes issue #1212 (again), this time properly built and tested

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1257,7 +1257,7 @@ Phaser.Loader.prototype = {
                             };
                             file.data.preload = 'auto';
                             file.data.src = this.baseURL + file.url;
-                            file.data.addEventListener('canplaythrough', Phaser.GAMES[this.game.id].load.fileComplete(this._fileIndex), false);
+                            file.data.addEventListener('canplaythrough', function () { Phaser.GAMES[_this.game.id].load.fileComplete(_this._fileIndex); }, false);
                             file.data.load();
                         }
                     }


### PR DESCRIPTION
This stops Phaser progressing with file loads when an audio file file failed in IE.

The problem was that it was calling fileComplete everytime instead of
setting it as a callback.
