### PR TITLE
Fix: Uncaught TypeError: Cannot read property '2' of undefined phaser.js...

### DIFF
--- a/build/phaser.js
+++ b/build/phaser.js
@@ -62446,7 +62446,7 @@ Phaser.TilemapLayer.prototype.render = function () {
                     tile = this._column[x];
                 }
 
-                if (tile && tile.index > -1)
+                if (tile && tile.index > -1 && this.map.tiles[tile.index])
                 {
                     set = this.map.tilesets[this.map.tiles[tile.index][2]];
 


### PR DESCRIPTION
...:63200

This is a bug which causes my tile level loading to fail unpredictably.
It only happens sometimes after importing a level from Tiled.

We need to continue to next loop iteration in the case where
map.tiles[tile.index] is undefined.

There was another line I just found which needs to make the same kind of check, see diff.
