### PR TITLE
Safari scroll delta final fix

### DIFF
--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -938,7 +938,7 @@ Phaser.TilemapLayer.prototype.renderDeltaScroll = function (shiftX, shiftY) {
         this.context.clearRect(((left * tw) - scrollX), 0, (right - left + 1) * tw, renderH);
 
         var trueTop = Math.floor((0 + scrollY) / th);
-        var trueBottom = Math.floor((renderH - 1 + scrollY) / th) + 1;
+        var trueBottom = Math.floor((renderH - 1 + scrollY) / th);
         this.renderRegion(scrollX, scrollY, left, trueTop, right, trueBottom);
     }
     if (top <= bottom)

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -135,6 +135,7 @@ Phaser.TilemapLayer = function (game, tilemap, index, width, height) {
     *
     * @property {integer} copySliceCount - [Internal] The number of vertical slices to copy when using a `copyCanvas`.
     *     This is ratio of the pixel count of the primary canvas to the copy canvas.
+    *     *Note*: Safari 7 based canvas implemenations do not work correctly if slices are used.
     *
     * @default
     */
@@ -142,7 +143,7 @@ Phaser.TilemapLayer = function (game, tilemap, index, width, height) {
         enableScrollDelta: true,
         overdrawRatio: 0.20,
         copyCanvas: null,
-        copySliceCount: 4
+        copySliceCount: 1
     };
 
     /**
@@ -937,7 +938,7 @@ Phaser.TilemapLayer.prototype.renderDeltaScroll = function (shiftX, shiftY) {
         this.context.clearRect(((left * tw) - scrollX), 0, (right - left + 1) * tw, renderH);
 
         var trueTop = Math.floor((0 + scrollY) / th);
-        var trueBottom = Math.floor((renderH - 1 + scrollY) / th);
+        var trueBottom = Math.floor((renderH - 1 + scrollY) / th) + 1;
         this.renderRegion(scrollX, scrollY, left, trueTop, right, trueBottom);
     }
     if (top <= bottom)


### PR DESCRIPTION
This fixes an issue with Safari 7-based implementations where the scroll delta would result in black regions at the bottom when scrolling up. It reverts some code that could - if only Safari worked correctly - reduce the secondary copy requirements.

The change increases the size of the copy canvas, but it is still shared between all layers.

This is *tested* on iOS 8 on an iPad mini 2 - and it works there. (It was only tested with one layer, in CANVAS mode, however.)

The performance is still much better than without scroll delta on this device; I am not sure how older devices compare - notably there may be more pixels copied overall, even if the total work done is less per pixel.

Ref. https://github.com/photonstorm/phaser/issues/1439#issuecomment-70591294