### PR TITLE
Add PLUS and MINUS to list of keyboard keys

### DIFF
--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -656,3 +656,5 @@ Phaser.Keyboard.INSERT = 45;
 Phaser.Keyboard.DELETE = 46;
 Phaser.Keyboard.HELP = 47;
 Phaser.Keyboard.NUM_LOCK = 144;
+Phaser.Keyboard.PLUS = 43;
+Phaser.Keyboard.MINUS = 45;


### PR DESCRIPTION
This commit adds the plus and minus to the list of all the keyboard keys that are more easy accessible.

Please note that this is NOT tested with the plus and minus that exists with the numpad keys, if someone could me ensure that this is correct, I'll be forever grateful.

Thanks for an awesome framework!
