### PR TITLE
Group - 'iterate' documentation and guard

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -6,15 +6,15 @@
 
 /**
 * A Group is a container for display objects that allows for fast pooling and object recycling.
+*
 * Groups can be nested within other Groups and have their own local transforms.
 * 
 * @class Phaser.Group
 * @extends PIXI.DisplayObjectContainer
-* @constructor
 * @param {Phaser.Game} game - A reference to the currently running game.
-* @param {Phaser.Group|Phaser.Sprite|null} parent - The parent Group, DisplayObject or DisplayObjectContainer that this Group will be added to. If `undefined` it will use game.world. If null it won't be added to anything.
-* @param {string} [name=group] - A name for this Group. Not used internally but useful for debugging.
-* @param {boolean} [addToStage=false] - If set to true this Group will be added directly to the Game.Stage instead of Game.World.
+* @param {Phaser.Group|Phaser.Sprite|null} parent - The parent Group, DisplayObject or DisplayObjectContainer that this group will be added to. If `undefined` it will use game.world. If null it won't be added to anything.
+* @param {string} [name=group] - A name for this group. Not used internally but useful for debugging.
+* @param {boolean} [addToStage=false] - If set to true this group will be added directly to the Game.Stage instead of Game.World.
 * @param {boolean} [enableBody=false] - If true all Sprites created with `Group.create` or `Group.createMulitple` will have a physics body created on them. Change the body type with physicsBodyType.
 * @param {number} [physicsBodyType=0] - If enableBody is true this is the type of physics body that is created on new Sprites. Phaser.Physics.ARCADE, Phaser.Physics.P2, Phaser.Physics.NINJA, etc.
 */
