### PR TITLE
Allow max velocity of 0 in Arcade physics computeVelocity

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -294,7 +294,7 @@ Phaser.Physics.Arcade.prototype = {
     */
     computeVelocity: function (axis, body, velocity, acceleration, drag, max) {
 
-        max = max || 10000;
+        max = typeof max !== 'undefined' ? max : 10000;
 
         if (axis == 1 && body.allowGravity)
         {


### PR DESCRIPTION
Previous method of setting default max did not allow falsey values.

Allows movement to be constrained to one axis. This is useful when using methods like accelerateToPointer for mouse control over e.g. the paddle in a Breakout-style game, player ship in Galaga-style game, etc.