### PR TITLE
Add a Heal Method to Phaser.Components.Health

### DIFF
--- a/src/gameobjects/components/Health.js
+++ b/src/gameobjects/components/Health.js
@@ -49,4 +49,22 @@ Phaser.Component.Health.prototype = {
 
     }
 
+    /**
+    * Heal the Game Object. This adds the given amount of health from the `health` property.
+    *
+    * @member
+    * @param {number} amount - The amount to add from the current `health` value.
+    * @return {Phaser.Sprite} This instance.
+    */
+    heal: function(amount) {
+
+        if (this.alive)
+        {
+            this.health += amount;
+        }
+
+        return this;
+
+    }
+
 };

--- a/src/gameobjects/components/Health.js
+++ b/src/gameobjects/components/Health.js
@@ -47,7 +47,7 @@ Phaser.Component.Health.prototype = {
 
         return this;
 
-    }
+    },
 
     /**
     * Heal the Game Object. This adds the given amount of health from the `health` property.


### PR DESCRIPTION
Ideal when used in games with health packs, bonus items, or healing sprites.

In fact: Doing a negative damage causes the same effect, but as a new method is better for documentation.