### PR TITLE
Fix for Key.enabled issue #1190

### DIFF
--- a/src/input/Key.js
+++ b/src/input/Key.js
@@ -22,6 +22,7 @@ Phaser.Key = function (game, keycode) {
     /**
     * The enabled state of the key - see `enabled`.
     * @property {boolean} _enabled
+    * @private
     */
     this._enabled = true;
 


### PR DESCRIPTION
For https://github.com/photonstorm/phaser/issues/1190 

I was just going to update the documentation, but after looking at the code it appeared that the "correct" work-about is actually the following, which seems like enough of a magical incantation to handled.

``` javascript
key.reset(false);
key.enabled = false;
```

If `reset` is called without any parameters it will be "hard" and eliminate any callbacks; and the key will always be re-enabled by `reset`.
