### PR TITLE
Update Camera.js

### DIFF
--- a/src/core/Camera.js
+++ b/src/core/Camera.js
@@ -74,7 +74,7 @@ Phaser.Camera = function (game, id, x, y, width, height) {
     * @property {boolean} roundPx - If a Camera has roundPx set to `true` it will call `view.floor` as part of its update loop, keeping its boundary to integer values. Set this to `false` to disable this from happening.
     * @default
     */
-    this.roundPx = true;
+    this.roundPx = false;
 
     /**
     * @property {boolean} atLimit - Whether this camera is flush with the World Bounds or not.


### PR DESCRIPTION
Set default Camera.roundPx value to false, in order to prevent almost-1-px jitter  (Pixi does subpixel rendering on (almost?) everything else in Phaser, so rounding here is not okay). 

@ next cleanup: remove this bool completely if there's no problems with the new default value.

This should solve issue #1377  and is how issue #1141 was supposed to be solved

Only caveat: this may have undesired side effects in some situations, as I dont know why this rounding was added in the first place..