### PR TITLE
yuidoc-to-jsdoc - bug fix and jsobj-like mapping

### DIFF
--- a/tasks/yuidoc-to-jsdoc/converter.js
+++ b/tasks/yuidoc-to-jsdoc/converter.js
@@ -177,7 +177,7 @@ function fixup_jsobject_like (rawType) {
 
     if (r.match(/^{([\w$.]+:\s*[\w$.]+,?\s*)+}$/)) {
         r = r.replace(/([\w$.]+):\s*([\w$.]+)(,?\s*)/g, function (m, a, b, c) {
-            if (c) { c = ", " };
+            if (c) { c = ", "; }
             return as_valid_identifier(a) + ": " + as_valid_identifier(b) + c;
         });
         return r;


### PR DESCRIPTION
Fixed bug with incorrect generation of "Array<>".

Added a primitive type-accepter for jsobject-like (for some very primitive
value); but it covers the PIXI case.
