### PR TITLE
Code/context fix for 1248

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1299,7 +1299,7 @@ Phaser.Loader.prototype = {
                     //  Note: The xdr.send() call is wrapped in a timeout to prevent an issue with the interface where some requests are lost
                     //  if multiple XDomainRequests are being sent at the same time.
                     setTimeout(function () {
-                        this._ajax.send();
+                        _this._ajax.send();
                     }, 0);
                 }
                 else


### PR DESCRIPTION
See https://github.com/photonstorm/phaser/issues/1248
If this actually makes the code "work" is another issue; but it will correct the reported context error.
- Fixes invalid usage of `this` in a callback with local variable `_this` which was already used in other contexts.
