### PR TITLE
Read ObjectLayer Objects .type property for Tiles

### DIFF
--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -448,6 +448,7 @@ Phaser.TilemapParser = {
 
                         gid: json.layers[i].objects[v].gid,
                         name: json.layers[i].objects[v].name,
+                        type: json.layers[i].objects[v].type,
                         x: json.layers[i].objects[v].x,
                         y: json.layers[i].objects[v].y,
                         visible: json.layers[i].objects[v].visible,

--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -448,7 +448,7 @@ Phaser.TilemapParser = {
 
                         gid: json.layers[i].objects[v].gid,
                         name: json.layers[i].objects[v].name,
-                        type: json.layers[i].objects[v].type,
+                        type: json.layers[i].objects[v].hasOwnProperty("type") ? json.layers[i].objects[v].type : "",
                         x: json.layers[i].objects[v].x,
                         y: json.layers[i].objects[v].y,
                         visible: json.layers[i].objects[v].visible,


### PR DESCRIPTION
Why isn't the .type already read from the objects details for Tile objects as it's there? Latest release version of Tiled 0.11.0 has this field for ObjectLayers Tile Objects and it's quite extensively used by other frameworks.

Well, I need this and I suppose there are other people too who might be interested in having this in here too. Currently I go around this by creating a custom property of "type" and setting my value on it but that's just extremely silly. :)