### PR TITLE
ScaleManager + DOM - window constraint updates

### DIFF
--- a/src/system/DOM.js
+++ b/src/system/DOM.js
@@ -309,9 +309,6 @@ Phaser.Device.whenReady(function (device) {
         get: scrollY
     });
 
-    // For Phaser.DOM.visualBounds
-    // Ref. http://quirksmode.org/mobile/tableViewport.html
-
     Object.defineProperty(Phaser.DOM.visualBounds, "x", {
         get: scrollX
     });
@@ -320,23 +317,46 @@ Phaser.Device.whenReady(function (device) {
         get: scrollY
     });
 
+    Object.defineProperty(Phaser.DOM.layoutBounds, "x", {
+        value: 0
+    });
+
+    Object.defineProperty(Phaser.DOM.layoutBounds, "y", {
+        value: 0
+    });
+
+    var treatAsDesktop = device.desktop &&
+        (document.documentElement.clientWidth <= window.innerWidth) &&
+        (document.documentElement.clientHeight <= window.innerHeight);
+
     // Desktop browsers align the layout viewport with the visual viewport.
     // This differs from mobile browsers with their zooming design.
-    if (device.desktop &&
-        (document.documentElement.clientWidth <= window.innerWidth) &&
-        (document.documentElement.clientHeight <= window.innerHeight))
+    // Ref. http://quirksmode.org/mobile/tableViewport.html  
+    if (treatAsDesktop)
     {
 
+        var clientWidth = function () {
+            return document.documentElement.clientWidth;
+        };
+        var clientHeight = function () {
+            return document.documentElement.clientHeight;
+        };
+
+        // Interested in area sans-scrollbar
         Object.defineProperty(Phaser.DOM.visualBounds, "width", {
-            get: function () {
-                return document.documentElement.clientWidth;
-            }
+            get: clientWidth
         });
 
         Object.defineProperty(Phaser.DOM.visualBounds, "height", {
-            get: function () {
-                return document.documentElement.clientHeight;
-            }
+            get: clientHeight
+        });
+
+        Object.defineProperty(Phaser.DOM.layoutBounds, "width", {
+            get: clientWidth
+        });
+
+        Object.defineProperty(Phaser.DOM.layoutBounds, "height", {
+            get: clientHeight
         });
 
     } else {
@@ -353,39 +373,29 @@ Phaser.Device.whenReady(function (device) {
             }
         });
 
+        Object.defineProperty(Phaser.DOM.layoutBounds, "width", {
+
+            get: function () {
+                var a = document.documentElement.clientWidth;
+                var b = window.innerWidth;
+
+                return a < b ? b : a; // max
+            }
+
+        });
+
+        Object.defineProperty(Phaser.DOM.layoutBounds, "height", {
+
+            get: function () {
+                var a = document.documentElement.clientHeight;
+                var b = window.innerHeight;
+
+                return a < b ? b : a; // max
+            }
+
+        });
+
     }
-
-    // For Phaser.DOM.layoutBounds
-
-    Object.defineProperty(Phaser.DOM.layoutBounds, "x", {
-        value: 0
-    });
-
-    Object.defineProperty(Phaser.DOM.layoutBounds, "y", {
-        value: 0
-    });
-
-    Object.defineProperty(Phaser.DOM.layoutBounds, "width", {
-
-        get: function () {
-            var a = document.documentElement.clientWidth;
-            var b = window.innerWidth;
-
-            return a < b ? b : a; // max
-        }
-
-    });
-
-    Object.defineProperty(Phaser.DOM.layoutBounds, "height", {
-
-        get: function () {
-            var a = document.documentElement.clientHeight;
-            var b = window.innerHeight;
-
-            return a < b ? b : a; // max
-        }
-
-    });
 
     // For Phaser.DOM.documentBounds
     // Ref. http://www.quirksmode.org/mobile/tableViewport_desktop.html


### PR DESCRIPTION
ScaleManager.windowContraints now allows specifing 'visual' or 'layout' as
the constraint. Using the 'layout' constraint should prevent a mobile
device from trying to resize the game when zooming.

Including the the new changes the defaults have been changed to

   windowContraints = { right: 'layout', bottom: '' }

This changes the current scaling behavior as seen in "Game Scaling" (as it
will only scale for the right edge) but also prevents such scaling from
going wonkers in some mobile environtments like the newer Android browser.
(Automatic scroll-to-top, albeit configurable, enabled for non-desktop by
default is not a fun situation here.)

To obtain the current semantics on a desktop the bottom should be changed
to 'layout'; although this will result in different behavior depending on
mobile device. To make the sizing also follow mobile zooming they should
be changed to 'visual'.

Also added temp Rectangle re-used for various internal calculations.

---

Phaser.DOM now also special-cases desktops to align the layout bounds
correctly (this may disagree with CSS breakpoints but it aligns the with
actual CSS width), without applying a window height/width expansion as
required on mobile browsers.

(And the jshint error isn't mine..)
