### PR TITLE
Make cache getters return null on missing entry

### DIFF
--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -615,6 +615,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getCanvas: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -635,6 +636,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getBitmapData: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -655,6 +657,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getBitmapFont: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -952,6 +955,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getTilemapData: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -1076,6 +1080,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getTexture: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -1096,6 +1101,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getSound: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -1116,6 +1122,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getSoundData: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -1183,6 +1190,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getText: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -1203,6 +1211,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getJSON: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -1223,6 +1232,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getXML: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -1243,6 +1253,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getBinary: Invalid key: "' + key + '"');
+            return null;
         }
 
     },
@@ -1263,6 +1274,7 @@ Phaser.Cache.prototype = {
         else
         {
             console.warn('Phaser.Cache.getUrl: Invalid url: "' + url  + '"');
+            return null;
         }
 
     },


### PR DESCRIPTION
Some getters in Game.Cache weren't returning anything on a missing entry, even if the function documentation stated the function returns null on a missing entry. 

This fixes the issue by returning null when the requested cache entry isn't found.
