### PR TITLE
Patch to fix a compatibility problem between Opal and Phaser for opal-phaser

### DIFF
--- a/src/animation/AnimationParser.js
+++ b/src/animation/AnimationParser.js
@@ -190,39 +190,41 @@ Phaser.AnimationParser = {
 
         for (var key in frames)
         {
-            var uuid = game.rnd.uuid();
+            if (frames.hasOwnProperty(key)) {
+                var uuid = game.rnd.uuid();
 
-            newFrame = data.addFrame(new Phaser.Frame(
-                i,
-                frames[key].frame.x,
-                frames[key].frame.y,
-                frames[key].frame.w,
-                frames[key].frame.h,
-                key,
-                uuid
-            ));
+                newFrame = data.addFrame(new Phaser.Frame(
+                    i,
+                    frames[key].frame.x,
+                    frames[key].frame.y,
+                    frames[key].frame.w,
+                    frames[key].frame.h,
+                    key,
+                    uuid
+                ));
 
-            PIXI.TextureCache[uuid] = new PIXI.Texture(PIXI.BaseTextureCache[cacheKey], {
-                x: frames[key].frame.x,
-                y: frames[key].frame.y,
-                width: frames[key].frame.w,
-                height: frames[key].frame.h
-            });
+                PIXI.TextureCache[uuid] = new PIXI.Texture(PIXI.BaseTextureCache[cacheKey], {
+                    x: frames[key].frame.x,
+                    y: frames[key].frame.y,
+                    width: frames[key].frame.w,
+                    height: frames[key].frame.h
+                });
 
-            if (frames[key].trimmed)
-            {
-                newFrame.setTrim(
-                    frames[key].trimmed,
-                    frames[key].sourceSize.w,
-                    frames[key].sourceSize.h,
-                    frames[key].spriteSourceSize.x,
-                    frames[key].spriteSourceSize.y,
-                    frames[key].spriteSourceSize.w,
-                    frames[key].spriteSourceSize.h
-                );
+                if (frames[key].trimmed)
+                {
+                    newFrame.setTrim(
+                        frames[key].trimmed,
+                        frames[key].sourceSize.w,
+                        frames[key].sourceSize.h,
+                        frames[key].spriteSourceSize.x,
+                        frames[key].spriteSourceSize.y,
+                        frames[key].spriteSourceSize.w,
+                        frames[key].spriteSourceSize.h
+                    );
+                }
+
+                i++;
             }
-
-            i++;
         }
 
         return data;


### PR DESCRIPTION
I'm working on an Opal wrapper for Phaser, to allow folks to write Phaser games entirely from Ruby code, and I ran into a problem trying to replicate a Phaser Example. I was working with the `atlasJSONHash` loader method, and there was an error coming from AnimationParser.js, due to something that Opal wasn't doing quite right. Phaser was iterating through a `frames` object (for JSON frames), with `for (var key in frames)`, but as Opal had something inside the object, it tried to add a frame for the "OpalClass".

A friend of mine created an issue about this on the Opal repository: https://github.com/opal/opal/issues/680
Fortunately, the creator of Opal came up with a solution that fixed this problem. I was hoping my change could get merged with Phaser, as I don't see it causing any problems.