### PR TITLE
Fix CORS loading BitmapFonts with IE9

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1466,7 +1466,7 @@ Phaser.Loader.prototype = {
         file.loaded = true;
 
         var loadNext = true;
-        var _this = this
+        var _this = this;
 
         switch (file.type)
         {
@@ -1735,7 +1735,7 @@ Phaser.Loader.prototype = {
             console.warn('Invalid XML Response Type', this._fileList[index]);
             console.warn(this._ajax);
           }
-          data = this._ajax.responseText
+          data = this._ajax.responseText;
         }
         else if (this._xhr && this._xhr.responseText)
         {

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1466,7 +1466,7 @@ Phaser.Loader.prototype = {
         file.loaded = true;
 
         var loadNext = true;
-        var _this = this;
+        var _this = this
 
         switch (file.type)
         {
@@ -1519,38 +1519,38 @@ Phaser.Loader.prototype = {
 
                     if (this.useXDomainRequest && window.XDomainRequest)
                     {
-                      this._ajax = new window.XDomainRequest();
+                        this._ajax = new window.XDomainRequest();
 
-                      // XDomainRequest has a few quirks. Occasionally it will abort requests
-                      // A way to avoid this is to make sure ALL callbacks are set even if not used
-                      // More info here: http://stackoverflow.com/questions/15786966/xdomainrequest-aborts-post-on-ie-9
-                      this._ajax.timeout = 3000;
+                        // XDomainRequest has a few quirks. Occasionally it will abort requests
+                        // A way to avoid this is to make sure ALL callbacks are set even if not used
+                        // More info here: http://stackoverflow.com/questions/15786966/xdomainrequest-aborts-post-on-ie-9
+                        this._ajax.timeout = 3000;
 
-                      this._ajax.onerror = function () {
-                        return _this.dataLoadError(_this._fileIndex);
-                      };
+                        this._ajax.onerror = function () {
+                            return _this.dataLoadError(_this._fileIndex);
+                        };
 
-                      this._ajax.ontimeout = function () {
-                        return _this.dataLoadError(_this._fileIndex);
-                      };
+                        this._ajax.ontimeout = function () {
+                            return _this.dataLoadError(_this._fileIndex);
+                        };
 
-                      this._ajax.onprogress = function() {};
+                        this._ajax.onprogress = function() {};
 
-                      this._ajax.onload = function(){
-                        return _this.xmlLoadComplete(_this._fileIndex);
-                      };
+                        this._ajax.onload = function(){
+                            return _this.xmlLoadComplete(_this._fileIndex);
+                        };
 
-                      this._ajax.open('GET', this.baseURL + file.xmlURL, true);
+                        this._ajax.open('GET', this.baseURL + file.xmlURL, true);
 
-                      //  Note: The xdr.send() call is wrapped in a timeout to prevent an issue with the interface where some requests are lost
-                      //  if multiple XDomainRequests are being sent at the same time.
-                      setTimeout(function () {
-                        _this._ajax.send();
-                      }, 0);
+                        //  Note: The xdr.send() call is wrapped in a timeout to prevent an issue with the interface where some requests are lost
+                        //  if multiple XDomainRequests are being sent at the same time.
+                        setTimeout(function () {
+                            _this._ajax.send();
+                        }, 0);
                     }
                     else
                     {
-                      this.xhrLoad(this._fileIndex, this.baseURL + file.xmlURL, 'text', 'xmlLoadComplete', 'dataLoadError');
+                        this.xhrLoad(this._fileIndex, this.baseURL + file.xmlURL, 'text', 'xmlLoadComplete', 'dataLoadError');
                     }
                 }
                 break;
@@ -1728,23 +1728,21 @@ Phaser.Loader.prototype = {
     xmlLoadComplete: function (index) {
         var data;
 
-        if (this._ajax && this._ajax.responseText)
-        {
-          if (this._ajax.contentType !== '' && this._ajax.contentType !== 'text/plain')
-          {
-            console.warn('Invalid XML Response Type', this._fileList[index]);
-            console.warn(this._ajax);
-          }
-          data = this._ajax.responseText;
+        if (this._ajax && this._ajax.responseText) {
+            if (this._ajax.contentType !== '' && this._ajax.contentType !== 'text/plain')
+            {
+                console.warn('Invalid XML Response Type', this._fileList[index]);
+                console.warn(this._ajax);
+            }
+            data = this._ajax.responseText
         }
-        else if (this._xhr && this._xhr.responseText)
-        {
-          if (this._xhr.responseType !== '' && this._xhr.responseType !== 'text')
-          {
-              console.warn('Invalid XML Response Type', this._fileList[index]);
-              console.warn(this._xhr);
-          }
-          data = this._xhr.responseText;
+        else if (this._xhr && this._xhr.responseText) {
+            if (this._xhr.responseType !== '' && this._xhr.responseType !== 'text')
+            {
+                console.warn('Invalid XML Response Type', this._fileList[index]);
+                console.warn(this._xhr);
+            }
+            data = this._xhr.responseText;
         }
 
         var xml;

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1466,7 +1466,7 @@ Phaser.Loader.prototype = {
         file.loaded = true;
 
         var loadNext = true;
-        var _this = this
+        var _this = this;
 
         switch (file.type)
         {
@@ -1734,7 +1734,7 @@ Phaser.Loader.prototype = {
                 console.warn('Invalid XML Response Type', this._fileList[index]);
                 console.warn(this._ajax);
             }
-            data = this._ajax.responseText
+            data = this._ajax.responseText;
         }
         else if (this._xhr && this._xhr.responseText) {
             if (this._xhr.responseType !== '' && this._xhr.responseType !== 'text')

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1728,7 +1728,8 @@ Phaser.Loader.prototype = {
     xmlLoadComplete: function (index) {
         var data;
 
-        if (this._ajax && this._ajax.responseText) {
+        if (this._ajax && this._ajax.responseText)
+        {
           if (this._ajax.contentType !== '' && this._ajax.contentType !== 'text/plain')
           {
             console.warn('Invalid XML Response Type', this._fileList[index]);
@@ -1736,7 +1737,8 @@ Phaser.Loader.prototype = {
           }
           data = this._ajax.responseText
         }
-        else if (this._xhr && this._xhr.responseText) {
+        else if (this._xhr && this._xhr.responseText)
+        {
           if (this._xhr.responseType !== '' && this._xhr.responseType !== 'text')
           {
               console.warn('Invalid XML Response Type', this._fileList[index]);


### PR DESCRIPTION
This fix enables phaser to load BitmapFonts under CORS-conditions with IE9 (when enabling useXDomainRequest).
Most of the code has been copy-pasted from the XML-load fix that was already in the code, but only used when loading XML-files directly.