### PR TITLE
fix(typescript): fix Matrix.fromArray definition

### DIFF
--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -10540,7 +10540,7 @@ declare module Phaser {
 
         apply(pos: Phaser.Point, newPos?: Phaser.Point): Phaser.Point;
         applyInverse(pos: Phaser.Point, newPos?: Phaser.Point): Phaser.Point;
-        fromArray(array: number[]);
+        fromArray(array: number[]): void;
         toArray(transpose: boolean): number[];
         translate(x: number, y: number): Phaser.Matrix;
         scale(x: number, y: number): Phaser.Matrix;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2056,7 +2056,7 @@ declare module Phaser {
 
         apply(pos: Phaser.Point, newPos?: Phaser.Point): Phaser.Point;
         applyInverse(pos: Phaser.Point, newPos?: Phaser.Point): Phaser.Point;
-        fromArray(array: number[]);
+        fromArray(array: number[]): void;
         toArray(transpose: boolean): number[];
         translate(x: number, y: number): Phaser.Matrix;
         scale(x: number, y: number): Phaser.Matrix;


### PR DESCRIPTION
Added explicity ```void``` return type for Matrix.fromArray.

Reason
It has similar function type in pixi.d.ts, and it caused troubles when using typescript compiler with ```--noImplicitAny``` flag.