### PR TITLE
Fix floating point inaccuracy in edge cases, behavior not consistent

### DIFF
--- a/src/tween/Easing.js
+++ b/src/tween/Easing.js
@@ -247,6 +247,8 @@ Phaser.Easing = {
         */
         In: function ( k ) {
 
+            if (k === 0) return 0;
+            if (k === 1) return 1;
             return 1 - Math.cos( k * Math.PI / 2 );
 
         },
@@ -260,6 +262,8 @@ Phaser.Easing = {
         */
         Out: function ( k ) {
 
+            if (k === 0) return 0;
+            if (k === 1) return 1;
             return Math.sin( k * Math.PI / 2 );
 
         },
@@ -273,6 +277,8 @@ Phaser.Easing = {
         */
         InOut: function ( k ) {
 
+            if (k === 0) return 0;
+            if (k === 1) return 1;
             return 0.5 * ( 1 - Math.cos( Math.PI * k ) );
 
         }


### PR DESCRIPTION
Inaccuracy in Math functions may cause ie. Tweens not to get to the end values properly if using cos/sin based Easings. Especially it happens that Math.cos( 1 \* Math.PI / 2) != 0 on Desktop Chrome OSX, but on Android Chrome result is correct. Possibly difference in floating point accuracy and Math.PI approx value.
