### PR TITLE
Corrected link to the Emitter documentation

### DIFF
--- a/resources/docstrap-master/template/tmpl/layout.tmpl
+++ b/resources/docstrap-master/template/tmpl/layout.tmpl
@@ -71,7 +71,7 @@
 						<li class="class-depth-1"><a href="Phaser.Sprite.html">Sprite</a></li>
 						<li class="class-depth-1"><a href="Phaser.Image.html">Image</a></li>
 						<li class="class-depth-1"><a href="Phaser.Sound.html">Sound</a></li>
-						<li class="class-depth-1"><a href="Phaser.Emitter.html">Emitter</a></li>
+						<li class="class-depth-1"><a href="Phaser.Particles.Arcade.Emitter.html">Particle Emitter</a></li>
 						<li class="class-depth-1"><a href="Phaser.Particle.html">Particle</a></li>
 						<li class="class-depth-1"><a href="Phaser.Text.html">Text</a></li>
 						<li class="class-depth-1"><a href="Phaser.Tween.html">Tween</a></li>


### PR DESCRIPTION
The link in the Game Object drop-down was refered to a non-exisnant type.
This also changes it from "Emitter" to "Particle Emiter" for clarity of
intent with Particles.

Ref. #1426 
