### PR TITLE
Update TilemapLayer.js

### DIFF
--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -600,7 +600,7 @@ Phaser.TilemapLayer.prototype.getTiles = function (x, y, width, height, collides
         }
     }
 
-    return this._results;
+    return this._results.slice();
 
 };
 


### PR DESCRIPTION
getTile now returns a copy of the results and not a reference.