### PR TITLE
Load audiosprite from asset pack

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1776,7 +1776,7 @@ Phaser.Loader.prototype = {
                     break;
 
                 case "audiosprite":
-                    this.audio(file.key, file.urls, file.jsonURL);
+                    this.audiosprite(file.key, file.urls, file.jsonURL, file.jsonData, file.autoDecode);
                     break;
 
                 case "tilemap":


### PR DESCRIPTION
The loader process the asset pack but to load the audio sprite, it uses the method "audio()" instead of "audiosprite()". The fix is to call "audiosprite()" with the right arguments.