### PR TITLE
Keyboard.js does not reflect Phaser.Key changes

### DIFF
--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -465,7 +465,7 @@ Phaser.Keyboard.prototype = {
 
         if (this._keys[keycode])
         {
-            return this._keys[keycode].justPressed(duration);
+            return this._keys[keycode].downDuration(duration);
         }
         else
         {
@@ -488,7 +488,7 @@ Phaser.Keyboard.prototype = {
 
         if (this._keys[keycode])
         {
-            return this._keys[keycode].justReleased(duration);
+            return this._keys[keycode].upDuration(duration);
         }
         else
         {


### PR DESCRIPTION
Calling justPressed or justReleased on Phaser.Keyboard throws an exception. Changed to reflect new method names in Phaser.Key

I imagine you'd want these methods renamed as well, but it appears to be called by a few other classes and I didn't want a huge pull-request.
