### PR TITLE
Loader - image loading can bypass 'onload'

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1235,16 +1235,18 @@ Phaser.Loader.prototype = {
                 file.data.onload = function () {
                     file.data.onload = null;
                     file.data.onerror = null;
-                    if (file.loaded) return;
-
-                    _this.fileComplete(_this._fileIndex);
+                    if (!file.loaded)
+                    {
+                        _this.fileComplete(_this._fileIndex);
+                    }
                 };
                 file.data.onerror = function () {
                     file.data.onload = null;
                     file.data.onerror = null;
-                    if (file.loaded) return;
-
-                    _this.fileError(_this._fileIndex);
+                    if (!file.loaded)
+                    {
+                        _this.fileError(_this._fileIndex);
+                    }
                 };
 
                 if (this.crossOrigin)


### PR DESCRIPTION
An image will check the 'complete' as well as width/height when it is
created - this check will be true for cached resources in modern browser
and bypassing the intermediate 'onload' event allows less latency when
loading cached image resources. This results in a tangible difference; it
might be possible to apply a similar bypass for audio tags.

This should not cause any adverse behavior and all the normal signal
dispatching occurs - this is the same check PIXI does for loading a
BaseTexture from an image, only this implementation doesn't suffer from
PIXI's race condition..

The onload/onerror events are also pruned and guarded better.
