### PR TITLE
Fixes neverending tween when duration set to zero (caused by division with zero)

### DIFF
--- a/src/tween/Tween.js
+++ b/src/tween/Tween.js
@@ -183,7 +183,7 @@ Phaser.Tween.prototype = {
     */
     to: function (properties, duration, ease, autoStart, delay, repeat, yoyo) {
 
-        if (typeof duration === 'undefined') { duration = 1000; }
+        if (typeof duration === 'undefined' || duration <= 0) { duration = 1000; }
         if (typeof ease === 'undefined') { ease = Phaser.Easing.Default; }
         if (typeof autoStart === 'undefined') { autoStart = false; }
         if (typeof delay === 'undefined') { delay = 0; }


### PR DESCRIPTION
 Passing a value of zero as the value of duration causes the
 calculations performed in Tween#update to divide by zero when
 calculating the next step for the tween. This causes the tweened
 property value to be set to NaN having undesireable results and
 also, causes the tween to never end since the ending criteria are
 never met.