### PR TITLE
Component documentation

### DIFF
--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -1829,7 +1829,7 @@ Phaser.BitmapData.prototype = {
 };
 
 /**
-* @name Phaser.Sprite#smoothed
+* @memberof Phaser.BitmapData
 * @property {boolean} smoothed - Gets or sets this BitmapData.contexts smoothing enabled value.
 */
 Object.defineProperty(Phaser.BitmapData.prototype, "smoothed", {

--- a/src/gameobjects/BitmapText.js
+++ b/src/gameobjects/BitmapText.js
@@ -14,6 +14,17 @@
 * @class Phaser.BitmapText
 * @constructor
 * @extends PIXI.BitmapText
+* @extends Phaser.Component.Core
+* @extends Phaser.Component.Angle
+* @extends Phaser.Component.AutoCull
+* @extends Phaser.Component.Bounds
+* @extends Phaser.Component.Destroy
+* @extends Phaser.Component.FixedToCamera
+* @extends Phaser.Component.InputEnabled
+* @extends Phaser.Component.InWorld
+* @extends Phaser.Component.LifeSpan
+* @extends Phaser.Component.PhysicsBody
+* @extends Phaser.Component.Reset
 * @param {Phaser.Game} game - A reference to the currently running game.
 * @param {number} x - X position of the new bitmapText object.
 * @param {number} y - Y position of the new bitmapText object.

--- a/src/gameobjects/Graphics.js
+++ b/src/gameobjects/Graphics.js
@@ -10,6 +10,17 @@
 * @class Phaser.Graphics
 * @constructor
 * @extends PIXI.Graphics
+* @extends Phaser.Component.Core
+* @extends Phaser.Component.Angle
+* @extends Phaser.Component.AutoCull
+* @extends Phaser.Component.Bounds
+* @extends Phaser.Component.Destroy
+* @extends Phaser.Component.FixedToCamera
+* @extends Phaser.Component.InputEnabled
+* @extends Phaser.Component.InWorld
+* @extends Phaser.Component.LifeSpan
+* @extends Phaser.Component.PhysicsBody
+* @extends Phaser.Component.Reset
 * @param {Phaser.Game} game Current game instance.
 * @param {number} x - X position of the new graphics object.
 * @param {number} y - Y position of the new graphics object.

--- a/src/gameobjects/Image.js
+++ b/src/gameobjects/Image.js
@@ -10,6 +10,21 @@
 *
 * @class Phaser.Image
 * @extends PIXI.Sprite
+* @extends Phaser.Component.Core
+* @extends Phaser.Component.Angle
+* @extends Phaser.Component.Animation
+* @extends Phaser.Component.AutoCull
+* @extends Phaser.Component.Bounds
+* @extends Phaser.Component.BringToTop
+* @extends Phaser.Component.Crop
+* @extends Phaser.Component.Destroy
+* @extends Phaser.Component.FixedToCamera
+* @extends Phaser.Component.InputEnabled
+* @extends Phaser.Component.LifeSpan
+* @extends Phaser.Component.LoadTexture
+* @extends Phaser.Component.Overlap
+* @extends Phaser.Component.Reset
+* @extends Phaser.Component.Smoothed
 * @constructor
 * @param {Phaser.Game} game - A reference to the currently running game.
 * @param {number} x - The x coordinate of the Image. The coordinate is relative to any parent container this Image may be in.

--- a/src/gameobjects/Rope.js
+++ b/src/gameobjects/Rope.js
@@ -12,6 +12,25 @@
 * @class Phaser.Rope
 * @constructor
 * @extends PIXI.Rope
+* @extends Phaser.Component.Core
+* @extends Phaser.Component.Angle
+* @extends Phaser.Component.Animation
+* @extends Phaser.Component.AutoCull
+* @extends Phaser.Component.Bounds
+* @extends Phaser.Component.BringToTop
+* @extends Phaser.Component.Crop
+* @extends Phaser.Component.Delta
+* @extends Phaser.Component.Destroy
+* @extends Phaser.Component.FixedToCamera
+* @extends Phaser.Component.InputEnabled
+* @extends Phaser.Component.InWorld
+* @extends Phaser.Component.LifeSpan
+* @extends Phaser.Component.LoadTexture
+* @extends Phaser.Component.Overlap
+* @extends Phaser.Component.PhysicsBody
+* @extends Phaser.Component.Reset
+* @extends Phaser.Component.ScaleMinMax
+* @extends Phaser.Component.Smoothed
 * @param {Phaser.Game} game - A reference to the currently running game.
 * @param {number} x - The x coordinate (in world space) to position the Rope at.
 * @param {number} y - The y coordinate (in world space) to position the Rope at.

--- a/src/gameobjects/Sprite.js
+++ b/src/gameobjects/Sprite.js
@@ -14,6 +14,25 @@
 * @class Phaser.Sprite
 * @constructor
 * @extends PIXI.Sprite
+* @extends Phaser.Component.Core
+* @extends Phaser.Component.Angle
+* @extends Phaser.Component.Animation
+* @extends Phaser.Component.AutoCull
+* @extends Phaser.Component.Bounds
+* @extends Phaser.Component.BringToTop
+* @extends Phaser.Component.Crop
+* @extends Phaser.Component.Delta
+* @extends Phaser.Component.Destroy
+* @extends Phaser.Component.FixedToCamera
+* @extends Phaser.Component.InputEnabled
+* @extends Phaser.Component.InWorld
+* @extends Phaser.Component.LifeSpan
+* @extends Phaser.Component.LoadTexture
+* @extends Phaser.Component.Overlap
+* @extends Phaser.Component.PhysicsBody
+* @extends Phaser.Component.Reset
+* @extends Phaser.Component.ScaleMinMax
+* @extends Phaser.Component.Smoothed
 * @param {Phaser.Game} game - A reference to the currently running game.
 * @param {number} x - The x coordinate (in world space) to position the Sprite at.
 * @param {number} y - The y coordinate (in world space) to position the Sprite at.
@@ -74,7 +93,7 @@ Phaser.Sprite.prototype.preUpdateCore = Phaser.Component.Core.preUpdate;
 /**
 * Automatically called by World.preUpdate.
 *
-* @method Phaser.Sprite#preUpdate
+* @method
 * @memberof Phaser.Sprite
 * @return {boolean} True if the Sprite was rendered, otherwise false.
 */

--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -14,6 +14,20 @@
 *
 * @class Phaser.Text
 * @extends PIXI.Text
+* @extends Phaser.Component.Core
+* @extends Phaser.Component.Angle
+* @extends Phaser.Component.AutoCull
+* @extends Phaser.Component.Bounds
+* @extends Phaser.Component.BringToTop
+* @extends Phaser.Component.Destroy
+* @extends Phaser.Component.FixedToCamera
+* @extends Phaser.Component.InputEnabled
+* @extends Phaser.Component.InWorld
+* @extends Phaser.Component.LifeSpan
+* @extends Phaser.Component.Overlap
+* @extends Phaser.Component.PhysicsBody
+* @extends Phaser.Component.Reset
+* @extends Phaser.Component.Smoothed
 * @constructor
 * @param {Phaser.Game} game - Current game instance.
 * @param {number} x - X position of the new text object.

--- a/src/gameobjects/TileSprite.js
+++ b/src/gameobjects/TileSprite.js
@@ -11,6 +11,20 @@
 * @class Phaser.TileSprite
 * @constructor
 * @extends PIXI.TilingSprite
+* @extends Phaser.Component.Core
+* @extends Phaser.Component.Angle
+* @extends Phaser.Component.Animation
+* @extends Phaser.Component.AutoCull
+* @extends Phaser.Component.Bounds
+* @extends Phaser.Component.Destroy
+* @extends Phaser.Component.FixedToCamera
+* @extends Phaser.Component.InputEnabled
+* @extends Phaser.Component.InWorld
+* @extends Phaser.Component.LoadTexture
+* @extends Phaser.Component.Overlap
+* @extends Phaser.Component.PhysicsBody
+* @extends Phaser.Component.Reset
+* @extends Phaser.Component.Smoothed
 * @param {Phaser.Game} game - A reference to the currently running game.
 * @param {number} x - The x coordinate (in world space) to position the TileSprite at.
 * @param {number} y - The y coordinate (in world space) to position the TileSprite at.

--- a/src/gameobjects/components/Angle.js
+++ b/src/gameobjects/components/Angle.js
@@ -1,3 +1,8 @@
+/**
+* Angle Component Features.
+*
+* @class
+*/
 Phaser.Component.Angle = function () {};
 
 Phaser.Component.Angle.prototype = {
@@ -7,7 +12,6 @@ Phaser.Component.Angle.prototype = {
     * Values outside this range are added to or subtracted from 360 to obtain a value within the range. For example, the statement player.angle = 450 is the same as player.angle = 90.
     * If you wish to work in radians instead of degrees use the property Sprite.rotation instead. Working in radians is also a little faster as it doesn't have to convert the angle.
     *
-    * @name Phaser.Sprite#angle
     * @property {number} angle - The angle of this Sprite in degrees.
     */
     angle: {

--- a/src/gameobjects/components/Animation.js
+++ b/src/gameobjects/components/Animation.js
@@ -1,3 +1,8 @@
+/**
+* Animation Component Features.
+*
+* @class
+*/
 Phaser.Component.Animation = function () {};
 
 Phaser.Component.Animation.prototype = {
@@ -6,8 +11,7 @@ Phaser.Component.Animation.prototype = {
     * Play an animation based on the given key. The animation should previously have been added via sprite.animations.add()
     * If the requested animation is already playing this request will be ignored. If you need to reset an already running animation do so directly on the Animation object itself.
     *
-    * @method Phaser.Sprite#play
-    * @memberof Phaser.Sprite
+    * @method
     * @param {string} name - The name of the animation to be played, e.g. "fire", "walk", "jump".
     * @param {number} [frameRate=null] - The framerate to play the animation at. The speed is given in frames per second. If not provided the previously set frameRate of the Animation is used.
     * @param {boolean} [loop=false] - Should the animation be looped after playback. If not provided the previously set loop value of the Animation is used.

--- a/src/gameobjects/components/AutoCull.js
+++ b/src/gameobjects/components/AutoCull.js
@@ -1,3 +1,8 @@
+/**
+* AutoCull Component Features.
+*
+* @class
+*/
 Phaser.Component.AutoCull = function () {};
 
 Phaser.Component.AutoCull.prototype = {
@@ -15,7 +20,6 @@ Phaser.Component.AutoCull.prototype = {
     /**
     * Checks if the Sprite bounds are within the game camera, otherwise false if fully outside of it.
     *
-    * @name Phaser.Sprite#inCamera
     * @property {boolean} inCamera - True if the Sprite bounds is within the game camera, even if only partially. Otherwise false if fully outside of it.
     * @readonly
     */

--- a/src/gameobjects/components/Bounds.js
+++ b/src/gameobjects/components/Bounds.js
@@ -1,3 +1,8 @@
+/**
+* Bounds Component Features.
+*
+* @class
+*/
 Phaser.Component.Bounds = function () {};
 
 Phaser.Component.Bounds.prototype = {
@@ -7,7 +12,6 @@ Phaser.Component.Bounds.prototype = {
     * This is the same as `Sprite.width * Sprite.anchor.x`.
     * It will only be > 0 if the Sprite.anchor.x is not equal to zero.
     *
-    * @name Phaser.Sprite#offsetX
     * @property {number} offsetX - The amount the sprite is visually offset from its x coordinate.
     * @readOnly
     */
@@ -26,7 +30,6 @@ Phaser.Component.Bounds.prototype = {
     * This is the same as `Sprite.height * Sprite.anchor.y`.
     * It will only be > 0 if the Sprite.anchor.y is not equal to zero.
     *
-    * @name Phaser.Sprite#offsetY
     * @property {number} offsetY - The amount the sprite is visually offset from its y coordinate.
     * @readOnly
     */
@@ -43,7 +46,6 @@ Phaser.Component.Bounds.prototype = {
     /**
     * The left coordinate of the Sprite, adjusted for the anchor.
     *
-    * @name Phaser.Sprite#left
     * @property {number} left - The left coordinate of the Sprite, adjusted for the anchor.
     * @readOnly
     */
@@ -60,7 +62,6 @@ Phaser.Component.Bounds.prototype = {
     /**
     * The right coordinate of the Sprite, adjusted for the anchor. This is the same as Sprite.x + Sprite.width - Sprite.offsetX.
     *
-    * @name Phaser.Sprite#right
     * @property {number} right - The right coordinate of the Sprite, adjusted for the anchor. This is the same as Sprite.x + Sprite.width - Sprite.offsetX.
     * @readOnly
     */
@@ -77,7 +78,6 @@ Phaser.Component.Bounds.prototype = {
     /**
     * The y coordinate of the Sprite, adjusted for the anchor.
     *
-    * @name Phaser.Sprite#top
     * @property {number} top - The y coordinate of the Sprite, adjusted for the anchor.
     * @readOnly
     */
@@ -94,7 +94,6 @@ Phaser.Component.Bounds.prototype = {
     /**
     * The sum of the y and height properties, adjusted for the anchor.
     *
-    * @name Phaser.Sprite#bottom
     * @property {number} bottom - The sum of the y and height properties, adjusted for the anchor.
     * @readOnly
     */

--- a/src/gameobjects/components/BringToTop.js
+++ b/src/gameobjects/components/BringToTop.js
@@ -1,10 +1,14 @@
+/**
+* BringToTop Component Features.
+*
+* @class
+*/
 Phaser.Component.BringToTop = function () {};
 
 /**
 * Brings the Sprite to the top of the display list it is a child of. Sprites that are members of a Phaser.Group are only
 * bought to the top of that Group, not the entire display list.
 *
-* @method Phaser.Sprite#bringToTop
 * @memberof Phaser.Sprite
 * @return (Phaser.Sprite) This instance.
 */
@@ -33,7 +37,6 @@ Phaser.Component.BringToTop.prototype.sendToBack = function() {
 /**
 * Moves the given child up one place in this group unless it's already at the top.
 *
-* @method Phaser.Group#moveUp
 * @return {any} The child that was moved.
 */
 Phaser.Component.BringToTop.prototype.moveUp = function () {
@@ -50,7 +53,6 @@ Phaser.Component.BringToTop.prototype.moveUp = function () {
 /**
 * Moves the given child down one place in this group unless it's already at the bottom.
 *
-* @method Phaser.Group#moveDown
 * @return {any} The child that was moved.
 */
 Phaser.Component.BringToTop.prototype.moveDown = function () {

--- a/src/gameobjects/components/Core.js
+++ b/src/gameobjects/components/Core.js
@@ -1,3 +1,8 @@
+/**
+* Core Component Features.
+*
+* @class
+*/
 Phaser.Component.Core = function () {};
 
 Phaser.Component.Core.install = function (components) {
@@ -135,7 +140,8 @@ Phaser.Component.Core.prototype = {
     previousPosition: null,
 
     /**
-    * @property {number} previousRotation - The rotation angle the Sprite was in at the last update (in radians)
+    * The rotation angle the Sprite was in at the last update (in radians)   
+    * @property {number} previousRotation2
     * @readOnly
     */
     previousRotation: 0,
@@ -165,53 +171,12 @@ Phaser.Component.Core.prototype = {
     _exists: true,
 
     /**
-    * Override and use this function in your own custom objects to handle any update requirements you may have.
-    * Remember if this Sprite has any children you should call update on them too.
+    * Controls if the core game loop and physics update this Sprite or not.
     *
-    * @method Phaser.Sprite#update
-    * @memberof Phaser.Sprite
-    */
-    update: function() {
-
-    },
-
-    /**
-    * Internal function called by the World postUpdate cycle.
-    *
-    * @method Phaser.Sprite#postUpdate
-    * @memberof Phaser.Sprite
-    */
-    postUpdate: function() {
-
-        if (this.key instanceof Phaser.BitmapData)
-        {
-            this.key.render();
-        }
-
-        if (this.components.PhysicsBody)
-        {
-            Phaser.Component.PhysicsBody.postUpdate.call(this);
-        }
-
-        if (this.components.FixedToCamera)
-        {
-            Phaser.Component.FixedToCamera.postUpdate.call(this);
-        }
-
-        for (var i = 0; i < this.children.length; i++)
-        {
-            this.children[i].postUpdate();
-        }
-
-    },
-
-    /**
-    * Sprite.exists controls if the core game loop and physics update this Sprite or not.
-    * When you set Sprite.exists to false it will remove its Body from the physics world (if it has one) and also set Sprite.visible to false.
+    * When `exists` is set to to false it will remove its Body from the physics world (if it has one) and also set Sprite.visible to false.
     * Setting Sprite.exists to true will re-add the Body to the physics world (if it has a body) and set Sprite.visible to true.
     *
-    * @name Phaser.Sprite#exists
-    * @property {boolean} exists - If the Sprite is processed by the core game update and physics.
+    * @property {boolean} exists - True if this game objects exists.
     */
     exists: {
 
@@ -246,6 +211,46 @@ Phaser.Component.Core.prototype = {
                 this.visible = false;
             }
 
+        }
+
+    },
+
+    /**
+    * Override and use this function in your own custom objects to handle any update requirements you may have.
+    * Remember if this Sprite has any children you should call update on them too.
+    *
+    * @method
+    */
+    update: function() {
+
+    },
+
+    /**
+    * Internal function called by the World postUpdate cycle.
+    *
+    * @method
+    * @protected
+    */
+    postUpdate: function() {
+
+        if (this.key instanceof Phaser.BitmapData)
+        {
+            this.key.render();
+        }
+
+        if (this.components.PhysicsBody)
+        {
+            Phaser.Component.PhysicsBody.postUpdate.call(this);
+        }
+
+        if (this.components.FixedToCamera)
+        {
+            Phaser.Component.FixedToCamera.postUpdate.call(this);
+        }
+
+        for (var i = 0; i < this.children.length; i++)
+        {
+            this.children[i].postUpdate();
         }
 
     }

--- a/src/gameobjects/components/Crop.js
+++ b/src/gameobjects/components/Crop.js
@@ -1,3 +1,8 @@
+/**
+* Crop Component Features.
+*
+* @class
+*/
 Phaser.Component.Crop = function () {};
 
 Phaser.Component.Crop.prototype = {
@@ -24,8 +29,7 @@ Phaser.Component.Crop.prototype = {
     * The rectangle object given to this method can be either a Phaser.Rectangle or any object so long as it has public x, y, width and height properties.
     * A reference to the rectangle is stored in Sprite.cropRect unless the `copy` parameter is `true` in which case the values are duplicated to a local object.
     *
-    * @method Phaser.Sprite#crop
-    * @memberof Phaser.Sprite
+    * @method
     * @param {Phaser.Rectangle} rect - The Rectangle used during cropping. Pass null or no parameters to clear a previously set crop rectangle.
     * @param {boolean} [copy=false] - If false Sprite.cropRect will be a reference to the given rect. If true it will copy the rect values into a local Sprite.cropRect object.
     */
@@ -64,8 +68,7 @@ Phaser.Component.Crop.prototype = {
     * If you have set a crop rectangle on this Sprite via Sprite.crop and since modified the Sprite.cropRect property (or the rectangle it references)
     * then you need to update the crop frame by calling this method.
     *
-    * @method Phaser.Sprite#updateCrop
-    * @memberof Phaser.Sprite
+    * @method
     */
     updateCrop: function() {
 

--- a/src/gameobjects/components/Delta.js
+++ b/src/gameobjects/components/Delta.js
@@ -1,3 +1,8 @@
+/**
+* Delta Component Features.
+*
+* @class
+*/
 Phaser.Component.Delta = function () {};
 
 Phaser.Component.Delta.prototype = {
@@ -5,7 +10,6 @@ Phaser.Component.Delta.prototype = {
     /**
     * Returns the delta x value. The difference between world.x now and in the previous step.
     *
-    * @name Phaser.Sprite#deltaX
     * @property {number} deltaX - The delta value. Positive if the motion was to the right, negative if to the left.
     * @readonly
     */
@@ -22,7 +26,6 @@ Phaser.Component.Delta.prototype = {
     /**
     * Returns the delta y value. The difference between world.y now and in the previous step.
     *
-    * @name Phaser.Sprite#deltaY
     * @property {number} deltaY - The delta value. Positive if the motion was downwards, negative if upwards.
     * @readonly
     */
@@ -39,7 +42,6 @@ Phaser.Component.Delta.prototype = {
     /**
     * Returns the delta z value. The difference between rotation now and in the previous step.
     *
-    * @name Phaser.Sprite#deltaZ
     * @property {number} deltaZ - The delta value.
     * @readonly
     */

--- a/src/gameobjects/components/Destroy.js
+++ b/src/gameobjects/components/Destroy.js
@@ -1,3 +1,8 @@
+/**
+* Destroy Component Features.
+*
+* @class
+*/
 Phaser.Component.Destroy = function () {};
 
 Phaser.Component.Destroy.prototype = {
@@ -12,8 +17,7 @@ Phaser.Component.Destroy.prototype = {
     * Destroys the Sprite. This removes it from its parent group, destroys the input, event and animation handlers if present
     * and nulls its reference to game, freeing it up for garbage collection.
     *
-    * @method Phaser.Sprite#destroy
-    * @memberof Phaser.Sprite
+    * @method
     * @param {boolean} [destroyChildren=true] - Should every child of this object have its destroy method called?
     */
     destroy: function(destroyChildren) {

--- a/src/gameobjects/components/FixedToCamera.js
+++ b/src/gameobjects/components/FixedToCamera.js
@@ -1,3 +1,8 @@
+/**
+* FixedToCamera Component Features.
+*
+* @class
+*/
 Phaser.Component.FixedToCamera = function () {};
 
 Phaser.Component.FixedToCamera.postUpdate = function () {
@@ -16,7 +21,9 @@ Phaser.Component.FixedToCamera.prototype = {
     * A Sprite that is fixed to the camera uses its x/y coordinates as offsets from the top left of the camera. These are stored in Sprite.cameraOffset.
     * Note that the cameraOffset values are in addition to any parent in the display list.
     * So if this Sprite was in a Group that has x: 200, then this will be added to the cameraOffset.x
+    *
     * Be careful not to set `fixedToCamera` on Game Objects which are in Groups that already have fixedToCamera enabled on them.
+    *
     * @property {boolean} fixedToCamera
     */
     fixedToCamera: false,

--- a/src/gameobjects/components/Health.js
+++ b/src/gameobjects/components/Health.js
@@ -1,3 +1,8 @@
+/**
+* Health Component Features.
+*
+* @class
+*/
 Phaser.Component.Health = function () {};
 
 Phaser.Component.Health.prototype = {
@@ -11,8 +16,7 @@ Phaser.Component.Health.prototype = {
     * Damages the Sprite, this removes the given amount from the Sprites health property.
     * If health is then taken below or is equal to zero `Sprite.kill` is called.
     *
-    * @method Phaser.Sprite#damage
-    * @memberof Phaser.Sprite
+    * @member
     * @param {number} amount - The amount to subtract from the Sprite.health value.
     * @return (Phaser.Sprite) This instance.
     */

--- a/src/gameobjects/components/InCamera.js
+++ b/src/gameobjects/components/InCamera.js
@@ -1,3 +1,8 @@
+/**
+* InCamera Component Features.
+*
+* @class
+*/
 Phaser.Component.InCamera = function () {};
 
 Phaser.Component.InCamera.prototype = {
@@ -5,7 +10,6 @@ Phaser.Component.InCamera.prototype = {
     /**
     * Checks if the Sprite bounds are within the game camera, otherwise false if fully outside of it.
     *
-    * @name Phaser.Sprite#inCamera
     * @property {boolean} inCamera - True if the Sprite bounds is within the game camera, even if only partially. Otherwise false if fully outside of it.
     * @readonly
     */

--- a/src/gameobjects/components/InWorld.js
+++ b/src/gameobjects/components/InWorld.js
@@ -1,3 +1,8 @@
+/**
+* InWorld Component Features.
+*
+* @class
+*/
 Phaser.Component.InWorld = function () {};
 
 Phaser.Component.InWorld.preUpdate = function () {
@@ -77,7 +82,6 @@ Phaser.Component.InWorld.prototype = {
     /**
     * Checks if the Sprite bounds are within the game world, otherwise false if fully outside of it.
     *
-    * @name Phaser.Sprite#inWorld
     * @property {boolean} inWorld - True if the Sprite bounds is within the game world, even if only partially. Otherwise false if fully outside of it.
     * @readonly
     */

--- a/src/gameobjects/components/InputEnabled.js
+++ b/src/gameobjects/components/InputEnabled.js
@@ -1,3 +1,8 @@
+/**
+* InputEnabled Component Features.
+*
+* @class
+*/
 Phaser.Component.InputEnabled = function () {};
 
 Phaser.Component.InputEnabled.prototype = {
@@ -11,7 +16,6 @@ Phaser.Component.InputEnabled.prototype = {
     * By default a Sprite won't process any input events at all. By setting inputEnabled to true the Phaser.InputHandler is
     * activated for this object and it will then start to process click/touch events and more.
     *
-    * @name Phaser.Sprite#inputEnabled
     * @property {boolean} inputEnabled - Set to true to allow this object to receive input events.
     */
     inputEnabled: {

--- a/src/gameobjects/components/LifeSpan.js
+++ b/src/gameobjects/components/LifeSpan.js
@@ -1,3 +1,8 @@
+/**
+* LifeSpan Component Features.
+*
+* @class
+*/
 Phaser.Component.LifeSpan = function () {};
 
 Phaser.Component.LifeSpan.preUpdate = function () {
@@ -41,8 +46,7 @@ Phaser.Component.LifeSpan.prototype = {
     * A resurrected Sprite has its alive, exists and visible properties all set to true.
     * It will dispatch the onRevived event, you can listen to Sprite.events.onRevived for the signal.
     *
-    * @method Phaser.Sprite#revive
-    * @memberof Phaser.Sprite
+    * @method
     * @param {number} [health=1] - The health to give the Sprite. Only applies if the GameObject has the Health component.
     * @return (Phaser.Sprite) This instance.
     */
@@ -74,8 +78,7 @@ Phaser.Component.LifeSpan.prototype = {
     * Note that killing a Sprite is a way for you to quickly recycle it in a Sprite pool, it doesn't free it up from memory.
     * If you don't need this Sprite any more you should call Sprite.destroy instead.
     *
-    * @method Phaser.Sprite#kill
-    * @memberof Phaser.Sprite
+    * @method
     * @return (Phaser.Sprite) This instance.
     */
     kill: function() {

--- a/src/gameobjects/components/LoadTexture.js
+++ b/src/gameobjects/components/LoadTexture.js
@@ -1,3 +1,8 @@
+/**
+* LoadTexture Component Features.
+*
+* @class
+*/
 Phaser.Component.LoadTexture = function () {};
 
 Phaser.Component.LoadTexture.prototype = {
@@ -12,8 +17,7 @@ Phaser.Component.LoadTexture.prototype = {
     * Changes the Texture the Sprite is using entirely. The old texture is removed and the new one is referenced or fetched from the Cache.
     * This causes a WebGL texture update, so use sparingly or in low-intensity portions of your game.
     *
-    * @method Phaser.Sprite#loadTexture
-    * @memberof Phaser.Sprite
+    * @method
     * @param {string|Phaser.RenderTexture|Phaser.BitmapData|PIXI.Texture} key - This is the image or texture used by the Sprite during rendering. It can be a string which is a reference to the Cache entry, or an instance of a RenderTexture, BitmapData or PIXI.Texture.
     * @param {string|number} [frame] - If this Sprite is using part of a sprite sheet or texture atlas you can specify the exact frame to use by giving a string or numeric index.
     * @param {boolean} [stopAnimation=true] - If an animation is already playing on this Sprite you can choose to stop it or let it carry on playing.
@@ -95,8 +99,7 @@ Phaser.Component.LoadTexture.prototype = {
     * Sets the Texture frame the Sprite uses for rendering.
     * This is primarily an internal method used by Sprite.loadTexture, although you may call it directly.
     *
-    * @method Phaser.Sprite#setFrame
-    * @memberof Phaser.Sprite
+    * @method
     * @param {Phaser.Frame} frame - The Frame to be used by the Sprite texture.
     */
     setFrame: function(frame) {
@@ -154,8 +157,7 @@ Phaser.Component.LoadTexture.prototype = {
     /**
     * Resets the Texture frame dimensions that the Sprite uses for rendering.
     *
-    * @method Phaser.Sprite#resetFrame
-    * @memberof Phaser.Sprite
+    * @method
     */
     resetFrame: function() {
 
@@ -167,7 +169,6 @@ Phaser.Component.LoadTexture.prototype = {
     },
 
     /**
-    * @name Phaser.Sprite#frame
     * @property {number} frame - Gets or sets the current frame index and updates the Texture Cache for display.
     */
     frame: {
@@ -183,7 +184,6 @@ Phaser.Component.LoadTexture.prototype = {
     },
 
     /**
-    * @name Phaser.Sprite#frameName
     * @property {string} frameName - Gets or sets the current frame name and updates the Texture Cache for display.
     */
     frameName: {

--- a/src/gameobjects/components/Overlap.js
+++ b/src/gameobjects/components/Overlap.js
@@ -1,3 +1,8 @@
+/**
+* Overlap Component Features.
+*
+* @class
+*/
 Phaser.Component.Overlap = function () {};
 
 Phaser.Component.Overlap.prototype = {
@@ -7,8 +12,7 @@ Phaser.Component.Overlap.prototype = {
     * This check ignores the Sprites hitArea property and runs a Sprite.getBounds comparison on both objects to determine the result.
     * Therefore it's relatively expensive to use in large quantities (i.e. with lots of Sprites at a high frequency), but should be fine for low-volume testing where physics isn't required.
     *
-    * @method Phaser.Sprite#overlap
-    * @memberof Phaser.Sprite
+    * @method
     * @param {Phaser.Sprite|Phaser.Image|Phaser.TileSprite|Phaser.Button|PIXI.DisplayObject} displayObject - The display object to check against.
     * @return {boolean} True if the bounds of this Sprite intersects at any point with the bounds of the given display object.
     */

--- a/src/gameobjects/components/PhysicsBody.js
+++ b/src/gameobjects/components/PhysicsBody.js
@@ -1,3 +1,8 @@
+/**
+* PhysicsBody Component Features.
+*
+* @class
+*/
 Phaser.Component.PhysicsBody = function () {};
 
 Phaser.Component.PhysicsBody.preUpdate = function () {
@@ -61,7 +66,6 @@ Phaser.Component.PhysicsBody.prototype = {
     /**
     * The position of the Sprite on the x axis relative to the local coordinates of the parent.
     *
-    * @name Phaser.Sprite#x
     * @property {number} x - The position of the Sprite on the x axis relative to the local coordinates of the parent.
     */
     x: {
@@ -88,7 +92,6 @@ Phaser.Component.PhysicsBody.prototype = {
     /**
     * The position of the Sprite on the y axis relative to the local coordinates of the parent.
     *
-    * @name Phaser.Sprite#y
     * @property {number} y - The position of the Sprite on the y axis relative to the local coordinates of the parent.
     */
     y: {

--- a/src/gameobjects/components/Reset.js
+++ b/src/gameobjects/components/Reset.js
@@ -1,3 +1,8 @@
+/**
+* Reset Component Features.
+*
+* @class
+*/
 Phaser.Component.Reset = function () {};
 
 /**
@@ -5,8 +10,7 @@ Phaser.Component.Reset = function () {};
 * sets alive, exists, visible and renderable all to true. Also resets the outOfBounds state and health values.
 * If the Sprite has a physics body that too is reset.
 *
-* @method Phaser.Sprite#reset
-* @memberof Phaser.Sprite
+* @method
 * @param {number} x - The x coordinate (in world space) to position the Sprite at.
 * @param {number} y - The y coordinate (in world space) to position the Sprite at.
 * @param {number} [health=1] - The health to give the Sprite. Only applies if the GameObject has the Health component.

--- a/src/gameobjects/components/ScaleMinMax.js
+++ b/src/gameobjects/components/ScaleMinMax.js
@@ -1,3 +1,8 @@
+/**
+* ScaleMinMax Component Features.
+*
+* @class
+*/
 Phaser.Component.ScaleMinMax = function () {};
 
 Phaser.Component.ScaleMinMax.prototype = {
@@ -25,7 +30,7 @@ Phaser.Component.ScaleMinMax.prototype = {
     /**
      * Adjust scaling limits, if set, to this Sprite.
      *
-     * @method Phaser.Sprite#checkTransform
+     * @method
      * @private
      * @param {PIXI.Matrix} wt - The updated worldTransform matrix.
      */
@@ -74,8 +79,7 @@ Phaser.Component.ScaleMinMax.prototype = {
      * 
      * Call setScaleMinMax(null) to clear both the scaleMin and scaleMax values.
      *
-     * @method Phaser.Sprite#setScaleMinMax
-     * @memberof Phaser.Sprite
+     * @method
      * @param {number|null} minX - The minimum horizontal scale value this Sprite can scale down to.
      * @param {number|null} minY - The minimum vertical scale value this Sprite can scale down to.
      * @param {number|null} maxX - The maximum horizontal scale value this Sprite can scale up to.

--- a/src/gameobjects/components/Smoothed.js
+++ b/src/gameobjects/components/Smoothed.js
@@ -1,3 +1,8 @@
+/**
+* Smoothed Component Features.
+*
+* @class
+*/
 Phaser.Component.Smoothed = function () {};
 
 Phaser.Component.Smoothed.prototype = {
@@ -5,7 +10,6 @@ Phaser.Component.Smoothed.prototype = {
     /**
     * Enable or disable texture smoothing for this Sprite. Only works for bitmap/image textures. Smoothing is enabled by default.
     *
-    * @name Phaser.Sprite#smoothed
     * @property {boolean} smoothed - Set to true to smooth the texture of this Sprite, or false to disable smoothing (great for pixel art)
     */
     smoothed: {


### PR DESCRIPTION
Basic structure/changes to allow shared documentation and generation of component-type pages.

Note that there appears to be a "quirk" with jsdoc I am tracking down, so while this is vastly improved overall not all members of the Component types are correctly shown on the target types (eg. Sprite#exists does not show up).

- Required changes for documentation to show up correctly
  - Uses multiple `@extends`, which currently [mostly/should] work in jsdoc and like closure compiler

jsdoc (and cc) also support `@implements/@interface` - which would probably be more fitting - but jsdoc doesn't want to generate a separate HTML file for interfaces which is why `@extends/@class` is currently used.