### PR TITLE
DOM.visualBounds now includes scrollbars

### DIFF
--- a/src/system/DOM.js
+++ b/src/system/DOM.js
@@ -336,11 +336,13 @@ Phaser.Device.whenReady(function (device) {
     if (treatAsDesktop)
     {
 
+        // PST- When scrollbars are not included this causes upstream issues in ScaleManager.
+        // So reverted to the old "include scrollbars."
         var clientWidth = function () {
-            return document.documentElement.clientWidth;
+            return Math.max(window.innerWidth, document.documentElement.clientWidth);
         };
         var clientHeight = function () {
-            return document.documentElement.clientHeight;
+            return Math.max(window.innerHeight, document.documentElement.clientHeight);
         };
 
         // Interested in area sans-scrollbar


### PR DESCRIPTION
- While not ideal this fixes most (if not all) of the ScaleManager issue
  pointed out in #1400. This issue should be addressed later. As of now,
  as an interim fix, this avoids the reported issue entirely (or at least
  I have not been able to reproduce it), as well as assorted artifacts
  when resizign a window while scaling.
- The is is the 2.1 behavior: In certain cases this can result in the
  right or bottom of the Game being cut-off slightly (the width of a
  scrollbar) instead of scaled, which is why it was originally changed.
