### PR TITLE
Fix Rope.js

### DIFF
--- a/src/gameobjects/Rope.js
+++ b/src/gameobjects/Rope.js
@@ -61,7 +61,7 @@ Phaser.Rope = function (game, x, y, key, frame, points) {
     */
     this._scroll = new Phaser.Point();
 
-    PIXI.Rope.call(this, key, this.points);
+    PIXI.Rope.call(this, PIXI.TextureCache['__default'], this.points);
 
     Phaser.Component.Core.init.call(this, game, x, y, key, frame);
 


### PR DESCRIPTION
Rope creation key parameter didn't work, because PIXI.Rope requires a texture, not string.
Changed it like Sprite.