### PR TITLE
fixed scrollTo action triggered by click on TOC

### DIFF
--- a/resources/docstrap-master/template/static/scripts/toc.js
+++ b/resources/docstrap-master/template/static/scripts/toc.js
@@ -13,8 +13,10 @@ $.fn.toc = function(options) {
       e.preventDefault();
       var elScrollTo = $(e.target).attr('href');
       var $el = $(elScrollTo);
+      var topOffset = parseInt($('h4.name:first').css('marginTop').replace('px',''))
+                      + $('.navbar-inner').height();
 
-      $('body,html').animate({ scrollTop: $el.offset().top }, 400, 'swing', function() {
+      $('body,html').animate({ scrollTop: $el.offset().top - topOffset}, 400, 'swing', function() {
         location.hash = elScrollTo;
       });
     }


### PR DESCRIPTION
Since the navbar is fixed, its height is not taken into account when scrolling to a specific h4. So I am subtracting the height of the navbar plus the margin-top of an h4 to keep things nice :^)