### PR TITLE
Event-Signal object count optimization

### DIFF
--- a/src/animation/Animation.js
+++ b/src/animation/Animation.js
@@ -203,7 +203,7 @@ Phaser.Animation.prototype = {
             this._parent.tilingTexture = false;
         }
 
-        this._parent.events.onAnimationStart.dispatch(this._parent, this);
+        this._parent.events.onAnimationStart$dispatch(this._parent, this);
 
         this.onStart.dispatch(this._parent, this);
 
@@ -319,7 +319,7 @@ Phaser.Animation.prototype = {
 
         if (dispatchComplete)
         {
-            this._parent.events.onAnimationComplete.dispatch(this._parent, this);
+            this._parent.events.onAnimationComplete$dispatch(this._parent, this);
             this.onComplete.dispatch(this._parent, this);
         }
 
@@ -393,7 +393,7 @@ Phaser.Animation.prototype = {
                     this._frameIndex %= this._frames.length;
                     this.currentFrame = this._frameData.getFrame(this._frames[this._frameIndex]);
                     this.loopCount++;
-                    this._parent.events.onAnimationLoop.dispatch(this._parent, this);
+                    this._parent.events.onAnimationLoop$dispatch(this._parent, this);
                     this.onLoop.dispatch(this._parent, this);
                 }
                 else
@@ -578,7 +578,7 @@ Phaser.Animation.prototype = {
         this.isFinished = true;
         this.paused = false;
 
-        this._parent.events.onAnimationComplete.dispatch(this._parent, this);
+        this._parent.events.onAnimationComplete$dispatch(this._parent, this);
 
         this.onComplete.dispatch(this._parent, this);
 

--- a/src/animation/AnimationManager.js
+++ b/src/animation/AnimationManager.js
@@ -196,14 +196,6 @@ Phaser.AnimationManager.prototype = {
             }
         }
 
-        //  Create the signals the AnimationManager will emit
-        if (this.sprite.events.onAnimationStart === null)
-        {
-            this.sprite.events.onAnimationStart = new Phaser.Signal();
-            this.sprite.events.onAnimationComplete = new Phaser.Signal();
-            this.sprite.events.onAnimationLoop = new Phaser.Signal();
-        }
-
         this._outputFrames.length = 0;
 
         this._frameData.getFrameIndexes(frames, useNumericIndex, this._outputFrames);

--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -214,7 +214,7 @@ Phaser.Group.prototype.add = function (child, silent) {
 
         if (!silent && child.events)
         {
-            child.events.onAddedToGroup.dispatch(child, this);
+            child.events.onAddedToGroup$dispatch(child, this);
         }
 
         if (this.cursor === null)
@@ -278,7 +278,7 @@ Phaser.Group.prototype.addAt = function (child, index, silent) {
 
         if (!silent && child.events)
         {
-            child.events.onAddedToGroup.dispatch(child, this);
+            child.events.onAddedToGroup$dispatch(child, this);
         }
 
         if (this.cursor === null)
@@ -344,7 +344,7 @@ Phaser.Group.prototype.create = function (x, y, key, frame, exists) {
 
     if (child.events)
     {
-        child.events.onAddedToGroup.dispatch(child, this);
+        child.events.onAddedToGroup$dispatch(child, this);
     }
 
     if (this.cursor === null)
@@ -639,7 +639,7 @@ Phaser.Group.prototype.replace = function (oldChild, newChild) {
     {
         if (newChild.parent !== undefined)
         {
-            newChild.events.onRemovedFromGroup.dispatch(newChild, this);
+            newChild.events.onRemovedFromGroup$dispatch(newChild, this);
             newChild.parent.removeChild(newChild);
 
             if (newChild.parent instanceof Phaser.Group)
@@ -1669,7 +1669,7 @@ Phaser.Group.prototype.remove = function (child, destroy, silent) {
 
     if (!silent && child.events && !child.destroyPhase)
     {
-        child.events.onRemovedFromGroup.dispatch(child, this);
+        child.events.onRemovedFromGroup$dispatch(child, this);
     }
 
     var removed = this.removeChild(child);
@@ -1712,7 +1712,7 @@ Phaser.Group.prototype.removeAll = function (destroy, silent) {
     {
         if (!silent && this.children[0].events)
         {
-            this.children[0].events.onRemovedFromGroup.dispatch(this.children[0], this);
+            this.children[0].events.onRemovedFromGroup$dispatch(this.children[0], this);
         }
 
         var removed = this.removeChild(this.children[0]);
@@ -1759,7 +1759,7 @@ Phaser.Group.prototype.removeBetween = function (startIndex, endIndex, destroy, 
     {
         if (!silent && this.children[i].events)
         {
-            this.children[i].events.onRemovedFromGroup.dispatch(this.children[i], this);
+            this.children[i].events.onRemovedFromGroup$dispatch(this.children[i], this);
         }
 
         var removed = this.removeChild(this.children[i]);

--- a/src/gameobjects/Events.js
+++ b/src/gameobjects/Events.js
@@ -13,11 +13,12 @@
 *
 * Where `yourFunction` is the function you want called when this event occurs.
 *
-* Note that the Input related events only exist if the Sprite has had `inputEnabled` set to `true`.
+* The Input-related events will only be dispatched if the Sprite has had `inputEnabled` set to `true`
+* and the Animation-related events only apply to game objects with animations like {@link Phaser.Sprite}.
 *
 * @class Phaser.Events
 * @constructor
-* @param {Phaser.Sprite} sprite - A reference to the Sprite that owns this Events object.
+* @param {Phaser.Sprite} sprite - A reference to the game object / Sprite that owns this Events object.
 */
 Phaser.Events = function (sprite) {
 
@@ -26,99 +27,7 @@ Phaser.Events = function (sprite) {
     */
     this.parent = sprite;
 
-    /**
-    * @property {Phaser.Signal} onAddedToGroup - This signal is dispatched when the parent is added to a new Group.
-    */
-    this.onAddedToGroup = new Phaser.Signal();
-
-    /**
-    * @property {Phaser.Signal} onRemovedFromGroup - This signal is dispatched when the parent is removed from a Group.
-    */
-    this.onRemovedFromGroup = new Phaser.Signal();
-
-    /**
-    * @property {Phaser.Signal} onRemovedFromWorld - This signal is dispatched if this item or any of its parents are removed from the game world.
-    */
-    this.onRemovedFromWorld = new Phaser.Signal();
-
-    /**
-    * @property {Phaser.Signal} onDestroy - This signal is dispatched when the parent is destoyed.
-    */
-    this.onDestroy = new Phaser.Signal();
-
-    /**
-    * @property {Phaser.Signal} onKilled - This signal is dispatched when the parent is killed.
-    */
-    this.onKilled = new Phaser.Signal();
-
-    /**
-    * @property {Phaser.Signal} onRevived - This signal is dispatched when the parent is revived.
-    */
-    this.onRevived = new Phaser.Signal();
-
-    /**
-    * @property {Phaser.Signal} onOutOfBounds - This signal is dispatched when the parent leaves the world bounds (only if Sprite.checkWorldBounds is true).
-    */
-    this.onOutOfBounds = new Phaser.Signal();
-
-    /**
-    * @property {Phaser.Signal} onEnterBounds - This signal is dispatched when the parent returns within the world bounds (only if Sprite.checkWorldBounds is true).
-    */
-    this.onEnterBounds = new Phaser.Signal();
-
-    /**
-    * @property {Phaser.Signal} onInputOver - This signal is dispatched if the parent is inputEnabled and receives an over event from a Pointer.
-    * @default null
-    */
-    this.onInputOver = null;
-
-    /**
-    * @property {Phaser.Signal} onInputOut - This signal is dispatched if the parent is inputEnabled and receives an out event from a Pointer.
-    * @default null
-    */
-    this.onInputOut = null;
-
-    /**
-    * @property {Phaser.Signal} onInputDown - This signal is dispatched if the parent is inputEnabled and receives a down event from a Pointer.
-    * @default null
-    */
-    this.onInputDown = null;
-
-    /**
-    * @property {Phaser.Signal} onInputUp - This signal is dispatched if the parent is inputEnabled and receives an up event from a Pointer.
-    * @default null
-    */
-    this.onInputUp = null;
-
-    /**
-    * @property {Phaser.Signal} onDragStart - This signal is dispatched if the parent is inputEnabled and receives a drag start event from a Pointer.
-    * @default null
-    */
-    this.onDragStart = null;
-
-    /**
-    * @property {Phaser.Signal} onDragStop - This signal is dispatched if the parent is inputEnabled and receives a drag stop event from a Pointer.
-    * @default null
-    */
-    this.onDragStop = null;
-
-    /**
-    * @property {Phaser.Signal} onAnimationStart - This signal is dispatched when the parent has an animation that is played.
-    * @default null
-    */
-    this.onAnimationStart = null;
-
-    /**
-    * @property {Phaser.Signal} onAnimationComplete - This signal is dispatched when the parent has an animation that finishes playing.
-    * @default null
-    */
-    this.onAnimationComplete = null;
-
-    /**
-    * @property {Phaser.Signal} onAnimationLoop - This signal is dispatched when the parent has an animation that loops playback.
-    * @default null
-    */
-    this.onAnimationLoop = null;
+    // The signals are automatically added by the corresponding proxy properties
 
 };
 
@@ -131,35 +40,147 @@ Phaser.Events.prototype = {
      */
     destroy: function () {
 
-        this.parent = null;
+        this._parent = null;
 
-        this.onDestroy.dispose();
-        this.onAddedToGroup.dispose();
-        this.onRemovedFromGroup.dispose();
-        this.onRemovedFromWorld.dispose();
-        this.onKilled.dispose();
-        this.onRevived.dispose();
-        this.onOutOfBounds.dispose();
+        if (this._onDestroy)           { this._onDestroy.dispose(); }
+        if (this._onAddedToGroup)      { this._onAddedToGroup.dispose(); }
+        if (this._onRemovedFromGroup)  { this._onRemovedFromGroup.dispose(); }
+        if (this._onRemovedFromWorld)  { this._onRemovedFromWorld.dispose(); }
+        if (this._onKilled)            { this._onKilled.dispose(); }
+        if (this._onRevived)           { this._onRevived.dispose(); }
+        if (this._onOutOfBounds)       { this._onOutOfBounds.dispose(); }
 
-        if (this.onInputOver)
-        {
-            this.onInputOver.dispose();
-            this.onInputOut.dispose();
-            this.onInputDown.dispose();
-            this.onInputUp.dispose();
-            this.onDragStart.dispose();
-            this.onDragStop.dispose();
-        }
+        if (this._onInputOver)         { this._onInputOver.dispose(); }
+        if (this._onInputOut)          { this._onInputOut.dispose(); }
+        if (this._onInputDown)         { this._onInputDown.dispose(); }
+        if (this._onInputUp)           { this._onInputUp.dispose(); }
+        if (this._onDragStart)         { this._onDragStart.dispose(); }
+        if (this._onDragStop)          { this._onDragStop.dispose(); }
 
-        if (this.onAnimationStart)
-        {
-            this.onAnimationStart.dispose();
-            this.onAnimationComplete.dispose();
-            this.onAnimationLoop.dispose();
-        }
+        if (this._onAnimationStart)    { this._onAnimationStart.dispose(); }
+        if (this._onAnimationComplete) { this._onAnimationComplete.dispose(); }
+        if (this._onAnimationLoop)     { this._onAnimationLoop.dispose(); }
 
-    }
+    },
+
+    // The following properties are sentinels that will be replaced with getters
+
+    /**
+    * @property {Phaser.Signal} onAddedToGroup - This signal is dispatched when the parent is added to a new Group.
+    */
+    onAddedToGroup: null,
+
+    /**
+    * @property {Phaser.Signal} onRemovedFromGroup - This signal is dispatched when the parent is removed from a Group.
+    */
+    onRemovedFromGroup: null,
+
+    /**
+    * @property {Phaser.Signal} onRemovedFromWorld - This signal is dispatched if this item or any of its parents are removed from the game world.
+    */
+    onRemovedFromWorld: null,
+
+    /**
+    * @property {Phaser.Signal} onDestroy - This signal is dispatched when the parent is destoyed.
+    */
+    onDestroy: null,
+
+    /**
+    * @property {Phaser.Signal} onKilled - This signal is dispatched when the parent is killed.
+    */
+    onKilled: null,
+
+    /**
+    * @property {Phaser.Signal} onRevived - This signal is dispatched when the parent is revived.
+    */
+    onRevived: null,
+
+    /**
+    * @property {Phaser.Signal} onOutOfBounds - This signal is dispatched when the parent leaves the world bounds (only if Sprite.checkWorldBounds is true).
+    */
+    onOutOfBounds: null,
+
+    /**
+    * @property {Phaser.Signal} onEnterBounds - This signal is dispatched when the parent returns within the world bounds (only if Sprite.checkWorldBounds is true).
+    */
+    onEnterBounds: null,
+
+    /**
+    * @property {Phaser.Signal} onInputOver - This signal is dispatched if the parent is inputEnabled and receives an over event from a Pointer.
+    */
+    onInputOver: null,
+
+    /**
+    * @property {Phaser.Signal} onInputOut - This signal is dispatched if the parent is inputEnabled and receives an out event from a Pointer.
+    */
+    onInputOut: null,
+
+    /**
+    * @property {Phaser.Signal} onInputDown - This signal is dispatched if the parent is inputEnabled and receives a down event from a Pointer.
+    */
+    onInputDown: null,
+
+    /**
+    * @property {Phaser.Signal} onInputUp - This signal is dispatched if the parent is inputEnabled and receives an up event from a Pointer.
+    */
+    onInputUp: null,
+
+    /**
+    * @property {Phaser.Signal} onDragStart - This signal is dispatched if the parent is inputEnabled and receives a drag start event from a Pointer.
+    */
+    onDragStart: null,
+
+    /**
+    * @property {Phaser.Signal} onDragStop - This signal is dispatched if the parent is inputEnabled and receives a drag stop event from a Pointer.
+    */
+    onDragStop: null,
+
+    /**
+    * @property {Phaser.Signal} onAnimationStart - This signal is dispatched when the parent has an animation that is played.
+    */
+    onAnimationStart: null,
+
+    /**
+    * @property {Phaser.Signal} onAnimationComplete - This signal is dispatched when the parent has an animation that finishes playing.
+    */
+    onAnimationComplete: null,
+
+    /**
+    * @property {Phaser.Signal} onAnimationLoop - This signal is dispatched when the parent has an animation that loops playback.
+    */
+    onAnimationLoop: null
 
 };
 
 Phaser.Events.prototype.constructor = Phaser.Events;
+
+// Create an auto-create proxy getter and dispatch method for all events.
+// The backing property is the same as the event name, prefixed with '_'
+// and the dispatch method is the same as the event name postfixed with '$dispatch'.
+for (var prop in Phaser.Events.prototype)
+{
+
+    if (!Phaser.Events.prototype.hasOwnProperty(prop) ||
+        prop.indexOf('on') !== 0 ||
+        Phaser.Events.prototype[prop] !== null)
+    {
+        continue;
+    }
+
+    var backing = 'this._' + prop;
+    var dispatch = prop + '$dispatch';
+
+    // `new Function(string)` is ugly but it avoids closures and by-string property lookups.
+    // Since this is a [near] micro-optimization anyway, might as well go all the way.
+    /*jslint evil: true */
+
+    // The accessor creates a new Signal (and so it should only be used from user-code.)
+    Object.defineProperty(Phaser.Events.prototype, prop, {
+        get: new Function("return "+backing+" || ("+backing+" = new Phaser.Signal())")
+    });
+
+    // The dispatcher will only broadcast on an already-defined signal.
+    Phaser.Events.prototype[dispatch] =
+        new Function("return "+backing+" ? "+backing+".dispatch.apply("+backing+", arguments) : null");
+
+}

--- a/src/gameobjects/Image.js
+++ b/src/gameobjects/Image.js
@@ -479,7 +479,7 @@ Phaser.Image.prototype.revive = function() {
 
     if (this.events)
     {
-        this.events.onRevived.dispatch(this);
+        this.events.onRevived$dispatch(this);
     }
 
     return this;
@@ -504,7 +504,7 @@ Phaser.Image.prototype.kill = function() {
 
     if (this.events)
     {
-        this.events.onKilled.dispatch(this);
+        this.events.onKilled$dispatch(this);
     }
 
     return this;
@@ -529,7 +529,7 @@ Phaser.Image.prototype.destroy = function(destroyChildren) {
 
     if (this.events)
     {
-        this.events.onDestroy.dispatch(this);
+        this.events.onDestroy$dispatch(this);
     }
 
     if (this.parent)

--- a/src/gameobjects/Rope.js
+++ b/src/gameobjects/Rope.js
@@ -213,13 +213,13 @@ Phaser.Rope.prototype.preUpdate = function() {
         if (this._cache[5] === 1 && this.game.world.bounds.intersects(this._bounds))
         {
             this._cache[5] = 0;
-            this.events.onEnterBounds.dispatch(this);
+            this.events.onEnterBounds$dispatch(this);
         }
         else if (this._cache[5] === 0 && !this.game.world.bounds.intersects(this._bounds))
         {
             //  The Sprite WAS in the screen, but has now left.
             this._cache[5] = 1;
-            this.events.onOutOfBounds.dispatch(this);
+            this.events.onOutOfBounds$dispatch(this);
         }
     }
 
@@ -415,7 +415,7 @@ Phaser.Rope.prototype.destroy = function(destroyChildren) {
 
     if (this.events)
     {
-        this.events.onDestroy.dispatch(this);
+        this.events.onDestroy$dispatch(this);
     }
 
     if (this.filters)

--- a/src/gameobjects/Sprite.js
+++ b/src/gameobjects/Sprite.js
@@ -289,13 +289,13 @@ Phaser.Sprite.prototype.preUpdate = function() {
             if (this._cache[5] === 1 && this.game.world.bounds.intersects(this._bounds))
             {
                 this._cache[5] = 0;
-                this.events.onEnterBounds.dispatch(this);
+                this.events.onEnterBounds$dispatch(this);
             }
             else if (this._cache[5] === 0 && !this.game.world.bounds.intersects(this._bounds))
             {
                 //  The Sprite WAS in the screen, but has now left.
                 this._cache[5] = 1;
-                this.events.onOutOfBounds.dispatch(this);
+                this.events.onOutOfBounds$dispatch(this);
 
                 if (this.outOfBoundsKill)
                 {
@@ -627,7 +627,7 @@ Phaser.Sprite.prototype.revive = function(health) {
 
     if (this.events)
     {
-        this.events.onRevived.dispatch(this);
+        this.events.onRevived$dispatch(this);
     }
 
     return this;
@@ -652,7 +652,7 @@ Phaser.Sprite.prototype.kill = function() {
 
     if (this.events)
     {
-        this.events.onKilled.dispatch(this);
+        this.events.onKilled$dispatch(this);
     }
 
     return this;
@@ -677,7 +677,7 @@ Phaser.Sprite.prototype.destroy = function(destroyChildren) {
 
     if (this.events)
     {
-        this.events.onDestroy.dispatch(this);
+        this.events.onDestroy$dispatch(this);
     }
 
     if (this.parent)

--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -239,7 +239,7 @@ Phaser.Text.prototype.destroy = function (destroyChildren) {
 
     if (this.events)
     {
-        this.events.onDestroy.dispatch(this);
+        this.events.onDestroy$dispatch(this);
     }
 
     if (this.parent)

--- a/src/gameobjects/TileSprite.js
+++ b/src/gameobjects/TileSprite.js
@@ -219,13 +219,13 @@ Phaser.TileSprite.prototype.preUpdate = function() {
         if (this._cache[5] === 1 && this.game.world.bounds.intersects(this._bounds))
         {
             this._cache[5] = 0;
-            this.events.onEnterBounds.dispatch(this);
+            this.events.onEnterBounds$dispatch(this);
         }
         else if (this._cache[5] === 0 && !this.game.world.bounds.intersects(this._bounds))
         {
             //  The Sprite WAS in the screen, but has now left.
             this._cache[5] = 1;
-            this.events.onOutOfBounds.dispatch(this);
+            this.events.onOutOfBounds$dispatch(this);
         }
     }
 
@@ -448,7 +448,7 @@ Phaser.TileSprite.prototype.destroy = function(destroyChildren) {
 
     if (this.events)
     {
-        this.events.onDestroy.dispatch(this);
+        this.events.onDestroy$dispatch(this);
     }
 
     if (this.filters)

--- a/src/input/InputHandler.js
+++ b/src/input/InputHandler.js
@@ -264,16 +264,6 @@ Phaser.InputHandler.prototype = {
             this.enabled = true;
             this._wasEnabled = true;
 
-            //  Create the signals the Input component will emit
-            if (this.sprite.events && this.sprite.events.onInputOver === null)
-            {
-                this.sprite.events.onInputOver = new Phaser.Signal();
-                this.sprite.events.onInputOut = new Phaser.Signal();
-                this.sprite.events.onInputDown = new Phaser.Signal();
-                this.sprite.events.onInputUp = new Phaser.Signal();
-                this.sprite.events.onDragStart = new Phaser.Signal();
-                this.sprite.events.onDragStop = new Phaser.Signal();
-            }
         }
 
         this.sprite.events.onAddedToGroup.add(this.addedToGroup, this);
@@ -856,7 +846,7 @@ Phaser.InputHandler.prototype = {
 
             if (this.sprite && this.sprite.events)
             {
-                this.sprite.events.onInputOver.dispatch(this.sprite, pointer);
+                this.sprite.events.onInputOver$dispatch(this.sprite, pointer);
             }
         }
 
@@ -889,7 +879,7 @@ Phaser.InputHandler.prototype = {
 
         if (this.sprite && this.sprite.events)
         {
-            this.sprite.events.onInputOut.dispatch(this.sprite, pointer);
+            this.sprite.events.onInputOut$dispatch(this.sprite, pointer);
         }
 
     },
@@ -921,7 +911,7 @@ Phaser.InputHandler.prototype = {
 
             if (this.sprite && this.sprite.events)
             {
-                this.sprite.events.onInputDown.dispatch(this.sprite, pointer);
+                this.sprite.events.onInputDown$dispatch(this.sprite, pointer);
             }
 
             //  It's possible the onInputDown event created a new Sprite that is on-top of this one, so we ought to force a Pointer update
@@ -972,7 +962,7 @@ Phaser.InputHandler.prototype = {
                 //  Release the inputUp signal and provide optional parameter if pointer is still over the sprite or not
                 if (this.sprite && this.sprite.events)
                 {
-                    this.sprite.events.onInputUp.dispatch(this.sprite, pointer, true);
+                    this.sprite.events.onInputUp$dispatch(this.sprite, pointer, true);
                 }
             }
             else
@@ -980,7 +970,7 @@ Phaser.InputHandler.prototype = {
                 //  Release the inputUp signal and provide optional parameter if pointer is still over the sprite or not
                 if (this.sprite && this.sprite.events)
                 {
-                    this.sprite.events.onInputUp.dispatch(this.sprite, pointer, false);
+                    this.sprite.events.onInputUp$dispatch(this.sprite, pointer, false);
                 }
 
                 //  Pointer outside the sprite? Reset the cursor
@@ -1287,7 +1277,7 @@ Phaser.InputHandler.prototype = {
             this.sprite.bringToTop();
         }
 
-        this.sprite.events.onDragStart.dispatch(this.sprite, pointer);
+        this.sprite.events.onDragStart$dispatch(this.sprite, pointer);
 
     },
 
@@ -1351,7 +1341,7 @@ Phaser.InputHandler.prototype = {
             }
         }
 
-        this.sprite.events.onDragStop.dispatch(this.sprite, pointer);
+        this.sprite.events.onDragStop$dispatch(this.sprite, pointer);
 
         if (this.checkPointerOver(pointer) === false)
         {


### PR DESCRIPTION
There are a bunch of signals added for Sprites; more when input is
enabled. However, very few of these signals are ever actually used. While
the previous performance update related to Signals addressed the size of
each Signal object, this update is to reduce the number of Signal objects
as used by the Events type.

As a comparison the "Particle: Random Sprite" demo creates 3200+ Signals;
with this change there less than 70 signals created when running the same
demo. (Each Event creates at 8 signals by default, and there is an Event
for each of the 400 particles.)
A _huge_ amount (of albeit small) object reduction should be expected.

It does this by creating a signal proxy property getter and a signal
dispatch proxy. When the event property (eg. `onEvent`) is accessed a new
Signal object is created (and cached in `_onEvent`) as required. This
ensures that no user code has to perform an existance-check on the event
property first: it just continues to use the signal property as normal.

When the Phaser game code needs to dispatch the event it uses
`event.onEvent$dispath(..)` instead of `event.onEvent.dispatch(..)`. This
special auto-generated method automatically takes care of checking for if
the Signal has been created and only dispatches the event if this is the
case. (If the game code used the `onEvent` property itself the event
deferal approach would be defeated.)

This approach is designed to require minimal changes, not negatively
affect performance, and reduce the number of Signal objects and
corresponding Signal/Event resource usage.

The only known user-code change is that code can add to signal (eg.
onInput) events even when input is not enabled - this will allow some
previously invalid code run without throwing an exception.
