### PR TITLE
Fixes #1410 where newChild.parent could be set to undefined before use

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -692,24 +692,23 @@ Phaser.Group.prototype.replace = function (oldChild, newChild) {
 
     if (index !== -1)
     {
-        if (newChild.parent !== undefined)
+        if (newChild.parent)
         {
-            newChild.events.onRemovedFromGroup$dispatch(newChild, this);
-            newChild.parent.removeChild(newChild);
-
             if (newChild.parent instanceof Phaser.Group)
             {
-                newChild.parent.updateZ();
+                newChild.parent.remove(newChild);
+            }
+            else
+            {
+                newChild.parent.removeChild(newChild);
             }
         }
 
-        var temp = oldChild;
-
-        this.remove(temp);
+        this.remove(oldChild);
 
         this.addAt(newChild, index);
 
-        return temp;
+        return oldChild;
     }
 
 };


### PR DESCRIPTION
As pointed out, `newChild.parent` could be accessed after it was set to
undefined. This fix unifies the code from the various `GameObject#destroy` methods so
the previous issue does not occur.
