### PR TITLE
ScaleManager documentation updates

### DIFF
--- a/src/core/ScaleManager.js
+++ b/src/core/ScaleManager.js
@@ -15,8 +15,8 @@
 * dimenstions of the Display canvas's Parent container/element - the _effective CSS rules of the
 * canvas's Parent element play an important role_ in the operation of the ScaleManager. 
 *
-* The Display canvas - or Game size, depending {@link Phaser.ScaleManager#scaleMode scaleMode} - is updated to best utilize the Parent size.
-* When in Fullscreen mode or with `parentIsWindow` the Parent size is that of the visual viewport (see {@link Phaser.ScaleManager#getParentBounds getParentBounds}).
+* The Display canvas - or Game size, depending {@link #scaleMode} - is updated to best utilize the Parent size.
+* When in Fullscreen mode or with {@link #parentIsWindow} the Parent size is that of the visual viewport (see {@link Phaser.ScaleManager#getParentBounds getParentBounds}).
 *
 * Parent and Display canvas containment guidelines:
 *
@@ -82,8 +82,8 @@ Phaser.ScaleManager = function (game, width, height) {
 
     /**
     * Minimum width the canvas should be scaled to (in pixels).
-    * Change with `setMinMax`.
-    * @property {number} minWidth
+    * Change with {@link #setMinMax}.
+    * @property {?number} minWidth
     * @readonly
     * @protected
     */
@@ -92,8 +92,8 @@ Phaser.ScaleManager = function (game, width, height) {
     /**
     * Maximum width the canvas should be scaled to (in pixels).
     * If null it will scale to whatever width the browser can handle.
-    * Change with `setMinMax`.
-    * @property {number} maxWidth
+    * Change with {@link #setMinMax}.
+    * @property {?number} maxWidth
     * @readonly
     * @protected
     */
@@ -101,8 +101,8 @@ Phaser.ScaleManager = function (game, width, height) {
 
     /**
     * Minimum height the canvas should be scaled to (in pixels).
-    * Change with `setMinMax`.
-    * @property {number} minHeight
+    * Change with {@link #setMinMax}.
+    * @property {?number} minHeight
     * @readonly
     * @protected
     */
@@ -111,8 +111,8 @@ Phaser.ScaleManager = function (game, width, height) {
     /**
     * Maximum height the canvas should be scaled to (in pixels).
     * If null it will scale to whatever height the browser can handle.
-    * Change with `setMinMax`.
-    * @property {number} maxHeight
+    * Change with {@link #setMinMax}.
+    * @property {?number} maxHeight
     * @readonly
     * @protected
     */
@@ -129,7 +129,7 @@ Phaser.ScaleManager = function (game, width, height) {
 
     /**
     * If true, the game should only run in a landscape orientation.
-    * Change with `forceOrientation`.
+    * Change with {@link #forceOrientation}.
     * @property {boolean} forceLandscape
     * @readonly
     * @default
@@ -139,7 +139,7 @@ Phaser.ScaleManager = function (game, width, height) {
 
     /**
     * If true, the game should only run in a portrait 
-    * Change with `forceOrientation`.
+    * Change with {@link #forceOrientation}.
     * @property {boolean} forcePortrait
     * @readonly
     * @default
@@ -148,7 +148,7 @@ Phaser.ScaleManager = function (game, width, height) {
     this.forcePortrait = false;
 
     /**
-    * True if the `forceLandscape` or `forcePortrait` are set and do not agree with the browser orientation.
+    * True if {@link #forceLandscape} or {@link #forcePortrait} are set and do not agree with the browser orientation.
     *
     * This value is not updated immediately.
     *
@@ -159,14 +159,14 @@ Phaser.ScaleManager = function (game, width, height) {
     this.incorrectOrientation = false;
 
     /**
-    * See `pageAlignHorizontally`.
+    * See {@link #pageAlignHorizontally}.
     * @property {boolean} _pageAlignHorizontally
     * @private
     */
     this._pageAlignHorizontally = false;
 
     /**
-    * See `pageAlignVertically`.
+    * See {@link #pageAlignVertically}.
     * @property {boolean} _pageAlignVertically
     * @private
     */
@@ -197,7 +197,7 @@ Phaser.ScaleManager = function (game, width, height) {
     *     // The orientation just became incorrect:
     *     scale.incorrectOrientation && !wasIncorrect
     *
-    * It is possible that this signal is triggered after `forceOrientation` so the orientation
+    * It is possible that this signal is triggered after {@link #forceOrientation} so the orientation
     * correctness changes even if the orientation itself does not change.
     *
     * This is signaled from `preUpdate` (or `pauseUpdate`) _even when_ the game is paused.
@@ -230,7 +230,7 @@ Phaser.ScaleManager = function (game, width, height) {
     this.enterPortrait = new Phaser.Signal();
 
     /**
-    * This signal is dispatched when the browser enters an incorrect orientation, as defined by `forceOrientation`.
+    * This signal is dispatched when the browser enters an incorrect orientation, as defined by {@link #forceOrientation}.
     *
     * This is signaled from `preUpdate` (or `pauseUpdate`) _even when_ the game is paused.
     *
@@ -240,7 +240,7 @@ Phaser.ScaleManager = function (game, width, height) {
     this.enterIncorrectOrientation = new Phaser.Signal();
 
     /**
-    * This signal is dispatched when the browser leaves an incorrect orientation, as defined by `forceOrientation`.
+    * This signal is dispatched when the browser leaves an incorrect orientation, as defined by {@link #forceOrientation}.
     *
     * This is signaled from `preUpdate` (or `pauseUpdate`) _even when_ the game is paused.
     *
@@ -265,8 +265,8 @@ Phaser.ScaleManager = function (game, width, height) {
     this.fullScreenTarget = null;
 
     /**
-    * The fullscreen target, as created by `createFullScreenTarget`.
-    * This is not set if `fullScreenTarget` is used and is cleared when fullscreen mode ends.
+    * The fullscreen target, as created by {@link #createFullScreenTarget}.
+    * This is not set if {@link #fullScreenTarget} is used and is cleared when fullscreen mode ends.
     * @property {?DOMElement} _createdFullScreenTarget
     * @private
     */
@@ -278,12 +278,12 @@ Phaser.ScaleManager = function (game, width, height) {
     *
     * The signal is passed two arguments: `scale` (the ScaleManager), and an object in the form `{targetElement: DOMElement}`.
     *
-    * The `targetElement` is the {@link Phaser.ScaleManager#fullScreenTarget fullScreenTarget} element,
-    * if such is assigned, or a new element created by {@link Phaser.ScaleManager#createFullScreenTarget createFullScreenTarget}.
+    * The `targetElement` is the {@link #fullScreenTarget} element,
+    * if such is assigned, or a new element created by {@link #createFullScreenTarget}.
     *
     * Custom CSS styling or resets can be applied to `targetElement` as required.
     *
-    * If `targetElement` is _not_ the same element as {@link Phaser.ScaleManager.fullScreenTarget}:
+    * If `targetElement` is _not_ the same element as {@link #fullScreenTarget}:
     * - After initialization the Display canvas is moved onto the `targetElement` for
     *   the duration of the fullscreen mode, and restored to it's original DOM location when fullscreen is exited.
     * - The `targetElement` is moved/reparanted within the DOM and may have its CSS styles updated.
@@ -337,7 +337,7 @@ Phaser.ScaleManager = function (game, width, height) {
 
     /**
     * This signal is dispatched when the browser fails to enter fullscreen mode;
-    * or if the device does not support fullscreen mode and `startFullScreen` is invoked.
+    * or if the device does not support fullscreen mode and {@link #startFullScreen} is invoked.
     *
     * @property {Phaser.Signal} fullScreenFailed
     * @public
@@ -428,7 +428,10 @@ Phaser.ScaleManager = function (game, width, height) {
 
     /**
     * Various compatibility settings.
-    * The `(auto)` value indicates the setting is configured based on device and runtime information.
+    * A value of "(auto)" indicates the setting is configured based on device and runtime information.
+    *
+    * A {@link #refresh} may need to be peformed after making changes.
+    *
     * @protected
     * 
     * @property {boolean} [supportsFullscreen=(auto)] - True only if fullscreen support will be used. (Changing to fullscreen still might not work.)
@@ -440,6 +443,7 @@ Phaser.ScaleManager = function (game, width, height) {
     * @property {?Phaser.Point} [scrollTo=(auto)] - If specified the window will be scrolled to this position on every refresh.
     *
     * @property {boolean} [forceMinimumDocumentHeight=false] - If enabled the document elements minimum height is explicity set on updates.
+    *    The height set varies by device and may either be the height of the window or the viewport.
     *
     * @property {boolean} [canExpandParent=true] - If enabled then SHOW_ALL and USER_SCALE modes can try and expand the parent element. It may be necessary for the parent element to impose CSS width/height restrictions.
     *
@@ -473,18 +477,22 @@ Phaser.ScaleManager = function (game, width, height) {
     this._fullScreenScaleMode = Phaser.ScaleManager.NO_SCALE;
 
     /**
-    * If the parent container of the game is the browser window (ie. document.body), rather than a div, this should set to `true`.
+    * If the parent container of the Game canvas is the browser window itself (ie. document.body),
+    * rather than another div, this should set to `true`.
+    *
+    * The {@link #parentNode} property is generally ignored while this is in effect.
+    *
     * @property {boolean} parentIsWindow
-    * @readonly
     */
     this.parentIsWindow = false;
 
     /**
     * The _original_ DOM element for the parent of the Display canvas.
-    * This may be different in fullscreen - see `createFullScreenTarget`.
+    * This may be different in fullscreen - see {@link #createFullScreenTarget}.
+    *
+    * This should only be changed after moving the Game canvas to a different DOM parent.
     *
     * @property {?DOMElement} parentNode
-    * @readonly
     */
     this.parentNode = null;
 
@@ -531,7 +539,7 @@ Phaser.ScaleManager = function (game, width, height) {
     this.onResize = null;
 
     /**
-    * The context in which the `onResize` callback will be called.
+    * The context in which the {@link #onResize} callback will be called.
     * @property {object} onResizeContext
     * @private
     */
@@ -545,7 +553,7 @@ Phaser.ScaleManager = function (game, width, height) {
     this._fullScreenRestore = null;
 
     /**
-    * The _actual_ game dimensions, as initially set or set by `setGameSize`.
+    * The _actual_ game dimensions, as initially set or set by {@link #setGameSize}.
     * @property {Phaser.Rectangle} _gameSize
     * @private
     */
@@ -938,17 +946,17 @@ Phaser.ScaleManager.prototype = {
     /**
     * Sets the callback that will be invoked before sizing calculations.
     *
-    * This is the appropriate place to call `setUserScale` if needing custom dynamic scaling.
+    * This is the appropriate place to call {@link #setUserScale} if needing custom dynamic scaling.
     *
     * The callback is supplied with two arguments `scale` and `parentBounds` where `scale` is the ScaleManager
     * and `parentBounds`, a Phaser.Rectangle, is the size of the Parent element.
     *
     * This callback
     * - May be invoked even though the parent container or canvas sizes have not changed
-    * - Unlike `onSizeChange`, it runs _before_ the canvas is guaranteed to be updated
+    * - Unlike {@link #onSizeChange}, it runs _before_ the canvas is guaranteed to be updated
     * - Will be invoked from `preUpdate`, _even when_ the game is paused    
     *
-    * See `onSizeChange` for a better way of reacting to layout updates.
+    * See {@link #onSizeChange} for a better way of reacting to layout updates.
     * 
     * @method Phaser.ScaleManager#setResizeCallback
     * @public
@@ -965,7 +973,7 @@ Phaser.ScaleManager.prototype = {
     /**
     * Signals a resize - IF the canvas or Game size differs from the last signal.
     *
-    * This also triggers updates on `grid` (FlexGrid) and, if in a RESIZE mode, `game.state` (StateManager).
+    * This also triggers updates on {@link #grid} (FlexGrid) and, if in a RESIZE mode, `game.state` (StateManager).
     *
     * @method Phaser.ScaleMager#signalSizeChange
     * @private
@@ -1131,7 +1139,7 @@ Phaser.ScaleManager.prototype = {
 
     /**
     * Update relevant scaling values based on the ScaleManager dimension and game dimensions,
-    * which should already be set. This does not change `sourceAspectRatio`.
+    * which should already be set. This does not change {@link #sourceAspectRatio}.
     * 
     * @method Phaser.ScaleManager#updateScalingAndBounds
     * @private
@@ -1308,18 +1316,19 @@ Phaser.ScaleManager.prototype = {
     },
 
     /**
-    * The `refresh` methods informs the ScaleManager that a layout refresh is required.
+    * The "refresh" methods informs the ScaleManager that a layout refresh is required.
     *
     * The ScaleManager automatically queues a layout refresh (eg. updates the Game size or Display canvas layout)
     * when the browser is resized, the orientation changes, or when there is a detected change
     * of the Parent size. Refreshing is also done automatically when public properties,
-    * such as `scaleMode`, are updated or state-changing methods are invoked.
+    * such as {@link #scaleMode}, are updated or state-changing methods are invoked.
     *
-    * The `refresh` method _may_ need to be used in a few (rare) situtations when
+    * The "refresh" method _may_ need to be used in a few (rare) situtations when
     *
     * - a device change event is not correctly detected; or
     * - the Parent size changes (and an immediate reflow is desired); or
-    * - the ScaleManager state is updated by non-standard means.
+    * - the ScaleManager state is updated by non-standard means; or
+    * - certain {@link #compatibility} properties are manually changed.
     *
     * The queued layout refresh is not immediate but will run promptly in an upcoming `preRender`.
     * 
@@ -1416,10 +1425,10 @@ Phaser.ScaleManager.prototype = {
     /**
     * Returns the computed Parent size/bounds that the Display canvas is allowed/expected to fill.
     *
-    * If in fullscreen mode or without parent (see {@link Phaser.ScaleManager#parentIsWindow parentIsWindow}),
+    * If in fullscreen mode or without parent (see {@link #parentIsWindow}),
     * this will be the bounds of the visual viewport itself.
     *
-    * This function takes the `windowConstraints` into consideration - if the parent is partially outside
+    * This function takes the {@link #windowConstraints} into consideration - if the parent is partially outside
     * the viewport then this function may return a smaller than expected size.
     *
     * Values are rounded to the nearest pixel.
@@ -1702,7 +1711,7 @@ Phaser.ScaleManager.prototype = {
 
     /**
     * Updates the width/height such that the game is stretched to the available size.
-    * Honors `maxWidth` and `maxHeight` when _not_ in fullscreen.
+    * Honors {@link #maxWidth} and {@link #maxHeight} when _not_ in fullscreen.
     *
     * @method Phaser.ScaleManager#setExactFit
     * @private
@@ -1734,9 +1743,9 @@ Phaser.ScaleManager.prototype = {
 
     /**
     * Creates a fullscreen target. This is called automatically as as needed when entering
-    * fullscreen mode and the resulting element is supplied to `onFullScreenInit`.
+    * fullscreen mode and the resulting element is supplied to {@link #onFullScreenInit}.
     *
-    * Use {@link Phaser.ScaleManager#onFullScreenInit onFullScreenInit} to customize the created object.
+    * Use {@link #onFullScreenInit} to customize the created object.
     *
     * @method Phaser.ScaleManager#createFullScreenTarget
     * @protected
@@ -1757,10 +1766,10 @@ Phaser.ScaleManager.prototype = {
     * Start the browsers fullscreen mode - this _must_ be called from a user input Pointer or Mouse event.
     *
     * The Fullscreen API must be supported by the browser for this to work - it is not the same as setting
-    * the game size to fill the browser window. See `compatibility.supportsFullScreen` to check if the current
+    * the game size to fill the browser window. See {@link Phaser.ScaleManager#compatibility compatibility.supportsFullScreen} to check if the current
     * device is reported to support fullscreen mode.
     *
-    * The `fullScreenFailed` signal will be dispatched if the fullscreen change request failed or the game does not support the Fullscreen API.
+    * The {@link #fullScreenFailed} signal will be dispatched if the fullscreen change request failed or the game does not support the Fullscreen API.
     *
     * @method Phaser.ScaleManager#startFullScreen
     * @public
@@ -2133,7 +2142,8 @@ Phaser.ScaleManager.prototype.setScreenSize = Phaser.ScaleManager.prototype.upda
 Phaser.ScaleManager.prototype.setSize = Phaser.ScaleManager.prototype.reflowCanvas;
 
 /**
-* Checks if the browser is in the correct orientation for the game, dependent upon `forceLandscape` and `forcePortrait`, and updates the state.
+* Checks if the browser is in the correct orientation for the game,
+* dependent upon {@link #forceLandscape} and {@link #forcePortrait}, and updates the state.
 *
 * The appropriate event is dispatched if the orientation became valid or invalid.
 * 
@@ -2157,7 +2167,7 @@ Phaser.ScaleManager.prototype.checkOrientationState = function () {
 /**
 * The DOM element that is considered the Parent bounding element, if any.
 *
-* This `null` if `parentIsWindow` is true or if fullscreen mode is entered and `fullScreenTarget` is specified.
+* This `null` if {@link #parentIsWindow} is true or if fullscreen mode is entered and {@link #fullScreenTarget} is specified.
 * It will also be null if there is no game canvas or if the game canvas has no parent.
 *
 * @name Phaser.ScaleManager#boundingParent
@@ -2202,7 +2212,7 @@ Object.defineProperty(Phaser.ScaleManager.prototype, "boundingParent", {
 *       The dimensions of the game display area are changed to match the size of the parent container.
 *       That is, this mode _changes the Game size_ to match the display size.
 *       <p>
-*       Any manually set Game size (see `setGameSize`) is ignored while in effect.
+*       Any manually set Game size (see {@link #setGameSize}) is ignored while in effect.
 *   </dd>
 *   <dt>{@link Phaser.ScaleManager.USER_SCALE}</dt>
 *   <dd>
@@ -2305,12 +2315,12 @@ Object.defineProperty(Phaser.ScaleManager.prototype, "currentScaleMode", {
 });
 
 /**
-* If true then the Display canvas will be horizontally-aligned _in the parent container_.
+* When enabled the Display canvas will be horizontally-aligned _in the Parent container_ (or {@link Phaser.ScaleManager#parentIsWindow window}).
 *
-* To align across the page the Display canvas should be added directly to page;
-* or the parent container should itself be aligned.
+* To align horizontally across the page the Display canvas should be added directly to page;
+* or the parent container should itself be horizontally aligned.
 *
-* This is not applicable for the `RESIZE` scaling mode.
+* Horizontal alignment is not applicable with the {@link .RESIZE} scaling mode.
 *
 * @name Phaser.ScaleManager#pageAlignHorizontally
 * @property {boolean} pageAlignHorizontally
@@ -2337,12 +2347,19 @@ Object.defineProperty(Phaser.ScaleManager.prototype, "pageAlignHorizontally", {
 });
 
 /**
-* If true then the Display canvas will be vertically-aligned _in the parent container_.
+* When enabled the Display canvas will be vertically-aligned _in the Parent container_ (or {@link Phaser.ScaleManager#parentIsWindow window}).
 *
-* To align across the page the Display canvas should be added directly to page;
-* or the parent container should itself be aligned.
+* To align vertically the Parent element should have a _non-collapsible_ height, such that it will maintain
+* a height _larger_ than the height of the contained Game canvas - the game canvas will then be scaled vertically
+* _within_ the remaining available height dictated by the Parent element.
 *
-* This is not applicable for the `RESIZE` scaling mode.
+* One way to prevent the parent from collapsing is to add an absolute "min-height" CSS property to the parent element.
+* If specifying a relative "min-height/height" or adjusting margins, the Parent height must still be non-collapsible (see note).
+*
+* _Note_: In version 2.2 the minimum document height is _not_ automatically set to the viewport/window height.
+* To automatically update the minimum document height set {@link Phaser.ScaleManager#compatibility compatibility.forceMinimumDocumentHeight} to true.
+*
+* Vertical alignment is not applicable with the {@link .RESIZE} scaling mode.
 *
 * @name Phaser.ScaleManager#pageAlignVertically
 * @property {boolean} pageAlignVertically
@@ -2420,7 +2437,7 @@ Object.defineProperty(Phaser.ScaleManager.prototype, "isLandscape", {
 * @name Phaser.ScaleManager#orientation
 * @property {integer} orientation
 * @readonly
-* @deprecated 2.2.0 - Use `ScaleManager.screenOrientation` instead.
+* @deprecated 2.2.0 - Use {@link #screenOrientation} instead.
 */
 Object.defineProperty(Phaser.ScaleManager.prototype, "orientation", {
 


### PR DESCRIPTION
- Clarified proper usage of `pageAlignVertically` and add note about 2.2
  change and how to obtain 2.1 behavior.
- Removed the `@readonly` status of the `parentIsWindow` and `parentNode`;
  these can be updated in a controlled manner.
- Added intra-hyperlinks
- Updated some ancillary documentation

Ref. https://github.com/photonstorm/phaser/issues/1422
