### PR TITLE
crashfix: changed function call wordWrap() to runWordWrap()

### DIFF
--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -359,7 +359,7 @@ Phaser.Text.prototype.updateText = function () {
 
     if (this.style.wordWrap)
     {
-        outputText = this.wordWrap(this.text);
+        outputText = this.runWordWrap(this.text);
     }
 
     //split text into lines


### PR DESCRIPTION
Looks like an oversight in the very recent 2.1.3 release
