### PR TITLE
Corrected comment causing jsdoc-abort

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1806,7 +1806,7 @@ Phaser.Loader.prototype = {
     *
     * @method Phaser.Loader#getAudioURL
     * @private
-    * @param {object[]||string[]} urls - See {@link #audio} for format.
+    * @param {object[]|string[]} urls - See {@link #audio} for format.
     * @return {string} The URL to try and fetch; or null.
     */
     getAudioURL: function (urls) {


### PR DESCRIPTION
- jsdoc aborts on x||y found in types..