@@ -25,7 +25,9 @@ Phaser.Group = function (game, parent, name, addToStage, enableBody, physicsBody
     if (typeof physicsBodyType === 'undefined') { physicsBodyType = Phaser.Physics.ARCADE; }
 
     /**
-    * @property {Phaser.Game} game - A reference to the currently running Game.
+    * A reference to the currently running Game.
+    * @property {Phaser.Game} game
+    * @protected
     */
     this.game = game;
 
@@ -35,12 +37,15 @@ Phaser.Group = function (game, parent, name, addToStage, enableBody, physicsBody
     }
 
     /**
-    * @property {string} name - A name for this Group. Not used internally but useful for debugging.
+    * A name for this group. Not used internally but useful for debugging.
+    * @property {string} name
     */
     this.name = name || 'group';
 
     /**
-    * @property {number} z - The z-depth value of this object within its Group (remember the World is a Group as well). No two objects in a Group can have the same z value.
+    * The z-depth value of this object within its parent container/Group - the World is a Group as well.
+    * This value must be unique for each child in a Group.
+    * @property {number} z
     */
     this.z = 0;
 
@@ -58,77 +63,97 @@ Phaser.Group = function (game, parent, name, addToStage, enableBody, physicsBody
     }
 
     /**
-    * @property {number} type - Internal Phaser Type value.
+    * Internal Phaser Type value.
+    * @property {number} type
     * @protected
     */
     this.type = Phaser.GROUP;
 
     /**
-    * @property {boolean} alive - The alive property is useful for Groups that are children of other Groups and need to be included/excluded in checks like forEachAlive.
+    * The alive property is useful for Groups that are children of other Groups and need to be included/excluded in checks like forEachAlive.
+    * @property {boolean} alive
     * @default
     */
     this.alive = true;
 
     /**
-    * @property {boolean} exists - If exists is true the Group is updated, otherwise it is skipped.
+    * If exists is true the group is updated, otherwise it is skipped.
+    * @property {boolean} exists
     * @default
     */
     this.exists = true;
 
     /**
-    * @property {boolean} ignoreDestroy - A Group with `ignoreDestroy` set to `true` ignores all calls to its `destroy` method.
+    * A group with `ignoreDestroy` set to `true` ignores all calls to its `destroy` method.
+    * @property {boolean} ignoreDestroy
     * @default
     */
     this.ignoreDestroy = false;
 
     /**
-    * The type of objects that will be created when you use Group.create or Group.createMultiple. Defaults to Phaser.Sprite.
-    * When a new object is created it is passed the following parameters to its constructor: game, x, y, key, frame.
+    * The type of objects that will be created when using {@link Phaser.Group#create create} or {@link Phaser.Group#createMultiple createMultiple}.
+    *
+    * Any object may be used but it should extend either Sprite or Image and accept the same constructor arguments.
+    * When a new object is created it is passed the following parameters to its constructor: `(game, x, y, key, frame)`.
+    *
     * @property {object} classType
-    * @default
+    * @default {@link Phaser.Sprite}
     */
     this.classType = Phaser.Sprite;
 
     /**
-    * @property {Phaser.Point} scale - The scale of the Group container.
+    * The scale of the group container.
+    *
+    * @property {Phaser.Point} scale
     */
     this.scale = new Phaser.Point(1, 1);
 
     /**
-    * The cursor is a simple way to iterate through the objects in a Group using the Group.next and Group.previous functions.
-    * The cursor is set to the first child added to the Group and doesn't change unless you call next, previous or set it directly with Group.cursor.
-    * @property {any} cursor - The current display object that the Group cursor is pointing to.
+    * The current display object that the group cursor is pointing to, if any.
+    *
+    * The cursor is a way to iterate through the children in a Group using the `next` and `previous` functions.
+    * The cursor is set to the first child added to the group and doesn't change unless calling next, previous, or set it directly with Group.cursor.
+    * @property {?any} cursor
     */
     this.cursor = null;
 
     /**
-    * @property {Phaser.Point} cameraOffset - If this object is fixedToCamera then this stores the x/y offset that its drawn at, from the top-left of the camera view.
+    * If this object is `fixedToCamera` then this stores the x/y offset that its drawn at, from the top-left of the camera view.
+    * @property {Phaser.Point} cameraOffset
     */
     this.cameraOffset = new Phaser.Point();
 
     /**
-    * @property {boolean} enableBody - If true all Sprites created by, or added to this Group, will have a physics body enabled on them. Change the body type with `Group.physicsBodyType`.
+    * If true all Sprites created by, or added to this group, will have a physics body enabled on them.
+    * Change the body type with `Group.physicsBodyType`.
+    * @property {boolean} enableBody
     * @default
     */
     this.enableBody = enableBody;
 
     /**
-    * @property {boolean} enableBodyDebug - If true when a physics body is created (via Group.enableBody) it will create a physics debug object as well. Only works for P2 bodies.
+    * If true when a physics body is created (via `enableBody`) it will create a physics debug object as well.
+    * This only works for P2 bodies.
+    * @property {boolean} enableBodyDebug
     */
     this.enableBodyDebug = false;
 
     /**
-    * @property {number} physicsBodyType - If Group.enableBody is true this is the type of physics body that is created on new Sprites. Phaser.Physics.ARCADE, Phaser.Physics.P2, Phaser.Physics.NINJA, etc.
+    * If `enableBody` is true this is the type of physics body that is created on new Sprites.
+    * The valid values are Phaser.Physics.ARCADE, Phaser.Physics.P2, Phaser.Physics.NINJA, etc.
+    * @property {number} physicsBodyType
     */
     this.physicsBodyType = physicsBodyType;
 
     /**
-    * @property {Phaser.Signal} onDestroy - This signal is dispatched if this Group is destroyed.
+    * This signal is dispatched when the group is destroyed.
+    * @property {Phaser.Signal} onDestroy
     */
     this.onDestroy = new Phaser.Signal();
 
     /**
-    * @property {string} _sortProperty - The property on which children are sorted.
+    * The property on which children are sorted.
+    * @property {string} _sortProperty
     * @private
     */
     this._sortProperty = 'z';
@@ -156,46 +181,53 @@ Phaser.Group.prototype = Object.create(PIXI.DisplayObjectContainer.prototype);
 Phaser.Group.prototype.constructor = Phaser.Group;
 
 /**
+* A returnType value, as specified in {@link Phaser.Group#iterate iterate} eg.
 * @constant
-* @type {number}
+* @type {integer}
 */
 Phaser.Group.RETURN_NONE = 0;
 
 /**
+* A returnType value, as specified in {@link Phaser.Group#iterate iterate} eg.
 * @constant
-* @type {number}
+* @type {integer}
 */
 Phaser.Group.RETURN_TOTAL = 1;
 
 /**
+* A returnType value, as specified in {@link Phaser.Group#iterate iterate} eg.
 * @constant
-* @type {number}
+* @type {integer}
 */
 Phaser.Group.RETURN_CHILD = 2;
 
 /**
+* A sort ordering value, as specified in {@link Phaser.Group#sort sort} eg.
 * @constant
-* @type {number}
+* @type {integer}
 */
 Phaser.Group.SORT_ASCENDING = -1;
 
 /**
+* A sort ordering value, as specified in {@link Phaser.Group#sort sort} eg.
 * @constant
-* @type {number}
+* @type {integer}
 */
 Phaser.Group.SORT_DESCENDING = 1;
 
 /**
-* Adds an existing object to this Group. The object can be an instance of Phaser.Sprite, Phaser.Button or any other display object.
-* The child is automatically added to the top of the Group, so renders on-top of everything else within the Group. If you need to control
-* that then see the addAt method.
+* Adds an existing object as the top child in this group.
 *
-* @see Phaser.Group#create
-* @see Phaser.Group#addAt
+* The object can be an instance of Phaser.Sprite, Phaser.Button, or any other display object.
+*
+* The child is automatically added to the top of the group and is displayed on top of every previous child.
+* Use {@link Phaser.Group#addAt addAt} to control where a child is added.
+*
 * @method Phaser.Group#add
-* @param {*} child - An instance of Phaser.Sprite, Phaser.Button or any other display object.
+* @param {any} child - An instance of Phaser.Sprite, Phaser.Button or any other display object.
 * @param {boolean} [silent=false] - If the silent parameter is `true` the child will not dispatch the onAddedToGroup event.
-* @return {*} The child that was added to the Group.
+* @return {any} The child that was added to the group.
+* @see {@link Phaser.Group#create}, {@link Phaser.Group#addAt}
 */
 Phaser.Group.prototype.add = function (child, silent) {
 
@@ -228,14 +260,17 @@ Phaser.Group.prototype.add = function (child, silent) {
 };
 
 /**
-* Adds an array existing objects to this Group. The objects can be instances of Phaser.Sprite, Phaser.Button or any other display object.
-* The children are automatically added to the top of the Group, so render on-top of everything else within the Group.
+* Adds an array existing objects to this group.
+*
+* The objects can be instances of Phaser.Sprite, Phaser.Button, or any other display object.
+* The children are automatically added to the top of the group, so render on-top of everything else within the group.
+*
 * TODO: Add ability to pass the children as parameters rather than having to be an array.
 *
 * @method Phaser.Group#addMultiple
-* @param {array} children - An array containing instances of Phaser.Sprite, Phaser.Button or any other display object.
+* @param {array} children - An array containing instances of Phaser.Sprite, Phaser.Button, or any other display object.
 * @param {boolean} [silent=false] - If the silent parameter is `true` the children will not dispatch the onAddedToGroup event.
-* @return {*} The array of children that were added to the Group.
+* @return {any} The array of children that were added to the group.
 */
 Phaser.Group.prototype.addMultiple = function (children, silent) {
 
@@ -252,14 +287,16 @@ Phaser.Group.prototype.addMultiple = function (children, silent) {
 };
 
 /**
-* Adds an existing object to this Group. The object can be an instance of Phaser.Sprite, Phaser.Button or any other display object.
-* The child is added to the Group at the location specified by the index value, this allows you to control child ordering.
+* Adds an existing object to this group.
+*
+* The object can be an instance of Phaser.Sprite, Phaser.Button, or any other display object.
+* The child is added to the group at the location specified by the index value, this allows you to control child ordering.
 *
 * @method Phaser.Group#addAt
-* @param {*} child - An instance of Phaser.Sprite, Phaser.Button or any other display object..
-* @param {number} index - The index within the Group to insert the child to.
+* @param {any} child - An instance of Phaser.Sprite, Phaser.Button, or any other display object.
+* @param {number} [index=0] - The index within the group to insert the child to.
 * @param {boolean} [silent=false] - If the silent parameter is `true` the child will not dispatch the onAddedToGroup event.
-* @return {*} The child that was added to the Group.
+* @return {any} The child that was added to the group.
 */
 Phaser.Group.prototype.addAt = function (child, index, silent) {
 
@@ -292,11 +329,11 @@ Phaser.Group.prototype.addAt = function (child, index, silent) {
 };
 
 /**
-* Returns the child found at the given index within this Group.
+* Returns the child found at the given index within this group.
 *
 * @method Phaser.Group#getAt
 * @param {number} index - The index to return the child from.
-* @return {*} The child that was found at the given index. If the index was out of bounds then this will return -1.
+* @return {any} The child that was found at the given index, or -1 for an invalid index.
 */
 Phaser.Group.prototype.getAt = function (index) {
 
@@ -312,12 +349,13 @@ Phaser.Group.prototype.getAt = function (index) {
 };
 
 /**
-* Automatically creates a new Phaser.Sprite object and adds it to the top of this Group.
-* You can change Group.classType to any object and this call will create an object of that type instead, but it should extend either Sprite or Image.
+* Creates a new Phaser.Sprite object and adds it to the top of this group.
+*
+* Use {@link Phaser.Group#classType classType} to change the type of object creaded.
 *
 * @method Phaser.Group#create
-* @param {number} x - The x coordinate to display the newly created Sprite at. The value is in relation to the Group.x point.
-* @param {number} y - The y coordinate to display the newly created Sprite at. The value is in relation to the Group.y point.
+* @param {number} x - The x coordinate to display the newly created Sprite at. The value is in relation to the group.x point.
+* @param {number} y - The y coordinate to display the newly created Sprite at. The value is in relation to the group.y point.
 * @param {string} key - The Game.cache key of the image that this Sprite will use.
 * @param {number|string} [frame] - If the Sprite image contains multiple frames you can specify which one to use here.
 * @param {boolean} [exists=true] - The default exists state of the Sprite.
@@ -357,10 +395,12 @@ Phaser.Group.prototype.create = function (x, y, key, frame, exists) {
 };
 
 /**
-* Automatically creates multiple Phaser.Sprite objects and adds them to the top of this Group.
-* Useful if you need to quickly generate a pool of identical sprites, such as bullets. By default the sprites will be set to not exist
-* and will be positioned at 0, 0 (relative to the Group.x/y)
-* You can change Group.classType to any object and this call will create an object of that type instead, but it should extend either Sprite or Image.
+* Creates multiple Phaser.Sprite objects and adds them to the top of this group.
+*
+* Useful if you need to quickly generate a pool of identical sprites, such as bullets.
+*
+* By default the sprites will be set to not exist and will be positioned at 0, 0 (relative to the group.x/y).
+* Use {@link Phaser.Group#classType classType} to change the type of object creaded.
 *
 * @method Phaser.Group#createMultiple
 * @param {number} quantity - The number of Sprites to create.
@@ -382,6 +422,8 @@ Phaser.Group.prototype.createMultiple = function (quantity, key, frame, exists) 
 /**
 * Internal method that re-applies all of the childrens Z values.
 *
+* This must be called whenever children ordering is altered so that their `z` indices are correctly updated.
+*
 * @method Phaser.Group#updateZ
 * @protected
 */
@@ -397,11 +439,13 @@ Phaser.Group.prototype.updateZ = function () {
 };
 
 /**
-* Sets the Group cursor to the first object in the Group. If the optional index parameter is given it sets the cursor to the object at that index instead.
+* Sets the group cursor to the first child in the group.
+*
+* If the optional index parameter is given it sets the cursor to the object at that index instead.
 *
 * @method Phaser.Group#resetCursor
 * @param {number} [index=0] - Set the cursor to point to a specific index.
-* @return {*} The child the cursor now points to.
+* @return {any} The child the cursor now points to.
 */
 Phaser.Group.prototype.resetCursor = function (index) {
 
@@ -422,10 +466,12 @@ Phaser.Group.prototype.resetCursor = function (index) {
 };
 
 /**
-* Advances the Group cursor to the next object in the Group. If it's at the end of the Group it wraps around to the first object.
+* Advances the group cursor to the next (higher) object in the group.
+*
+* If the cursor is at the end of the group (top child) it is moved the start of the group (bottom child).
 *
 * @method Phaser.Group#next
-* @return {*} The child the cursor now points to.
+* @return {any} The child the cursor now points to.
 */
 Phaser.Group.prototype.next = function () {
 
@@ -449,10 +495,12 @@ Phaser.Group.prototype.next = function () {
 };
 
 /**
-* Moves the Group cursor to the previous object in the Group. If it's at the start of the Group it wraps around to the last object.
+* Moves the group cursor to the previous (lower) child in the group.
+*
+* If the cursor is at the start of the group (bottom child) it is moved to the end (top child).
 *
 * @method Phaser.Group#previous
-* @return {*} The child the cursor now points to.
+* @return {any} The child the cursor now points to.
 */
 Phaser.Group.prototype.previous = function () {
 
@@ -476,12 +524,13 @@ Phaser.Group.prototype.previous = function () {
 };
 
 /**
-* Swaps the position of two children in this Group. Both children must be in this Group.
-* You cannot swap a child with itself, or swap un-parented children.
+* Swaps the position of two children in this group.
+*
+* Both children must be in this group, a child cannot be swapped with itself, and unparented children cannot be swapped.
 *
 * @method Phaser.Group#swap
-* @param {*} child1 - The first child to swap.
-* @param {*} child2 - The second child to swap.
+* @param {any} child1 - The first child to swap.
+* @param {any} child2 - The second child to swap.
 */
 Phaser.Group.prototype.swap = function (child1, child2) {
 
@@ -491,11 +540,11 @@ Phaser.Group.prototype.swap = function (child1, child2) {
 };
 
 /**
-* Brings the given child to the top of this Group so it renders above all other children.
+* Brings the given child to the top of this group so it renders above all other children.
 *
 * @method Phaser.Group#bringToTop
-* @param {*} child - The child to bring to the top of this Group.
-* @return {*} The child that was moved.
+* @param {any} child - The child to bring to the top of this group.
+* @return {any} The child that was moved.
 */
 Phaser.Group.prototype.bringToTop = function (child) {
 
@@ -510,11 +559,11 @@ Phaser.Group.prototype.bringToTop = function (child) {
 };
 
 /**
-* Sends the given child to the bottom of this Group so it renders below all other children.
+* Sends the given child to the bottom of this group so it renders below all other children.
 *
 * @method Phaser.Group#sendToBack
-* @param {*} child - The child to send to the bottom of this Group.
-* @return {*} The child that was moved.
+* @param {any} child - The child to send to the bottom of this group.
+* @return {any} The child that was moved.
 */
 Phaser.Group.prototype.sendToBack = function (child) {
 
@@ -529,11 +578,11 @@ Phaser.Group.prototype.sendToBack = function (child) {
 };
 
 /**
-* Moves the given child up one place in this Group unless it's already at the top.
+* Moves the given child up one place in this group unless it's already at the top.
 *
 * @method Phaser.Group#moveUp
-* @param {*} child - The child to move up in the Group.
-* @return {*} The child that was moved.
+* @param {any} child - The child to move up in the group.
+* @return {any} The child that was moved.
 */
 Phaser.Group.prototype.moveUp = function (child) {
 
@@ -553,11 +602,11 @@ Phaser.Group.prototype.moveUp = function (child) {
 };
 
 /**
-* Moves the given child down one place in this Group unless it's already at the top.
+* Moves the given child down one place in this group unless it's already at the bottom.
 *
 * @method Phaser.Group#moveDown
-* @param {*} child - The child to move down in the Group.
-* @return {*} The child that was moved.
+* @param {any} child - The child to move down in the group.
+* @return {any} The child that was moved.
 */
 Phaser.Group.prototype.moveDown = function (child) {
 
@@ -577,10 +626,10 @@ Phaser.Group.prototype.moveDown = function (child) {
 };
 
 /**
-* Positions the child found at the given index within this Group to the given x and y coordinates.
+* Positions the child found at the given index within this group to the given x and y coordinates.
 *
 * @method Phaser.Group#xy
-* @param {number} index - The index of the child in the Group to set the position of.
+* @param {number} index - The index of the child in the group to set the position of.
 * @param {number} x - The new x position of the child.
 * @param {number} y - The new y position of the child.
 */
@@ -599,7 +648,9 @@ Phaser.Group.prototype.xy = function (index, x, y) {
 };
 
 /**
-* Reverses all children in this Group. Note that this does not propagate, only direct children are re-ordered.
+* Reverses all children in this group.
+*
+* This operaation applies only to immediate children and does not propagate to subgroups.
 *
 * @method Phaser.Group#reverse
 */
@@ -611,11 +662,11 @@ Phaser.Group.prototype.reverse = function () {
 };
 
 /**
-* Get the index position of the given child in this Group. This should always match the childs z property.
+* Get the index position of the given child in this group, which should match the child's `z` property.
 *
 * @method Phaser.Group#getIndex
-* @param {*} child - The child to get the index for.
-* @return {number} The index of the child or -1 if it's not a member of this Group.
+* @param {any} child - The child to get the index for.
+* @return {number} The index of the child or -1 if it's not a member of this group.
 */
 Phaser.Group.prototype.getIndex = function (child) {
 
@@ -624,12 +675,12 @@ Phaser.Group.prototype.getIndex = function (child) {
 };
 
 /**
-* Replaces a child of this Group with the given newChild. The newChild cannot be a member of this Group.
+* Replaces a child of this group with the given newChild. The newChild cannot be a member of this group.
 *
 * @method Phaser.Group#replace
-* @param {*} oldChild - The child in this Group that will be replaced.
-* @param {*} newChild - The child to be inserted into this Group.
-* @return {*} Returns the oldChild that was replaced within this Group.
+* @param {any} oldChild - The child in this group that will be replaced.
+* @param {any} newChild - The child to be inserted into this group.
+* @return {any} Returns the oldChild that was replaced within this group.
 */
 Phaser.Group.prototype.replace = function (oldChild, newChild) {
 
@@ -660,10 +711,12 @@ Phaser.Group.prototype.replace = function (oldChild, newChild) {
 };
 
 /**
-* Checks if the child has the given property. Will scan up to 4 levels deep only.
+* Checks if the child has the given property.
+*
+* Will scan up to 4 levels deep only.
 *
 * @method Phaser.Group#hasProperty
-* @param {*} child - The child to check for the existance of the property on.
+* @param {any} child - The child to check for the existance of the property on.
 * @param {array} key - An array of strings that make up the property.
 * @return {boolean} True if the child has the property, otherwise false.
 */
@@ -694,16 +747,18 @@ Phaser.Group.prototype.hasProperty = function (child, key) {
 
 /**
 * Sets a property to the given value on the child. The operation parameter controls how the value is set.
-* Operation 0 means set the existing value to the given value, or if force is `false` create a new property with the given value.
-* 1 will add the given value to the value already present.
-* 2 will subtract the given value from the value already present.
-* 3 will multiply the value already present by the given value.
-* 4 will divide the value already present by the given value.
+*
+* The operations are:
+* - 0: set the existing value to the given value; if force is `true` a new property will be created if needed
+* - 1: will add the given value to the value already present.
+* - 2: will subtract the given value from the value already present.
+* - 3: will multiply the value already present by the given value.
+* - 4: will divide the value already present by the given value.
 *
 * @method Phaser.Group#setProperty
-* @param {*} child - The child to set the property value on.
+* @param {any} child - The child to set the property value on.
 * @param {array} key - An array of strings that make up the property that will be set.
-* @param {*} value - The value that will be set.
+* @param {any} value - The value that will be set.
 * @param {number} [operation=0] - Controls how the value is assigned. A value of 0 replaces the value with the new one. A value of 1 adds it, 2 subtracts it, 3 multiplies it and 4 divides it.
 * @param {boolean} [force=false] - If `force` is true then the property will be set on the child regardless if it already exists or not. If false and the property doesn't exist, nothing will be set.
 * @return {boolean} True if the property was set, false if not.
@@ -772,9 +827,9 @@ Phaser.Group.prototype.setProperty = function (child, key, value, operation, for
 * Checks a property for the given value on the child.
 *
 * @method Phaser.Group#checkProperty
-* @param {*} child - The child to check the property value on.
+* @param {any} child - The child to check the property value on.
 * @param {array} key - An array of strings that make up the property that will be set.
-* @param {*} value - The value that will be checked.
+* @param {any} value - The value that will be checked.
 * @param {boolean} [force=false] - If `force` is true then the property will be checked on the child regardless if it already exists or not. If true and the property doesn't exist, false will be returned.
 * @return {boolean} True if the property was was equal to value, false if not.
 */
@@ -798,13 +853,14 @@ Phaser.Group.prototype.checkProperty = function (child, key, value, force) {
 };
 
 /**
-* This function allows you to quickly set a property on a single child of this Group to a new value.
+* Quickly set a property on a single child of this group to a new value.
+*
 * The operation parameter controls how the new value is assigned to the property, from simple replacement to addition and multiplication.
 *
 * @method Phaser.Group#set
 * @param {Phaser.Sprite} child - The child to set the property on.
 * @param {string} key - The property, as a string, to be set. For example: 'body.velocity.x'
-* @param {*} value - The value that will be set.
+* @param {any} value - The value that will be set.
 * @param {boolean} [checkAlive=false] - If set then the child will only be updated if alive=true.
 * @param {boolean} [checkVisible=false] - If set then the child will only be updated if visible=true.
 * @param {number} [operation=0] - Controls how the value is assigned. A value of 0 replaces the value with the new one. A value of 1 adds it, 2 subtracts it, 3 multiplies it and 4 divides it.
@@ -828,15 +884,16 @@ Phaser.Group.prototype.set = function (child, key, value, checkAlive, checkVisib
 };
 
 /**
-* This function allows you to quickly set the same property across all children of this Group to a new value.
-* This call doesn't descend down children, so if you have a Group inside of this Group, the property will be set on the Group but not its children.
+* Quickly set the same property across all children of this group to a new value.
+*
+* This call doesn't descend down children, so if you have a Group inside of this group, the property will be set on the group but not its children.
 * If you need that ability please see `Group.setAllChildren`.
 *
 * The operation parameter controls how the new value is assigned to the property, from simple replacement to addition and multiplication.
 *
 * @method Phaser.Group#setAll
 * @param {string} key - The property, as a string, to be set. For example: 'body.velocity.x'
-* @param {*} value - The value that will be set.
+* @param {any} value - The value that will be set.
 * @param {boolean} [checkAlive=false] - If set then only children with alive=true will be updated. This includes any Groups that are children.
 * @param {boolean} [checkVisible=false] - If set then only children with visible=true will be updated. This includes any Groups that are children.
 * @param {number} [operation=0] - Controls how the value is assigned. A value of 0 replaces the value with the new one. A value of 1 adds it, 2 subtracts it, 3 multiplies it and 4 divides it.
@@ -862,16 +919,16 @@ Phaser.Group.prototype.setAll = function (key, value, checkAlive, checkVisible, 
 };
 
 /**
-* This function allows you to quickly set the same property across all children of this Group, and any child Groups, to a new value.
+* Quickly set the same property across all children of this group, and any child Groups, to a new value.
 *
-* If this Group contains other Groups then the same property is set across their children as well, iterating down until it reaches the bottom.
-* Unlike with Group.setAll the property is NOT set on child Groups itself.
+* If this group contains other Groups then the same property is set across their children as well, iterating down until it reaches the bottom.
+* Unlike with `setAll` the property is NOT set on child Groups itself.
 *
 * The operation parameter controls how the new value is assigned to the property, from simple replacement to addition and multiplication.
 *
 * @method Phaser.Group#setAllChildren
 * @param {string} key - The property, as a string, to be set. For example: 'body.velocity.x'
-* @param {*} value - The value that will be set.
+* @param {any} value - The value that will be set.
 * @param {boolean} [checkAlive=false] - If set then only children with alive=true will be updated. This includes any Groups that are children.
 * @param {boolean} [checkVisible=false] - If set then only children with visible=true will be updated. This includes any Groups that are children.
 * @param {number} [operation=0] - Controls how the value is assigned. A value of 0 replaces the value with the new one. A value of 1 adds it, 2 subtracts it, 3 multiplies it and 4 divides it.
@@ -903,12 +960,13 @@ Phaser.Group.prototype.setAllChildren = function (key, value, checkAlive, checkV
 };
 
 /**
-* This function allows you to quickly check that the same property across all children of this Group is equal to the given value.
-* This call doesn't descend down children, so if you have a Group inside of this Group, the property will be checked on the Group but not its children.
+* Quickly check that the same property across all children of this group is equal to the given value.
+*
+* This call doesn't descend down children, so if you have a Group inside of this group, the property will be checked on the group but not its children.
 *
 * @method Phaser.Group#checkAll
 * @param {string} key - The property, as a string, to be set. For example: 'body.velocity.x'
-* @param {*} value - The value that will be checked.
+* @param {any} value - The value that will be checked.
 * @param {boolean} [checkAlive=false] - If set then only children with alive=true will be checked. This includes any Groups that are children.
 * @param {boolean} [checkVisible=false] - If set then only children with visible=true will be checked. This includes any Groups that are children.
 * @param {boolean} [force=false] - If `force` is true then the property will be checked on the child regardless if it already exists or not. If true and the property doesn't exist, false will be returned.
@@ -935,8 +993,9 @@ Phaser.Group.prototype.checkAll = function (key, value, checkAlive, checkVisible
 };
 
 /**
-* Adds the amount to the given property on all children in this Group.
-* Group.addAll('x', 10) will add 10 to the child.x value.
+* Adds the amount to the given property on all children in this group.
+*
+* `Group.addAll('x', 10)` will add 10 to the child.x value for each child.
 *
 * @method Phaser.Group#addAll
 * @param {string} property - The property to increment, for example 'body.velocity.x' or 'angle'.
@@ -951,8 +1010,9 @@ Phaser.Group.prototype.addAll = function (property, amount, checkAlive, checkVis
 };
 
 /**
-* Subtracts the amount from the given property on all children in this Group.
-* Group.subAll('x', 10) will minus 10 from the child.x value.
+* Subtracts the amount from the given property on all children in this group.
+*
+* `Group.subAll('x', 10)` will minus 10 from the child.x value for each child.
 *
 * @method Phaser.Group#subAll
 * @param {string} property - The property to decrement, for example 'body.velocity.x' or 'angle'.
@@ -967,8 +1027,9 @@ Phaser.Group.prototype.subAll = function (property, amount, checkAlive, checkVis
 };
 
 /**
-* Multiplies the given property by the amount on all children in this Group.
-* Group.multiplyAll('x', 2) will x2 the child.x value.
+* Multiplies the given property by the amount on all children in this group.
+*
+* `Group.multiplyAll('x', 2)` will x2 the child.x value for each child.
 *
 * @method Phaser.Group#multiplyAll
 * @param {string} property - The property to multiply, for example 'body.velocity.x' or 'angle'.
@@ -983,8 +1044,9 @@ Phaser.Group.prototype.multiplyAll = function (property, amount, checkAlive, che
 };
 
 /**
-* Divides the given property by the amount on all children in this Group.
-* Group.divideAll('x', 2) will half the child.x value.
+* Divides the given property by the amount on all children in this group.
+*
+* `Group.divideAll('x', 2)` will half the child.x value for each child.
 *
 * @method Phaser.Group#divideAll
 * @param {string} property - The property to divide, for example 'body.velocity.x' or 'angle'.
@@ -999,13 +1061,14 @@ Phaser.Group.prototype.divideAll = function (property, amount, checkAlive, check
 };
 
 /**
-* Calls a function on all of the children that have exists=true in this Group.
+* Calls a function, specified by name, on all children in the group who exist (or do not exist).
+*
 * After the existsValue parameter you can add as many parameters as you like, which will all be passed to the child callback.
 *
 * @method Phaser.Group#callAllExists
-* @param {function} callback - The function that exists on the children that will be called.
+* @param {string} callback - Name of the function on the children to call.
 * @param {boolean} existsValue - Only children with exists=existsValue will be called.
-* @param {...*} parameter - Additional parameters that will be passed to the callback.
+* @param {...any} parameter - Additional parameters that will be passed to the callback.
 */
 Phaser.Group.prototype.callAllExists = function (callback, existsValue) {
 
@@ -1022,7 +1085,7 @@ Phaser.Group.prototype.callAllExists = function (callback, existsValue) {
 };
 
 /**
-* Returns a reference to a function that exists on a child of the Group based on the given callback array.
+* Returns a reference to a function that exists on a child of the group based on the given callback array.
 *
 * @method Phaser.Group#callbackFromArray
 * @param {object} child - The object to inspect.
@@ -1075,13 +1138,15 @@ Phaser.Group.prototype.callbackFromArray = function (child, callback, length) {
 };
 
 /**
-* Calls a function on all of the children regardless if they are dead or alive (see callAllExists if you need control over that)
+* Calls a function, specified by name, on all on children.
+*
+* The function is called for all children regardless if they are dead or alive (see callAllExists for different options).
 * After the method parameter and context you can add as many extra parameters as you like, which will all be passed to the child.
 *
 * @method Phaser.Group#callAll
-* @param {string} method - A string containing the name of the function that will be called. The function must exist on the child.
+* @param {string} method - Name of the function on the child to call. Deep property lookup is supported.
 * @param {string} [context=null] - A string containing the context under which the method will be executed. Set to null to default to the child.
-* @param {...*} parameter - Additional parameters that will be passed to the method.
+* @param {...any} args - Additional parameters that will be passed to the method.
 */
 Phaser.Group.prototype.callAll = function (method, context) {
 
@@ -1199,7 +1264,8 @@ Phaser.Group.prototype.postUpdate = function () {
 
 
 /**
-* Allows you to obtain a Phaser.ArraySet of children that return true for the given predicate
+* Find children matching a certain predicate.
+*
 * For example:
 *
 *     var healthyList = Group.filter(function(child, index, children) {
@@ -1210,8 +1276,8 @@ Phaser.Group.prototype.postUpdate = function () {
 * Note: Currently this will skip any children which are Groups themselves.
 *
 * @method Phaser.Group#filter
-* @param {function} predicate - The function that each child will be evaluated against. Each child of the Group will be passed to it as its first parameter, the index as the second, and the entire child array as the third
-* @param {boolean} [checkExists=false] - If set only children with exists=true will be passed to the callback, otherwise all children will be passed.
+* @param {function} predicate - The function that each child will be evaluated against. Each child of the group will be passed to it as its first parameter, the index as the second, and the entire child array as the third
+* @param {boolean} [checkExists=false] - If true, only existing can be selected; otherwise all children can be selected and will be passed to the predicate.
 * @return {Phaser.ArraySet} Returns an array list containing all the children that the predicate returned true for
 */
 Phaser.Group.prototype.filter = function (predicate, checkExists) {
@@ -1238,15 +1304,21 @@ Phaser.Group.prototype.filter = function (predicate, checkExists) {
 };
 
 /**
-* Allows you to call your own function on each member of this Group. You must pass the callback and context in which it will run.
-* After the checkExists parameter you can add as many parameters as you like, which will all be passed to the callback along with the child.
-* For example: Group.forEach(awardBonusGold, this, true, 100, 500)
+* Call a function on each child in this group.
+*
+* Additional arguments for the callback can be specified after the `checkExists` parameter. For example,
+*
+*     Group.forEach(awardBonusGold, this, true, 100, 500)
+*
+* would invoke thee `awardBonusGolds` with the parameters `(child, 100, 500)`.
+*
 * Note: Currently this will skip any children which are Groups themselves.
 *
 * @method Phaser.Group#forEach
-* @param {function} callback - The function that will be called. Each child of the Group will be passed to it as its first parameter.
-* @param {Object} callbackContext - The context in which the function should be called (usually 'this').
-* @param {boolean} [checkExists=false] - If set only children with exists=true will be passed to the callback, otherwise all children will be passed.
+* @param {function} callback - The function that will be called for each applicable child. The child will be passed as the first argument.
+* @param {object} [callbackContext=undefined] - The context in which the function should be called (usually 'this').
+* @param {boolean} [checkExists=false] - If set only children matching for which `exists` is true will be passed to the callback, otherwise all children will be passed.
+* @param {...any} [args=(none)] - Additional arguments to pass to the callback function, after the child item.
 */
 Phaser.Group.prototype.forEach = function (callback, callbackContext, checkExists) {
 
@@ -1267,13 +1339,14 @@ Phaser.Group.prototype.forEach = function (callback, callbackContext, checkExist
 };
 
 /**
-* Allows you to call your own function on each member of this Group where child.exists=true. You must pass the callback and context in which it will run.
-* You can add as many parameters as you like, which will all be passed to the callback along with the child.
-* For example: Group.forEachExists(causeDamage, this, 500)
+* Call a function on each existing child in this group.
+*
+* See {@link Phaser.Group#forEach forEach} for details.
 *
 * @method Phaser.Group#forEachExists
-* @param {function} callback - The function that will be called. Each child of the Group will be passed to it as its first parameter.
-* @param {Object} callbackContext - The context in which the function should be called (usually 'this').
+* @param {function} callback - The function that will be called for each applicable child. The child will be passed as the first argument.
+* @param {object} [callbackContext=undefined] - The context in which the function should be called (usually 'this').
+* @param {...any} [args=(none)] - Additional arguments to pass to the callback function, after the child item.
 */
 Phaser.Group.prototype.forEachExists = function (callback, callbackContext) {
 
@@ -1285,13 +1358,14 @@ Phaser.Group.prototype.forEachExists = function (callback, callbackContext) {
 };
 
 /**
-* Allows you to call your own function on each alive member of this Group (where child.alive=true). You must pass the callback and context in which it will run.
-* You can add as many parameters as you like, which will all be passed to the callback along with the child.
-* For example: Group.forEachAlive(causeDamage, this, 500)
+* Call a function on each alive child in this group.
+*
+* See {@link Phaser.Group#forEach forEach} for details.
 *
 * @method Phaser.Group#forEachAlive
-* @param {function} callback - The function that will be called. Each child of the Group will be passed to it as its first parameter.
-* @param {Object} callbackContext - The context in which the function should be called (usually 'this').
+* @param {function} callback - The function that will be called for each applicable child. The child will be passed as the first argument.
+* @param {object} [callbackContext=undefined] - The context in which the function should be called (usually 'this').
+* @param {...any} [args=(none)] - Additional arguments to pass to the callback function, after the child item.
 */
 Phaser.Group.prototype.forEachAlive = function (callback, callbackContext) {
 
@@ -1303,13 +1377,14 @@ Phaser.Group.prototype.forEachAlive = function (callback, callbackContext) {
 };
 
 /**
-* Allows you to call your own function on each dead member of this Group (where alive=false). You must pass the callback and context in which it will run.
-* You can add as many parameters as you like, which will all be passed to the callback along with the child.
-* For example: Group.forEachDead(bringToLife, this)
+* Call a function on each dead child in this group.
+*
+* See {@link Phaser.Group#forEach forEach} for details.
 *
 * @method Phaser.Group#forEachDead
-* @param {function} callback - The function that will be called. Each child of the Group will be passed to it as its first parameter.
-* @param {Object} callbackContext - The context in which the function should be called (usually 'this').
+* @param {function} callback - The function that will be called for each applicable child. The child will be passed as the first argument.
+* @param {object} [callbackContext=undefined] - The context in which the function should be called (usually 'this').
+* @param {...any} [args=(none)] - Additional arguments to pass to the callback function, after the child item.
 */
 Phaser.Group.prototype.forEachDead = function (callback, callbackContext) {
 
@@ -1321,14 +1396,16 @@ Phaser.Group.prototype.forEachDead = function (callback, callbackContext) {
 };
 
 /**
-* Call this function to sort the group according to a particular value and order.
+* Sort the group according to a particular key and ordering.
+*
+* Call this function to sort the group according to a particular key value and order.
 * For example to depth sort Sprites for Zelda-style game you might call `group.sort('y', Phaser.Group.SORT_ASCENDING)` at the bottom of your `State.update()`.
 *
 * @method Phaser.Group#sort
-* @param {string} [index='z'] - The `string` name of the property you want to sort on. Defaults to the objects z-depth value.
-* @param {number} [order=Phaser.Group.SORT_ASCENDING] - The `Group` constant that defines the sort order. Possible values are Phaser.Group.SORT_ASCENDING and Phaser.Group.SORT_DESCENDING.
+* @param {string} [key='z'] - The name of the property to sort on. Defaults to the objects z-depth value.
+* @param {integer} [order=Phaser.Group.SORT_ASCENDING] - Order ascending ({@link Phaser.Group.SORT_ASCENDING SORT_ASCENDING}) or descending ({@link Phaser.Group.SORT_DESCENDING SORT_DESCENDING}).
 */
-Phaser.Group.prototype.sort = function (index, order) {
+Phaser.Group.prototype.sort = function (key, order) {
 
     if (this.children.length < 2)
     {
@@ -1336,10 +1413,10 @@ Phaser.Group.prototype.sort = function (index, order) {
         return;
     }
 
-    if (typeof index === 'undefined') { index = 'z'; }
+    if (typeof key === 'undefined') { key = 'z'; }
     if (typeof order === 'undefined') { order = Phaser.Group.SORT_ASCENDING; }
 
-    this._sortProperty = index;
+    this._sortProperty = key;
 
     if (order === Phaser.Group.SORT_ASCENDING)
     {
@@ -1355,12 +1432,13 @@ Phaser.Group.prototype.sort = function (index, order) {
 };
 
 /**
-* This allows you to use your own sort handler function.
-* It will be sent two parameters: the two children involved in the comparison (a and b). It should return -1 if a > b, 1 if a < b or 0 if a === b.
+* Sort the group according to custom sort function.
+*
+* The `sortHandler` is provided the two parameters: the two children involved in the comparison (a and b). It should return -1 if a > b, 1 if a < b or 0 if a === b.
 *
 * @method Phaser.Group#customSort
-* @param {function} sortHandler - Your sort handler function. It will be sent two parameters: the two children involved in the comparison. It must return -1, 1 or 0.
-* @param {object} context - The scope in which the sortHandler is called.
+* @param {function} sortHandler - The custom sort function.
+* @param {object} [context=undefined] - The scope in which the sortHandler is called.
 */
 Phaser.Group.prototype.customSort = function (sortHandler, context) {
 
@@ -1380,6 +1458,7 @@ Phaser.Group.prototype.customSort = function (sortHandler, context) {
 * An internal helper function for the sort process.
 *
 * @method Phaser.Group#ascendingSortHandler
+* @protected
 * @param {object} a - The first object being sorted.
 * @param {object} b - The second object being sorted.
 */
@@ -1411,6 +1490,7 @@ Phaser.Group.prototype.ascendingSortHandler = function (a, b) {
 * An internal helper function for the sort process.
 *
 * @method Phaser.Group#descendingSortHandler
+* @protected
 * @param {object} a - The first object being sorted.
 * @param {object} b - The second object being sorted.
 */
@@ -1432,7 +1512,7 @@ Phaser.Group.prototype.descendingSortHandler = function (a, b) {
 };
 
 /**
-* Iterates over the children of the Group performing one of several actions for matched children.
+* Iterates over the children of the group performing one of several actions for matched children.
 *
 * A child is considered a match when it has a property, named `key`, whose value is equal to `value`
 * according to a strict equality comparison.
@@ -1505,29 +1585,30 @@ Phaser.Group.prototype.iterate = function (key, value, returnType, callback, cal
 };
 
 /**
-* Call this function to retrieve the first object with exists == (the given state) in the Group.
+* Get the first item that exists, or doesn't exist.
 *
 * @method Phaser.Group#getFirstExists
-* @param {boolean} state - True or false.
-* @return {Any} The first child, or null if none found.
+* @param {boolean} [exists=true] - If true, find the first existing child; otherwise find the first non-existing child.
+* @return {any} The first matching child, or null if none found.
 */
-Phaser.Group.prototype.getFirstExists = function (state) {
+Phaser.Group.prototype.getFirstExists = function (exists) {
 
-    if (typeof state !== 'boolean')
+    if (typeof exists !== 'boolean')
     {
-        state = true;
+        exists = true;
     }
 
-    return this.iterate('exists', state, Phaser.Group.RETURN_CHILD);
+    return this.iterate('exists', exists, Phaser.Group.RETURN_CHILD);
 
 };
 
 /**
-* Call this function to retrieve the first object with alive === true in the group.
+* Get the first child that is alive (`child.alive === true`).
+*
 * This is handy for checking if everything has been wiped out, or choosing a squad leader, etc.
 *
 * @method Phaser.Group#getFirstAlive
-* @return {Any} The first alive child, or null if none found.
+* @return {any} The first alive child, or null if none found.
 */
 Phaser.Group.prototype.getFirstAlive = function () {
 
@@ -1536,11 +1617,12 @@ Phaser.Group.prototype.getFirstAlive = function () {
 };
 
 /**
-* Call this function to retrieve the first object with alive === false in the group.
+* Get the first child that is dead (`child.alive === false`).
+*
 * This is handy for checking if everything has been wiped out, or choosing a squad leader, etc.
 *
 * @method Phaser.Group#getFirstDead
-* @return {Any} The first dead child, or null if none found.
+* @return {any} The first dead child, or null if none found.
 */
 Phaser.Group.prototype.getFirstDead = function () {
 
@@ -1549,10 +1631,12 @@ Phaser.Group.prototype.getFirstDead = function () {
 };
 
 /**
-* Returns the child at the top of this Group. The top is the one being displayed (rendered) above every other child.
+* Return the child at the top of this group.
+*
+* The top child is the child displayed (rendered) above every other child.
 *
 * @method Phaser.Group#getTop
-* @return {Any} The child at the top of the Group.
+* @return {any} The child at the top of the group.
 */
 Phaser.Group.prototype.getTop = function () {
 
@@ -1564,10 +1648,12 @@ Phaser.Group.prototype.getTop = function () {
 };
 
 /**
-* Returns the child at the bottom of this Group. The bottom is the one being displayed (rendered) below every other child.
+* Returns the child at the bottom of this group.
+*
+* The bottom child the child being displayed (rendered) below every other child.
 *
 * @method Phaser.Group#getBottom
-* @return {Any} The child at the bottom of the Group.
+* @return {any} The child at the bottom of the group.
 */
 Phaser.Group.prototype.getBottom = function () {
 
@@ -1579,7 +1665,7 @@ Phaser.Group.prototype.getBottom = function () {
 };
 
 /**
-* Call this function to find out how many members of the group are alive.
+* Get the number of living children in this group.
 *
 * @method Phaser.Group#countLiving
 * @return {number} The number of children flagged as alive.
@@ -1591,7 +1677,7 @@ Phaser.Group.prototype.countLiving = function () {
 };
 
 /**
-* Call this function to find out how many members of the group are dead.
+* Get the number of dead children in this group.
 *
 * @method Phaser.Group#countDead
 * @return {number} The number of children flagged as dead.
@@ -1603,12 +1689,12 @@ Phaser.Group.prototype.countDead = function () {
 };
 
 /**
-* Returns a member at random from the group.
+* Returns a random child from the group.
 *
 * @method Phaser.Group#getRandom
-* @param {number} startIndex - Optional offset off the front of the array. Default value is 0, or the beginning of the array.
-* @param {number} length - Optional restriction on the number of values you want to randomly select from.
-* @return {Any} A random child of this Group.
+* @param {number} [startIndex=0] - Offset from the front of the front of the group (lowest child).
+* @param {number} [length=(to top)] - Restriction on the number of values you want to randomly select from.
+* @return {any} A random child of this group, or null if an invalid range was specified.
 */
 Phaser.Group.prototype.getRandom = function (startIndex, length) {
 
@@ -1625,14 +1711,17 @@ Phaser.Group.prototype.getRandom = function (startIndex, length) {
 };
 
 /**
-* Removes the given child from this Group. This will dispatch an onRemovedFromGroup event from the child (if it has one),
-* reset the Group cursor and optionally destroy the child.
+* Removes the given child from this group.
+*
+* This will dispatch an `onRemovedFromGroup` event from the child (if it has one), and optionally destroy the child.
+*
+* If the group cursor was referring to the removed child it is updated to refer to the next child.
 *
 * @method Phaser.Group#remove
-* @param {Any} child - The child to remove.
-* @param {boolean} [destroy=false] - You can optionally call destroy on the child that was removed.
-* @param {boolean} [silent=false] - If the silent parameter is `true` the child will not dispatch the onRemovedFromGroup event.
-* @return {boolean} true if the child was removed from this Group, otherwise false.
+* @param {any} child - The child to remove.
+* @param {boolean} [destroy=false] - If true, `destroy` will be invoked on the removed child.
+* @param {boolean} [silent=false] - If true, the the child will not dispatch the `onRemovedFromGroup` event.
+* @return {boolean} true if the child was removed from this group, otherwise false.
 */
 Phaser.Group.prototype.remove = function (child, destroy, silent) {
 
@@ -1668,12 +1757,11 @@ Phaser.Group.prototype.remove = function (child, destroy, silent) {
 };
 
 /**
-* Removes all children from this Group, setting the `parent` property of the children to `null`.
-* The Group container remains on the display list.
+* Removes all children from this group, but does not remove the group from its parent.
 *
 * @method Phaser.Group#removeAll
-* @param {boolean} [destroy=false] - You can optionally call destroy on each child that is removed.
-* @param {boolean} [silent=false] - If the silent parameter is `true` the children will not dispatch their onRemovedFromGroup events.
+* @param {boolean} [destroy=false] - If true, `destroy` will be invoked on each removed child.
+* @param {boolean} [silent=false] - If true, the children will not dispatch their `onRemovedFromGroup` events.
 */
 Phaser.Group.prototype.removeAll = function (destroy, silent) {
 
@@ -1706,13 +1794,13 @@ Phaser.Group.prototype.removeAll = function (destroy, silent) {
 };
 
 /**
-* Removes all children from this Group whos index falls beteen the given startIndex and endIndex values.
+* Removes all children from this group whose index falls beteen the given startIndex and endIndex values.
 *
 * @method Phaser.Group#removeBetween
 * @param {number} startIndex - The index to start removing children from.
-* @param {number} [endIndex] - The index to stop removing children at. Must be higher than startIndex. If undefined this method will remove all children between startIndex and the end of the Group.
-* @param {boolean} [destroy=false] - You can optionally call destroy on the child that was removed.
-* @param {boolean} [silent=false] - If the silent parameter is `true` the children will not dispatch their onRemovedFromGroup events.
+* @param {number} [endIndex] - The index to stop removing children at. Must be higher than startIndex. If undefined this method will remove all children between startIndex and the end of the group.
+* @param {boolean} [destroy=false] - If true, `destroy` will be invoked on each removed child.
+* @param {boolean} [silent=false] - If true, the children will not dispatch their `onRemovedFromGroup` events.
 */
 Phaser.Group.prototype.removeBetween = function (startIndex, endIndex, destroy, silent) {
 
@@ -1759,11 +1847,13 @@ Phaser.Group.prototype.removeBetween = function (startIndex, endIndex, destroy, 
 };
 
 /**
-* Destroys this Group. Removes all children, then removes the container from the display list and nulls references.
+* Destroys this group.
+*
+* Removes all children, then removes this group from its parent and nulls references.
 *
 * @method Phaser.Group#destroy
-* @param {boolean} [destroyChildren=true] - Should every child of this Group have its destroy method called?
-* @param {boolean} [soft=false] - A 'soft destroy' (set to true) doesn't remove this Group from its parent or null the game reference. Set to false and it does.
+* @param {boolean} [destroyChildren=true] - If true, `destroy` will be invoked on each removed child.
+* @param {boolean} [soft=false] - A 'soft destroy' (set to true) doesn't remove this group from its parent or null the game reference. Set to false and it does.
 */
 Phaser.Group.prototype.destroy = function (destroyChildren, soft) {
 
@@ -1793,8 +1883,10 @@ Phaser.Group.prototype.destroy = function (destroyChildren, soft) {
 };
 
 /**
+* Total number of existing children in the group.
+*
 * @name Phaser.Group#total
-* @property {number} total - The total number of children in this Group who have a state of exists = true.
+* @property {number} total
 * @readonly
 */
 Object.defineProperty(Phaser.Group.prototype, "total", {
@@ -1808,8 +1900,10 @@ Object.defineProperty(Phaser.Group.prototype, "total", {
 });
 
 /**
+* Total number of children in this group, regardless of exists/alive status.
+*
 * @name Phaser.Group#length
-* @property {number} length - The total number of children in this Group, regardless of their exists/alive status.
+* @property {number} length 
 * @readonly
 */
 Object.defineProperty(Phaser.Group.prototype, "length", {
@@ -1823,10 +1917,13 @@ Object.defineProperty(Phaser.Group.prototype, "length", {
 });
 
 /**
-* The angle of rotation of the Group container. This will adjust the Group container itself by modifying its rotation.
+* The angle of rotation of the group container, in degrees.
+*
+* This will adjust the group container itself by modifying its rotation.
 * This will have no impact on the rotation value of its children, but it will update their worldTransform and on-screen position.
+*
 * @name Phaser.Group#angle
-* @property {number} angle - The angle of rotation given in degrees, where 0 degrees = to the right.
+* @property {number} angle
 */
 Object.defineProperty(Phaser.Group.prototype, "angle", {
 
@@ -1841,12 +1938,14 @@ Object.defineProperty(Phaser.Group.prototype, "angle", {
 });
 
 /**
-* A Group that is fixed to the camera uses its x/y coordinates as offsets from the top left of the camera. These are stored in Group.cameraOffset.
-* Note that the cameraOffset values are in addition to any parent in the display list.
-* So if this Group was in a Group that has x: 200, then this will be added to the cameraOffset.x
+* Is this group fixed to the camera?
+* A Group that is fixed to the camera uses its x/y coordinates as offsets from the top left of the camera.
+*
+* These are stored in {@link Phaser.Group#cameraOffset cameraOffset} and are in addition to any parent in the display list.
+* So if this group was in a Group that has x: 200, then this will be added to the cameraOffset.x
 *
 * @name Phaser.Group#fixedToCamera
-* @property {boolean} fixedToCamera - Set to true to fix this Group to the Camera at its current world coordinates.
+* @property {boolean} fixedToCamera
 */
 Object.defineProperty(Phaser.Group.prototype, "fixedToCamera", {
 
@@ -1874,32 +1973,42 @@ Object.defineProperty(Phaser.Group.prototype, "fixedToCamera", {
 //  Documentation stubs
 
 /**
-* The x coordinate of the Group container. You can adjust the Group container itself by modifying its coordinates.
+* The x coordinate of the group container.
+*
+* You can adjust the group container itself by modifying its coordinates.
 * This will have no impact on the x/y coordinates of its children, but it will update their worldTransform and on-screen position.
 * @name Phaser.Group#x
-* @property {number} x - The x coordinate of the Group container.
+* @property {number} x
 */
 
 /**
-* The y coordinate of the Group container. You can adjust the Group container itself by modifying its coordinates.
+* The y coordinate of the group container.
+*
+* You can adjust the group container itself by modifying its coordinates.
 * This will have no impact on the x/y coordinates of its children, but it will update their worldTransform and on-screen position.
 * @name Phaser.Group#y
-* @property {number} y - The y coordinate of the Group container.
+* @property {number} y
 */
 
 /**
-* The angle of rotation of the Group container. This will adjust the Group container itself by modifying its rotation.
+* The angle of rotation of the group container, in radians.
+*
+* This will adjust the group container itself by modifying its rotation.
 * This will have no impact on the rotation value of its children, but it will update their worldTransform and on-screen position.
 * @name Phaser.Group#rotation
-* @property {number} rotation - The angle of rotation given in radians.
+* @property {number} rotation
 */
 
 /**
+* The visible state of the group. Non-visible Groups and all of their children are not rendered.
+*
 * @name Phaser.Group#visible
-* @property {boolean} visible - The visible state of the Group. Non-visible Groups and all of their children are not rendered.
+* @property {boolean} visible
 */
 
 /**
+* The alpha value of the group container.
+*
 * @name Phaser.Group#alpha
-* @property {number} alpha - The alpha value of the Group container.
+* @property {number} alpha
 */


### PR DESCRIPTION
Update iterate documentation to cover usage of `args` and added a guard so
that the callback can be used without requiring that `args` is specified.

Ref. https://github.com/photonstorm/phaser/issues/1352
