### PR TITLE
Update sample asset pack file.

### DIFF
--- a/resources/Asset Pack JSON Format/assetPack.json
+++ b/resources/Asset Pack JSON Format/assetPack.json
@@ -38,6 +38,13 @@
             "overwrite": false
         },
         {
+            //   Loads a generic XML document
+            "type": "xml",
+            "key": "level-01-definitions",
+            "url": "assets/data/level-01-definitions.xml",
+            "overwrite": false
+        },
+        {
             //   Loads a JavaScript File with optional callback
             "type": "script",
             "key": "webfonts",
@@ -63,10 +70,25 @@
             "spacing": 0
         },
         {
+            //   Loads a Video File
+            "type": "video",
+            "key": "chrome",
+            "urls": [ "assets/video/chrome.webm", "assets/video/chrome.m4v" ]
+        },
+        {
             //   Loads an Audio File
             "type": "audio",
             "key": "boden",
             "urls": ["assets/audio/bodenstaendig_2000_in_rock_4bit.mp3", "assets/audio/bodenstaendig_2000_in_rock_4bit.ogg"],
+            "autoDecode": true
+        },
+        {
+            //   Loads an Audiosprite file and its metadata
+            "type": "audiosprite",
+            "key": "dialog",
+            "urls": [ "assets/audiosprites/dialog.m4a", "assets/audiosprites/dialog.oga" ],
+            "jsonURL": "assets/audiosprites/dialog.json"
+            "jsonData": null,
             "autoDecode": true
         },
         {
@@ -99,9 +121,9 @@
         {
             //   Loads a Bitmap Font File.
             "type": "bitmapFont",
-            "key": "ship",
-            "textureURL": "assets/tilemaps/ship_physics.json",
-            "xmlURL": "assets/tilemaps/ship_physics.json",
+            "key": "desyrel",
+            "textureURL": "assets/fonts/bitmapFonts/desyrel.png",
+            "xmlURL": "assets/fonts/bitmapFonts/desyrel.xml",
             "xmlData": null,
             "xSpacing": 0,
             "ySpacing": 0


### PR DESCRIPTION
This commit brings up some needed updates to the `assetPack.json` sample file,
including:

-   The addition of the missing sample entries for the following file types,
    added in recent versions of Phaser:

    -   a XML file;
    -   an Audiosprite file;
    -   a Video file entries.

-   Fix the example Bitmap Font entry.
