### PR TITLE
Typescript definition fixes for Graphics

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1405,6 +1405,7 @@ declare module Phaser {
         destroy(): void;
         drawTriangle(points: Phaser.Point[], cull?: boolean): void;
         drawTriangles(vertices: any[], indices?: number[], cull?: boolean): void;
+        generateTexture(resolution?: number, scaleMode?: number): PIXI.RenderTexture;
         postUpdate(): void;
         preUpdate(): void;
         update(): void;


### PR DESCRIPTION
Fixes incorrect parameters for generateTexture.

Both parameters should be optional because 
[resolution is set to 1 if undefined](https://github.com/photonstorm/phaser/blob/v2.3.0/src/pixi/primitives/Graphics.js#L641)
[scaleMode is set to PIXI.scaleModes.DEFAULT](https://github.com/photonstorm/phaser/blob/v2.3.0/src/pixi/textures/BaseTexture.js#L53)

I wanted to override generateTexture in Phaser.Graphics so they're also optional in Phaser documentation, but haven't found a good way to do this. I was thinking about this:

src/gameobjects/Graphics.js

```javascript
Phaser.Graphics.prototype.superGenerateTexture = Phaser.Graphics.prototype.generateTexture;

/**
 * Useful function that returns a texture of the graphics object that can then be used to create sprites
 * This can be quite useful if your geometry is complicated and needs to be reused multiple times.
 *
 * @method generateTexture
 * @param {Number} [resolution=1] - The resolution of the texture being generated
 * @param {Number} [scaleMode=PIXI.scaleModes.DEFAULT] - Should be one of the PIXI.scaleMode consts
 * @return {Texture} a texture of the graphics object
 */
Phaser.Graphics.prototype.generateTexture = function(resolution, scaleMode) {

    if (typeof resolution === 'undefined') { resolution = 1; }
    if (typeof scaleMode === 'undefined') { scaleMode = PIXI.scaleModes.DEFAULT; }
    this.superGenerateTexture(resolution, scaleMode);

};