### PR TITLE
Texture width is recalculated larger on subsequent call to updateText() ...

### DIFF
--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -379,7 +379,7 @@ Phaser.Text.prototype.updateText = function () {
 
     var width = maxLineWidth + this.style.strokeThickness;
 
-    this.canvas.width = (width + this.context.lineWidth) * this.resolution;
+    this.canvas.width = width * this.resolution;
     
     //calculate text height
     var lineHeight = fontProperties.fontSize + this.style.strokeThickness;


### PR DESCRIPTION
...when text has a stroke thickness > 1

In function override Phaser.Text.prototype.updateText(), don't include this.context.lineWidth in width calculation as it's already incorporated by this.style.strokeThickness.

The problem can be demonstrated as follows:
1. Go to Phaser text stroke example with Phaser V2.1.2 (http://examples.phaser.io/_site/view_full.html?d=text&f=text%20stroke.js&t=text%20stroke&phaser_version=v2.1.2&)
2. Open up browser dev console and type "text.updateText()" watch the text as you hit return
3. Result, nothing, as expected
4. Now go to same example with Phaser V2.1.3 (http://examples.phaser.io/_site/view_full.html?d=text&f=text%20stroke.js&t=text%20stroke&phaser_version=v2.1.3&)
5. Repeat step 2
6. Result, the text jumps left a few pixels
