### PR TITLE
Check for existence of sprite on body destroy

### DIFF
--- a/src/physics/p2/Body.js
+++ b/src/physics/p2/Body.js
@@ -753,7 +753,7 @@ Phaser.Physics.P2.Body.prototype = {
                 }
             }
         }
-        
+
         if (this.data.world !== this.game.physics.p2.world)
         {
             this.game.physics.p2.addBody(this);
@@ -797,8 +797,11 @@ Phaser.Physics.P2.Body.prototype = {
         }
 
         this.debugBody = null;
-        this.sprite.body = null;
-        this.sprite = null;
+
+        if (this.sprite) {
+            this.sprite.body = null;
+            this.sprite = null;
+        }
 
     },
 
@@ -1032,9 +1035,9 @@ Phaser.Physics.P2.Body.prototype = {
     removeShape: function (shape) {
 
 		var result = this.data.removeShape(shape);
-	
+
 		this.shapeChanged();
-	
+
         return result;
     },
 


### PR DESCRIPTION
P2.Body#destroy() assumes the body will have a sprite property, but that is not always true. Phaser's API can create situations with null sprites if you use `physics.createBody()`:

https://github.com/photonstorm/phaser/blob/master/src/physics/p2/World.js#L1523