### PR TITLE
Fixes issue with custom Particle from BitmapData

### DIFF
--- a/src/animation/AnimationManager.js
+++ b/src/animation/AnimationManager.js
@@ -536,7 +536,7 @@ Object.defineProperty(Phaser.AnimationManager.prototype, 'frame', {
 
     set: function (value) {
 
-        if (typeof value === 'number' && this._frameData.getFrame(value) !== null)
+        if (typeof value === 'number' && this._frameData && this._frameData.getFrame(value) !== null)
         {
             this.currentFrame = this._frameData.getFrame(value);
 


### PR DESCRIPTION
- Added null/undefined check for this._frameData
- Fixes issue presented when providing a ParticleEmitter with a
  custom Particle class that was introduced sometime after version
  2.0.7 (for examples see: http://examples.phaser.io/_site/view_full.html?d=particles&f=particle+class.js&t=particle%20class)
