### PR TITLE
Fixed wheelDelta type on Typescript definition file

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2136,7 +2136,7 @@ declare module Phaser {
         _wheelEvent: WheelEventProxy;
         pointerLock: Phaser.Signal;
         stopOnGameOut: boolean;
-        wheelDelta: WheelEventProxy;
+        wheelDelta: number;
 
         onMouseDown(event: MouseEvent): void;
         onMouseMove(event: MouseEvent): void;


### PR DESCRIPTION
Changed type `WheelEventProxy` to `number` for property `wheelDelta` in `phaser.d.ts` as specified in the Phaser Documentation: http://docs.phaser.io/Phaser.Mouse.html#wheelDelta