### PR TITLE
Groups always had zero z index 

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -39,17 +39,21 @@ Phaser.Group = function (game, parent, name, addToStage, enableBody, physicsBody
     */
     this.name = name || 'group';
 
+    /**
+    * @property {number} z - The z-depth value of this object within its Group (remember the World is a Group as well). No two objects in a Group can have the same z value.
+    */
+    this.z = 0;
+
     PIXI.DisplayObjectContainer.call(this);
 
-    if (addToStage)
-    {
+    if (addToStage) {
         this.game.stage.addChild(this);
+        this.z = this.game.stage.children.length;
     }
-    else
-    {
-        if (parent)
-        {
+    else {
+        if (parent) {
             parent.addChild(this);
+            this.z = parent.children.length;
         }
     }
 


### PR DESCRIPTION
Newly added groups were always initialising their z index to zero, instead of their position in the parent child list.
