### PR TITLE
TilemapParser: fixed check for image collection

### DIFF
--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -321,7 +321,7 @@ Phaser.TilemapParser = {
             //  name, firstgid, width, height, margin, spacing, properties
             var set = json.tilesets[i];
 
-            if (!set.tiles)
+            if (set.image)
             {
                 var newSet = new Phaser.Tileset(set.name, set.firstgid, set.tilewidth, set.tileheight, set.margin, set.spacing, set.properties);
 


### PR DESCRIPTION
Hi, here is a clean request for the tiny fix to the JSON parser.  For the record, this prevents a tilesheet tileset containing additional information in the `tiles` sub node from failing to load.
