### PR TITLE
fix issue with lineSpacing, no space was added between the lines. The co...

### DIFF
--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -385,7 +385,7 @@ Phaser.Text.prototype.updateText = function () {
     this.canvas.width = width * this.resolution;
     
     //calculate text height
-    var lineHeight = fontProperties.fontSize + this.style.strokeThickness;
+    var lineHeight = fontProperties.fontSize + this.style.strokeThickness + this._lineSpacing;
  
     var height = lineHeight * lines.length;
 
@@ -429,8 +429,6 @@ Phaser.Text.prototype.updateText = function () {
         {
             linePositionX += (maxLineWidth - lineWidths[i]) / 2;
         }
-
-        linePositionY += this._lineSpacing;
 
         if (this.colors.length > 0)
         {


### PR DESCRIPTION
This is a very small fix for an annoying problem.
I'm using the following line to add lineSpacing:
`this.questionText.lineSpacing = 20;`

Then this happens:
![screen shot 2014-11-25 at 16 48 03](https://cloud.githubusercontent.com/assets/951290/5185899/f9967500-74c2-11e4-812f-ddd1f3dc228b.png)
Here the complete text moves 20px down.

This is what should happen (with the fix):
![screen shot 2014-11-25 at 16 48 40](https://cloud.githubusercontent.com/assets/951290/5185900/fc506a08-74c2-11e4-9675-e18eb449e405.png)
Here all lines have the correct lineSpacing of 20px.

Example: http://jsfiddle.net/q4r45cxq/
