### PR TITLE
fix #1551 - detect mouseup on tilesprites

### DIFF
--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -844,10 +844,10 @@ Phaser.Input.prototype = {
         {
             return (displayObject.hitArea.contains(this._localPoint.x, this._localPoint.y));
         }
-        else if (displayObject instanceof PIXI.Sprite)
+        else if (displayObject instanceof Phaser.TileSprite)
         {
-            var width = displayObject.texture.frame.width;
-            var height = displayObject.texture.frame.height;
+            var width = displayObject.width;
+            var height = displayObject.height;
             var x1 = -width * displayObject.anchor.x;
 
             if (this._localPoint.x >= x1 && this._localPoint.x < x1 + width)
@@ -860,10 +860,10 @@ Phaser.Input.prototype = {
                 }
             }
         }
-        else if (displayObject instanceof Phaser.TileSprite)
+        else if (displayObject instanceof PIXI.Sprite)
         {
-            var width = displayObject.width;
-            var height = displayObject.height;
+            var width = displayObject.texture.frame.width;
+            var height = displayObject.texture.frame.height;
             var x1 = -width * displayObject.anchor.x;
 
             if (this._localPoint.x >= x1 && this._localPoint.x < x1 + width)


### PR DESCRIPTION
Although the git diff might look a bit misleading (because the two branches share some pieces of code), all that is done is actually just change the order of the branches, so that `displayObject` is first checked if it's an intance of a `Phaser.TileSprite` (if so execute it's branch which remained unmodified), and if it isn't a `Phaser.TileSprite`, check if it's an instance of `PIXI.Sprite` (and do the same, code unchanged within the branch).
I guess the issue happened because `Phaser.TileSprite` is a subclass of `PIXI.Sprite`, so it got catched in the if check.