### PR TITLE
Return actual boolean value instead of 1

### DIFF
--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -581,7 +581,7 @@ Phaser.Math = {
     */
     isOdd: function (n) {
         // Does not work with extremely large values
-        return (n & 1);
+        return !!(n & 1);
     },
 
     /**


### PR DESCRIPTION
Phaser.Math.isOdd is documented as returning {boolean} but returns {number} instead. This breaks strict comparisons and is inconsistent with Phaser.Math.isEven.
