### PR TITLE
Wrapped play() calls to "fix" IE Windows Phone random crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Android browser does not support Full Screen.
 * The RandomDataGenerator could be seeded with an array of values. However if the array contained a zero it would stop seeding from that point (thanks @jpcloud @pnstickne #1456)
 * Added extra checks to Sound.play to stop it throwing DOM Exception Error 11 if the `sound.readyState` wasn't set or the sound was invalid. Also wrapped `stop()`` call in a `try catch`.
 * Time.reset would incorrectly reset the `_started` property, now maps it to `Time.time` (thanks @XekeDeath #1467)
+* Wrapped `play()`` calls in a `try catch` when not using webAudio, IE on Windows Phone throws randomly `Unexpected call or property access`
 
 ### Pixi.js 2.2.0 Updates
 

--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -610,7 +610,11 @@ Phaser.Sound.prototype = {
             {
                 if (this._sound && (this.game.device.cocoonJS || this._sound.readyState === 4))
                 {
-                    this._sound.play();
+                    try {
+                        this._sound.play();
+                    }
+                    catch (e) {
+                    }
                     //  This doesn't become available until you call play(), wonderful ...
                     this.totalDuration = this._sound.duration;
 
@@ -729,7 +733,11 @@ Phaser.Sound.prototype = {
             }
             else
             {
-                this._sound.play();
+                try {
+                    this._sound.play();
+                }
+                catch (e) {
+                }
             }
 
             this.isPlaying = true;
@@ -768,7 +776,11 @@ Phaser.Sound.prototype = {
             }
             else if (this.usingAudioTag)
             {
-                this._sound.pause();
+                try {
+                    this._sound.pause();
+                }
+                catch (e) {
+                }
                 this._sound.currentTime = 0;
             }
         }
@@ -831,7 +843,7 @@ Phaser.Sound.prototype = {
 
     /**
      * Fades the volume of this Sound from its current value to the given volume over the duration specified.
-     * At the end of the fade Sound.onFadeComplete is dispatched with this Sound object as the first parameter, 
+     * At the end of the fade Sound.onFadeComplete is dispatched with this Sound object as the first parameter,
      * and the final volume (volume) as the second parameter.
      *
      * @method Phaser.Sound#fadeTo


### PR DESCRIPTION
Wrapped play() calls to "fix" IE Windows Phone random "Unexpected call or property access" crashes.

The play() calls may fail even if using proper audio formats and html !DOCTYPE html.