### PR TITLE
Update Sprite.js for renderCanvas method

### DIFF
--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -399,8 +399,8 @@ PIXI.Sprite.prototype._renderCanvas = function(renderSession)
                                 this.texture.crop.height,
                                 dx / resolution,
                                 dy / resolution,
-                                this.texture.crop.width / resolution,
-                                this.texture.crop.height / resolution);
+                                this.texture.frame.width / resolution,
+                                this.texture.frame.height / resolution);
         }
         else
         {
@@ -412,8 +412,8 @@ PIXI.Sprite.prototype._renderCanvas = function(renderSession)
                                 this.texture.crop.height,
                                 dx / resolution,
                                 dy / resolution,
-                                this.texture.crop.width / resolution,
-                                this.texture.crop.height / resolution);
+                                this.texture.frame.width / resolution,
+                                this.texture.frame.height / resolution);
         }
     }
 


### PR DESCRIPTION
Default when we change Sprite.width and height, we are changing Sprite.scale acutally. I need to change the size of Sprite but NOT changing its scale, so i modify Sprite.texture.frame size. I test changing Sprite.texture.frame size all right in WEBGL, but when i switch to CANVAS, i found the Sprite's size doesn't change. 
I found the Sprite._renderCanvas's code drawImage not using texture.frame'size but using texture.crop's size. I think we should use frame's size for drawImage.