### PR TITLE
Signal - memory optimization / reductions

### DIFF
--- a/src/core/SignalBinding.js
+++ b/src/core/SignalBinding.js
@@ -15,7 +15,7 @@
 * @param {Phaser.Signal} signal - Reference to Signal object that listener is currently bound to.
 * @param {function} listener - Handler function bound to the signal.
 * @param {boolean} isOnce - If binding should be executed just once.
-* @param {object} [listenerContext] - Context on which listener will be executed (object that should represent the `this` variable inside listener function).
+* @param {object} [listenerContext=null] - Context on which listener will be executed (object that should represent the `this` variable inside listener function).
 * @param {number} [priority] - The priority level of the event listener. (default = 0).
 */
 Phaser.SignalBinding = function (signal, listener, isOnce, listenerContext, priority) {
@@ -26,16 +26,15 @@ Phaser.SignalBinding = function (signal, listener, isOnce, listenerContext, prio
     */
     this._listener = listener;
 
-    /**
-    * @property {boolean} _isOnce - If binding should be executed just once.
-    * @private
-    */
-    this._isOnce = isOnce;
+    if (isOnce)
+    {
+        this._isOnce = true;
+    }
 
-    /**
-    * @property {object|undefined|null} context - Context on which listener will be executed (object that should represent the `this` variable inside listener function).
-    */
-    this.context = listenerContext;
+    if (listenerContext != null) /* not null/undefined */
+    {
+        this.context = listenerContext;
+    }
 
     /**
     * @property {Phaser.Signal} _signal - Reference to Signal object that listener is currently bound to.
@@ -43,34 +42,50 @@ Phaser.SignalBinding = function (signal, listener, isOnce, listenerContext, prio
     */
     this._signal = signal;
 
+    if (priority)
+    {
+        this._priority = priority;
+    }
+
+};
+
+Phaser.SignalBinding.prototype = {
+
+    /**
+    * @property {?object} context - Context on which listener will be executed (object that should represent the `this` variable inside listener function).
+    */
+    context: null,
+
+    /**
+    * @property {boolean} _isOnce - If binding should be executed just once.
+    * @private
+    */
+    _isOnce: false,
+
     /**
     * @property {number} _priority - Listener priority.
     * @private
     */
-    this._priority = priority || 0;
+    _priority: 0,
 
     /**
     * @property {number} callCount - The number of times the handler function has been called.
     */
-    this.callCount = 0;
+    callCount: 0,
 
     /**
     * If binding is active and should be executed.
     * @property {boolean} active
     * @default
     */
-    this.active = true;
+    active: true,
 
     /**
     * Default parameters passed to listener during `Signal.dispatch` and `SignalBinding.execute` (curried parameters).
     * @property {array|null} params
     * @default
     */
-    this.params = null;
-
-};
-
-Phaser.SignalBinding.prototype = {
+    params: null,
 
     /**
     * Call listener passing arbitrary parameters.


### PR DESCRIPTION
There are a fair amount of Signal objects created. In the current
implementation these are somewhat "fat" objects for two reasons:
- A closure / ad-hoc `dispatch` is created for each new Signal - this
  increases the retained size by 138+ bytes/Signal in Chrome.
- There are a number of instance variables that never change from their
  default value, and the bindings array is always created, even if never
  used.

This change "lightens" the Signals such that there is significantly less
penalty for having many (unusued) signals.

As an example of how much this _does_ play a role, in the "Random Sprite"
demo ~2000 Signals are created, with only 12 of these signals being
subscribed to. This results in a shallow size of ~300K and a retained size
of ~600K (which is almost as much memory as required by the
Sprites/Sprites themselves!) for .. nothing.

With these changes the shallow and retained sizes are less than 50K each -
and this is with only ~200 sprites!

This change addresses these issues by
- Changing it so there is _no_ `dispatch` closure created. This is a
  _breaking change_ (although there is no usage of such in core where it
  breaks); the code referenced "#24", but no such [relevant?] issue could be found on
  github.
  
  In the rare case that code needs to obtain a dispatch-closure, the
  `boundDispatch` property can be used to trivially obtain a (cached)
  closure.
- The properties and default values are moved into the prototype; and the
  `_bindings` array creation is deferred. This change, coupled with the
  removal of the automatic closure, results in a very lightweight
  ~24bytes/object (in Chrome) for unbound signals.

This is minor breaking change, as per the removal of the automatic
closure; but no such need/usage was found in the core. (There may be cases
in the examples, which were not checked.)

If merely opting for the array creation delay and keeping the default
properties in the prototype the shallow size is still halved; less
significant but still a consideration.
