### PR TITLE
Fix some errors in the definitions files for Phaser.Group

### DIFF
--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -7142,7 +7142,7 @@ declare module Phaser {
         * @param child The child to bring to the top of this group.
         * @return The child that was moved.
         */
-        bringToTop(): PIXI.DisplayObject;
+        bringToTop(child: any): any;
 
         /**
         * Calls a function, specified by name, on all on children.
@@ -7454,7 +7454,7 @@ declare module Phaser {
         * @param child The child to move down in the group.
         * @return The child that was moved.
         */
-        moveDown(): PIXI.DisplayObject;
+        moveDown(child: any): any;
 
         /**
         * Moves the given child up one place in this group unless it's already at the top.

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1451,7 +1451,7 @@ declare module Phaser {
         addAll(property: string, amount: number, checkAlive: boolean, checkVisible: boolean): void;
         addAt(child: any, index: number, silent?: boolean): any;
         addMultiple(children: any[], silent?: boolean): any[];
-        bringToTop(): PIXI.DisplayObject;
+        bringToTop(child: any): any;
         callAll(method: string, context: any, ...parameters: any[]): void;
         callAllExists(callback: Function, existsValue: boolean, ...parameters: any[]): void;
         callbackFromArray(child: any, callback: Function, length: number): void;
@@ -1479,7 +1479,7 @@ declare module Phaser {
         getTop(): any;
         hasProperty(child: any, key: string[]): boolean;
         iterate(key: string, value: any, returnType: number, callback?: Function, callbackContext?: any, ...args: any[]): any;
-        moveDown(): PIXI.DisplayObject;
+        moveDown(child: any): any;
         moveUp(child: any): any;
         multiplyAll(property: string, amount: number, checkAlive: boolean, checkVisible: boolean): void;
         next(): void;


### PR DESCRIPTION
There was some errors in the definitions for Phaser.Group causing Typescript to error when using bringToTop and moveDown.

It appears to have been broken here: https://github.com/photonstorm/phaser/commit/7994427583edfad1454be42b58f9e4c837dc8e01