### PR TITLE
Add original position in onDragStart

### DIFF
--- a/src/input/InputHandler.js
+++ b/src/input/InputHandler.js
@@ -1240,6 +1240,8 @@ Phaser.InputHandler.prototype = {
     */
     startDrag: function (pointer) {
 
+        var originalPosition = (this.dragFromCenter) ? this.sprite.position.clone() : this.sprite.position;
+
         this.isDragged = true;
         this._draggedPointerID = pointer.id;
         this._pointerData[pointer.id].isDragged = true;
@@ -1277,7 +1279,7 @@ Phaser.InputHandler.prototype = {
             this.sprite.bringToTop();
         }
 
-        this.sprite.events.onDragStart$dispatch(this.sprite, pointer);
+        this.sprite.events.onDragStart$dispatch(this.sprite, pointer, originalPosition);
 
     },
 


### PR DESCRIPTION
When the onDragStart event is trigerred, the position of the sprite has
already changed if the lockCenter is activated. So it's impossible to
know the original position of the sprite.
The new parameter give the position in all the cases.

See http://www.html5gamedevs.com/topic/12025-get-original-position-when-dragging-with-lockcenter/
