### PR TITLE
Looking up object layers based on id, uid or name

### DIFF
--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -390,10 +390,32 @@ Phaser.Tilemap.prototype = {
         }
 
         var sprite;
+        var found = false;
 
         for (var i = 0, len = this.objects[name].length; i < len; i++)
         {
-            if (this.objects[name][i].gid === gid)
+            if (typeof this.objects[name][i].gid !== 'undefined' &&
+                typeof gid === 'number') {
+                if (this.objects[name][i].gid === gid) {
+                    found = true;
+                }
+            }
+
+            if (typeof this.objects[name][i].id !== 'undefined' &&
+                typeof gid === 'number') {
+                if (this.objects[name][i].id === gid) {
+                    found = true;
+                }
+            }
+
+            if (typeof this.objects[name][i].name !== 'undefined' &&
+                typeof gid === 'string') {
+                if (this.objects[name][i].name === gid) {
+                    found = true;
+                }
+            }
+
+            if (found)
             {
                 sprite = new CustomClass(this.game, this.objects[name][i].x, this.objects[name][i].y, key, frame);
 
@@ -401,6 +423,9 @@ Phaser.Tilemap.prototype = {
                 sprite.visible = this.objects[name][i].visible;
                 sprite.autoCull = autoCull;
                 sprite.exists = exists;
+
+                sprite.width = this.objects[name][i].width;
+                sprite.height = this.objects[name][i].height;
 
                 if (this.objects[name][i].rotation)
                 {


### PR DESCRIPTION
The description of the method stated that you could pass a string to look up an object layer based on its name, but the original code only looked for a gui property, regardless of type.

I'm using Tiled 0.11.0 on OSX, and my exported json-file doesn't contain a gui property on the object layers. Here's a snippet of my file:
```
{
    "layers":[
        {
         "draworder":"topdown",
         "height":0,
         "name":"Objects",
         "objects":[
                {
                 "height":48,
                 "id":1,
                 "name":"pier",
                 "properties":
                    {

                    },
                 "rotation":0,
                 "type":"",
                 "visible":true,
                 "width":64,
                 "x":208,
                 "y":240
                }],
         "opacity":1,
         "properties":
            {
             "type":"pier"
            },
         "type":"objectgroup",
         "visible":true,
         "width":0,
         "x":0,
         "y":0
        }]
    }]
}
```

The property in my file is called id and not uid. This might be due to changes in one of the later releases of Tiled. I kept the check for uid to avoid possibly breaking compatibility with older versions of Tiled.

I also added scaling of the sprite.

Feel free to make formatting changes, or rewrite the function to better fit the programming style of Phaser.