### PR TITLE
RandomDataGenerator seeding fix

### DIFF
--- a/src/math/RandomDataGenerator.js
+++ b/src/math/RandomDataGenerator.js
@@ -8,8 +8,13 @@
 
 /**
 * An extremely useful repeatable random data generator.
+*
 * Based on Nonsense by Josh Faul https://github.com/jocafa/Nonsense.
-* Random number generator from http://baagoe.org/en/wiki/Better_random_numbers_for_javascript
+*
+* The random number genererator is based on the Alea PRNG, but is modified.
+*  - https://github.com/coverslide/node-alea
+*  - https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
+*  - http://baagoe.org/en/wiki/Better_random_numbers_for_javascript (original, perm. 404)
 *
 * @class Phaser.RandomDataGenerator
 * @constructor
@@ -71,22 +76,29 @@ Phaser.RandomDataGenerator.prototype = {
     /**
     * Reset the seed of the random data generator.
     *
+    * _Note_: the seed array is only processed up to the first `undefined` (or `null`) value, should such be present.
+    *
     * @method Phaser.RandomDataGenerator#sow
-    * @param {any[]} seeds
+    * @param {any[]} seeds - The array of seeds: the `toString()` of each value is used.
     */
     sow: function (seeds) {
 
-        if (typeof seeds === "undefined") { seeds = []; }
-
+        // Always reset to default seed
         this.s0 = this.hash(' ');
         this.s1 = this.hash(this.s0);
         this.s2 = this.hash(this.s1);
         this.c = 1;
 
-        var seed;
-
-        for (var i = 0; seed = seeds[i++]; )
+        if (!seeds)
         {
+            return;
+        }
+
+        // Apply any seeds
+        for (var i = 0; i < seeds.length && (seeds[i] != null); i++)
+        {
+            var seed = seeds[i];
+
             this.s0 -= this.hash(seed);
             this.s0 += ~~(this.s0 < 0);
             this.s1 -= this.hash(seed);


### PR DESCRIPTION
Per https://github.com/photonstorm/phaser/issues/1456 the `sow` function
terminates too early on certain false-y values including 0 (and possibly
"").

This changes that, so that 1) only `undefined` and `null` will terminate
the seed sequence processing (this is to maximize backwards compatibility)
and 2) the `length` of the array is honored.

The documentation also reflects the old (and new/altered) behavior.

This is very minor breaking change; hopefully such is mitigated with
leaving in the null/undefined termination.
