### PR TITLE
ScaleManger - better FS init, documentation

### DIFF
--- a/docs/scripts/toc.js
+++ b/docs/scripts/toc.js
@@ -201,7 +201,15 @@ jQuery.fn.toc.defaults = {
     return $heading.text();
   },
   itemClass: function(i, heading, $heading, prefix) {
-    return prefix + '-' + $heading[0].tagName.toLowerCase();
+    // Remove all classes not starting like 'toc-'
+    var tocClasses = ($heading.attr('class') || '')
+      .replace(/\b\S+/gi, function (m) {
+        return m.indexOf("toc-") === 0 ? m : '';
+      });
+
+    var itemClass = prefix + '-' + $heading[0].tagName.toLowerCase();
+
+    return tocClasses + ' ' + itemClass;
   }
 
 };


### PR DESCRIPTION
- Added `onFullScreenInit` signal which is the correct place for a client
  to alter the FS target element, such as to set a background color or add
  a CSS class.
- Increased documentation overview and specificity including expected
  Parent behavior, sizing calculations, and when `refresh` may be required.
- Grouped documentation for scale modes (in 'scaleMode')
- Separated out internal/deprecated `setScreenSize` method from
  `updateLayout`.

There are no known breaking changes.
