### PR TITLE
Simplified call to updateTransform - unified and verified fix for 1424

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -301,12 +301,6 @@ Phaser.Game = function (width, height, renderer, parent, state, transparent, ant
     this._codePaused = false;
 
     /**
-    * @property {boolean} _updateTransform - Was Stage.updateTransform called in updateLogic or skipped?
-    * @private
-    */
-    this._updateTransform = false;
-
-    /**
     * The ID of the current/last logic update applied this render frame, starting from 0.
     *
     * The first update is `currentUpdateID === 0` and the last update is `currentUpdateID === updatesThisFrame.`
@@ -711,8 +705,6 @@ Phaser.Game.prototype = {
 
         this.time.update(time);
 
-        this._updateTransform = false;
-
         // if the logic time is spiraling upwards, skip a frame entirely
         if (this._spiralling > 1 && !this.forceSingleUpdate)
         {
@@ -756,7 +748,11 @@ Phaser.Game.prototype = {
             {
                 this._deltaTime -= slowStep;
                 this.currentUpdateID = count;
+
                 this.updateLogic(1.0 / this.time.desiredFps);
+                //  Sync the scene graph after _every_ logic update to account for moved game objects                
+                this.stage.updateTransform();
+
                 count++;
 
                 if (this.forceSingleUpdate && count === 1)
@@ -827,10 +823,6 @@ Phaser.Game.prototype = {
             this.state.pauseUpdate();
             this.debug.preUpdate();
         }
-
-        //  We do this regardless to avoid physics issues
-        this.stage.updateTransform();
-        this._updateTransform = true;
 
     },
 

--- a/src/core/Stage.js
+++ b/src/core/Stage.js
@@ -199,11 +199,6 @@ Phaser.Stage.prototype.postUpdate = function () {
 */
 Phaser.Stage.prototype.updateTransform = function () {
 
-    if (this.game._updateTransform)
-    {
-        return;
-    }
-
     this.worldAlpha = 1;
 
     for (var i = 0, j = this.children.length; i < j; i++)


### PR DESCRIPTION
This change implements the original suggestion of using `updateTransform`,
but applies so globally instead of within a particular postUpdate
function.

Now the game loop calls `updateTransform` after each `updateLogic` call
unconditionally; it is updates that change the world that are accounted
for, not the rendering. This removes some previous checks that were
preventing correct behavior with the previous patch.

This makes the assumption that game objects (eg. Sprites) are only
modified within callbacks triggered before the completion of the
`postUpdate` walking of the scene graph.
- User code that runs outside of the "game update", such as a `setTimeout`
  timer, will need to explicitly update transformations so that the world
  is synced by the next `preUpdate`: but this is not the expected case and
  is already outside the Phaser update model.
- If this assumption does not hold or is too weak, the transformations
  could also be applied once at the start of every game update loop
  (before any render or update). This change would at most double the time
  spent on apply the transformations.

The consistent root application of `updateTransform` passes all reported failing
cases and resolves #1424 just as the original proposal of having the
change performed in the Sprite postUpdate but will work more consistently
across all scene-bound game objects by descending the entire graph for all types.

On a desktop Chrome browser the inclusion also has minimal relative impact
as shown by the summarized results. The percentages given are the summed
CPU time of relevant required operations along with that of the
updateTransform itself:

- 10,000 non-collision particles:
  - 12% pre/post update, 2.4% updateTransform
- 100 colliding particles:
  - 2% pre/post update & collision, 0.3% updateTransform
- 1000 colliding particles:
  - 40% pre/post update & collision, 1% updateTransform

With this update the time is still dominated by required game
updates, and more so, by any actual work like Physics.