### PR TITLE
Issue 1413 - allow marker with `Sound.fadeIn`

### DIFF
--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -1,5 +1,4 @@
 /**
-/**
 * @author       Richard Davey <rich@photonstorm.com>
 * @copyright    2014 Photon Storm Ltd.
 * @license      {@link https://github.com/photonstorm/phaser/blob/master/license.txt|MIT License}


### PR DESCRIPTION
`Sound.fadeIn` now accepts a marker as a 3rd parameter. Just as with
`play`, this is where the sound starts at.

This is a minor breaking change; code that was playing from a marker and
then used `fadeIn` expecting to play from the beginning will need to be to
the last parameter explicitly. This does not affect code that always
played a sound from the start.
