### PR TITLE
Remove unused "tolerance" arg in Rectangle.js.

### DIFF
--- a/src/geom/Rectangle.js
+++ b/src/geom/Rectangle.js
@@ -277,12 +277,11 @@ Phaser.Rectangle.prototype = {
     * This method checks the x, y, width, and height properties of the Rectangles.
     * @method Phaser.Rectangle#intersects
     * @param {Phaser.Rectangle} b - The second Rectangle object.
-    * @param {number} tolerance - A tolerance value to allow for an intersection test with padding, default to 0.
     * @return {boolean} A value of true if the specified object intersects with this Rectangle object; otherwise false.
     */
-    intersects: function (b, tolerance) {
+    intersects: function (b) {
 
-        return Phaser.Rectangle.intersects(this, b, tolerance);
+        return Phaser.Rectangle.intersects(this, b);
 
     },
 


### PR DESCRIPTION
The instance method for `Rectangle::intersects` delegates to the static method/function `Phaser.Rectangle.intersects`. However, the former takes a `tolerance` argument, while the latter doesn't, which means that the argument does nothing, so remove it.

It seems #290 was a similar kind of problem.
