### PR TITLE
Fix row/col count formula.

### DIFF
--- a/src/tilemap/Tileset.js
+++ b/src/tilemap/Tileset.js
@@ -214,8 +214,8 @@ Phaser.Tileset.prototype = {
     updateTileData: function (imageWidth, imageHeight) {
 
         // May be fractional values
-        var rowCount = (imageHeight - this.tileMargin) / (this.tileHeight + this.tileSpacing);
-        var colCount = (imageWidth - this.tileMargin) / (this.tileWidth + this.tileSpacing);
+        var rowCount = (imageHeight - this.tileMargin * 2 + this.tileSpacing) / (this.tileHeight + this.tileSpacing);
+        var colCount = (imageWidth - this.tileMargin * 2 + this.tileSpacing) / (this.tileWidth + this.tileSpacing);
 
         if (rowCount % 1 !== 0 || colCount % 1 !== 0)
         {


### PR DESCRIPTION
**This fixes the rendering issue for tilesets with margin/spacing as described in photonstorm/phaser#1641.**

The formula at 217/218 as previously written only accounts for the left/top margin pixels, but adding the right/bottom margin is important for checking whether the image is sized correctly or not. Furthermore, when counting rows and columns, the use of Math.floor at 227/228 does prevent loading of partial tiles if the image is in fact sized correctly, but in this case (where the margin is smaller than the spacing) it will actually cut off the last row and column of tiles.

With the previous formula, rowCount is:
`var rowCount = (432 - 2) / (32 + 4) = ~11.95`
This causes the "even multiple" warning. The `Math.floor` call at 227 then forces this value down to 11 rows, when in fact there are 12. This in turn causes Phaser to assign tile IDs incorrectly, which leads to the wrong tiles being displayed.

Changing the formula at 217/218 to the following will handle this case, while preserving the current version's ability to discard extraneous pixels:
`var rowCount = (imageHeight - this.tileMargin * 2 + this.tileSpacing) / (this.tileHeight + this.tileSpacing);`
Thus:
`var rowCount = (432 - 4 + 4) / (32 + 4) = 12`
...which is the correct value, as confirmed by Tiled.

Since colCount works the same way, all of the above applies there.

See also photonstorm/phaser#1371, which resulted in the current version of the code. The change in the associated pull request fixed the issue, but didn't account for these margin/spacing issues.

Additional "test cases":
* 4 rows, 16px tiles, 0 margin, 0 spacing. Image height would be 64px. `(64 - 0 + 0) / (16 + 0) = 4 rows`
* 4 rows, 16px tiles, 2 margin, 1 spacing. Image height would be 71px. `(71 - 4 + 1) / (16 + 1) = 4 rows`

Image showing result of this change to Phaser:
![fixed_phaser_rendering](https://cloud.githubusercontent.com/assets/1486137/6386576/9e1aeca8-bd40-11e4-9d53-b89801d445d4.PNG)

**Link to minimal project with a Phaser build that includes this fix:**
https://github.com/zekoff/phaser-tileset-fixed