### PR TITLE
Use `mute` instead of `_muted` to check whether or not a sound should be muted

### DIFF
--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -385,7 +385,7 @@ Phaser.Sound.prototype = {
     /**
     * Called automatically by the AudioContext when the sound stops playing.
     * Doesn't get called if the sound is set to loop or is a section of an Audio Sprite.
-    * 
+    *
     * @method Phaser.Sound#onEndedHandler
     * @protected
     */
@@ -483,7 +483,7 @@ Phaser.Sound.prototype = {
 
     /**
     * Play this sound, or a marked section of it.
-    * 
+    *
     * @method Phaser.Sound#play
     * @param {string} [marker=''] - If you want to play a marker then give the key here, otherwise leave blank to play the full sound.
     * @param {number} [position=0] - The starting position to play the sound from - this is ignored if you provide a marker.
@@ -531,7 +531,7 @@ Phaser.Sound.prototype = {
 
         if (marker === '' && Object.keys(this.markers).length > 0)
         {
-            //  If they didn't specify a marker but this is an audio sprite, 
+            //  If they didn't specify a marker but this is an audio sprite,
             //  we should never play the entire thing
             return this;
         }
@@ -691,9 +691,9 @@ Phaser.Sound.prototype = {
                     }
 
                     this._sound.currentTime = this.position;
-                    this._sound.muted = this._muted;
+                    this._sound.muted = this.mute;
 
-                    if (this._muted)
+                    if (this.mute)
                     {
                         this._sound.volume = 0;
                     }
@@ -902,7 +902,7 @@ Phaser.Sound.prototype = {
         this.fadeTo(duration, 1);
 
     },
-    
+
     /**
      * Decreases the volume of this Sound from its current value to 0 over the duration specified.
      * At the end of the fade Sound.onFadeComplete is dispatched with this Sound object as the first parameter,
@@ -919,7 +919,7 @@ Phaser.Sound.prototype = {
 
     /**
      * Fades the volume of this Sound from its current value to the given volume over the duration specified.
-     * At the end of the fade Sound.onFadeComplete is dispatched with this Sound object as the first parameter, 
+     * At the end of the fade Sound.onFadeComplete is dispatched with this Sound object as the first parameter,
      * and the final volume (volume) as the second parameter.
      *
      * @method Phaser.Sound#fadeTo


### PR DESCRIPTION
This fixes a problem with IE11 where the value of the mute property of the SoundManager does not affect sounds. This problem was brought up a couple months ago [in the forums](http://www.html5gamedevs.com/topic/10840-soundmanager-mute-on-ie11/). Looking at the code, this problem probably affects all of the browsers that don't support WebAudio.