### PR TITLE
Fix for webkitAudioContext warning.

### DIFF
--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -897,7 +897,7 @@ Phaser.Device._initialize = function () {
     function _checkAudio () {
 
         device.audioData = !!(window['Audio']);
-        device.webAudio = !!(window['AudioContext'] || window['webkitAudioContext']);
+        device.webAudio = !!(window['webkitAudioContext'] || window['AudioContext']);
         var audioElement = document.createElement('audio');
         var result = false;
 


### PR DESCRIPTION
Fixed console warning with message: 'webkitAudioContext' is deprecated. Please use 'AudioContext' instead.