### PR TITLE
JSON support for BitmapFont atlases

### DIFF
--- a/src/gameobjects/BitmapText.js
+++ b/src/gameobjects/BitmapText.js
@@ -5,13 +5,13 @@
 */
 
 /**
-* BitmapText objects work by taking a texture file and an XML file that describes the font structure.
+* BitmapText objects work by taking a texture file and an XML or JSON file that describes the font structure.
 * It then generates a new Sprite object for each letter of the text, proportionally spaced out and aligned to 
 * match the font structure.
 * 
 * BitmapText objects are less flexible than Text objects, in that they have less features such as shadows, fills and the ability 
-* to use Web Fonts. However you trade this flexibility for pure rendering speed. You can also create visually compelling BitmapTexts by 
-* processing the font texture in an image editor first, applying fills and any other effects required.
+* to use Web Fonts, however you trade this flexibility for rendering speed. You can also create visually compelling BitmapTexts by
+* processing the font texture in an image editor, applying fills and any other effects required.
 *
 * To create multi-line text insert \r, \n or \r\n escape codes into the text string.
 *
@@ -23,6 +23,8 @@
 * BMFont (Windows, free): http://www.angelcode.com/products/bmfont/
 * Glyph Designer (OS X, commercial): http://www.71squared.com/en/glyphdesigner
 * Littera (Web-based, free): http://kvazars.com/littera/
+*
+* For most use cases it is recommended to use XML. If you wish to use JSON, the formatting should be equal to the result of running a valid XML file through the popular X2JS library.
 *
 * @class Phaser.BitmapText
 * @constructor

--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -385,23 +385,29 @@ Phaser.Cache.prototype = {
     * @param {string} key - The unique key by which you will reference this object.
     * @param {string} url - URL of this font xml file.
     * @param {object} data - Extra font data.
-    * @param {object} xmlData - Texture atlas frames data.
+    * @param {object} atlasData - Texture atlas frames data.
     * @param {number} [xSpacing=0] - If you'd like to add additional horizontal spacing between the characters then set the pixel value here.
     * @param {number} [ySpacing=0] - If you'd like to add additional vertical spacing between the lines then set the pixel value here.
     */
-    addBitmapFont: function (key, url, data, xmlData, xSpacing, ySpacing) {
+    addBitmapFont: function (key, url, data, atlasData, atlasType, xSpacing, ySpacing) {
 
         this._images[key] = { url: url, data: data };
 
         PIXI.BaseTextureCache[key] = new PIXI.BaseTexture(data);
         // PIXI.TextureCache[key] = new PIXI.Texture(PIXI.BaseTextureCache[key]);
 
-        Phaser.LoaderParser.bitmapFont(this.game, xmlData, key, xSpacing, ySpacing);
+        if (atlasType === 'json')
+        {
+            Phaser.LoaderParser.jsonBitmapFont(this.game, atlasData, key, xSpacing, ySpacing);
+        }
+        else
+        {
+            Phaser.LoaderParser.xmlBitmapFont(this.game, atlasData, key, xSpacing, ySpacing);
+        }
 
         this._bitmapFont[key] = PIXI.BitmapText.fonts[key];
 
         this._resolveURL(url, this._bitmapFont[key]);
-
     },
 
     /**

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1188,11 +1188,11 @@ Phaser.Loader.prototype = {
                 var json, xml;
 
                 try
-        {
+                {
                     json = JSON.parse(atlasData);
-        }
+                }
                 catch ( e )
-            {
+                {
                     xml = this.parseXml(atlasData);
                 }
 

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -112,7 +112,7 @@ Phaser.Loader = function (game) {
     this.onFileStart = new Phaser.Signal();
 
     /**
-    * This event is dispatched when a file has either loaded or failed to load.    *
+    * This event is dispatched when a file has either loaded or failed to load.
     *
     * Any function bound to this will receive the following parameters:
     *
@@ -1157,53 +1157,56 @@ Phaser.Loader.prototype = {
     *
     * @method Phaser.Loader#bitmapFont
     * @param {string} key - Unique asset key of the bitmap font.
-    * @param {string} [textureURL] - URL of the Bitmap Font texture file. If undefined or `null` the url will be set to `<key>.png`, i.e. if `key` was "megaFont" then the URL will be "megaFont.png".
-    * @param {string} [xmlURL] - URL of the Bitmap Font data file. If undefined or `null` and no data is given the url will be set to `<key>.xml`, i.e. if `key` was "megaFont" then the URL will be "megaFont.xml".
-    * @param {object} [xmlData] - An optional XML data object.
+    * @param {string} textureURL -  URL of the Bitmap Font texture file. If undefined or `null` the url will be set to `<key>.png`, i.e. if `key` was "megaFont" then the URL will be "megaFont.png".
+    * @param {string} atlasURL - URL of the Bitmap Font atlas file (xml/json).
+    * @param {object} atlasData - An optional Bitmap Font atlas in string form (stringified xml/json).
     * @param {number} [xSpacing=0] - If you'd like to add additional horizontal spacing between the characters then set the pixel value here.
     * @param {number} [ySpacing=0] - If you'd like to add additional vertical spacing between the lines then set the pixel value here.
     * @return {Phaser.Loader} This Loader instance.
     */
-    bitmapFont: function (key, textureURL, xmlURL, xmlData, xSpacing, ySpacing) {
-
+    bitmapFont: function (key, textureURL, atlasURL, atlasData, xSpacing, ySpacing) {
         if (typeof textureURL === 'undefined' || textureURL === null)
         {
             textureURL = key + '.png';
         }
 
-        if (typeof xmlURL === 'undefined') { xmlURL = null; }
-        if (typeof xmlData === 'undefined') { xmlData = null; }
+        if (typeof atlasURL === 'undefined') { atlasURL = null; }
+        if (typeof atlasData === 'undefined') { atlasData = null; }
         if (typeof xSpacing === 'undefined') { xSpacing = 0; }
         if (typeof ySpacing === 'undefined') { ySpacing = 0; }
 
-        if (!xmlURL && !xmlData)
+        //  A URL to a json/xml atlas has been given
+        if (atlasURL)
         {
-            xmlURL = key + '.xml';
-        }
-
-        //  A URL to a json/xml file has been given
-        if (xmlURL)
-        {
-            this.addToFileList('bitmapfont', key, textureURL, { xmlURL: xmlURL, xSpacing: xSpacing, ySpacing: ySpacing });
+            this.addToFileList('bitmapfont', key, textureURL, { atlasURL: atlasURL, xSpacing: xSpacing, ySpacing: ySpacing });
         }
         else
         {
-            //  An xml string or object has been given
-            if (typeof xmlData === 'string')
+            //  A stringified xml/json atlas has been given
+            if (typeof atlasData === 'string')
             {
-                var xml = this.parseXml(xmlData);
+                var json, xml;
 
-                if (!xml)
-                {
-                    throw new Error("Phaser.Loader. Invalid Bitmap Font XML given");
+                try
+        {
+                    json = JSON.parse(atlasData);
+        }
+                catch ( e )
+            {
+                    xml = this.parseXml(atlasData);
                 }
 
-                this.addToFileList('bitmapfont', key, textureURL, { xmlURL: null, xmlData: xml, xSpacing: xSpacing, ySpacing: ySpacing });
+                if (!xml && !json)
+                {
+                    throw new Error("Phaser.Loader. Invalid Bitmap Font atlas given");
+                }
+
+                this.addToFileList('bitmapfont', key, textureURL, { atlasURL: null, atlasData: json || xml,
+                    atlasType: (!!json ? 'json' : 'xml'), xSpacing: xSpacing, ySpacing: ySpacing });
             }
         }
 
         return this;
-
     },
 
     /**
@@ -1844,7 +1847,7 @@ Phaser.Loader.prototype = {
                     break;
 
                 case "bitmapFont":
-                    this.bitmapFont(file.key, file.textureURL, file.xmlURL, file.xmlData, file.xSpacing, file.ySpacing);
+                    this.bitmapFont(file.key, file.textureURL, file.atlasURL, file.atlasData, file.xSpacing, file.ySpacing);
                     break;
 
                 case "atlasJSONArray":
@@ -2494,15 +2497,35 @@ Phaser.Loader.prototype = {
 
             case 'bitmapfont':
 
-                if (!file.xmlURL)
+                if (!file.atlasURL)
                 {
-                    this.game.cache.addBitmapFont(file.key, file.url, file.data, file.xmlData, file.xSpacing, file.ySpacing);
+                    this.game.cache.addBitmapFont(file.key, file.url, file.data, file.atlasData, file.atlasType, file.xSpacing, file.ySpacing);
                 }
                 else
                 {
                     //  Load the XML before carrying on with the next file
                     loadNext = false;
-                    this.xhrLoad(file, this.transformUrl(file.xmlURL, file), 'text', this.xmlLoadComplete);
+                    this.xhrLoad(file, this.transformUrl(file.atlasURL, file), 'text', function (file, xhr) {
+                        var json;
+
+                        try
+                        {
+                            // Try to parse as JSON, if it fails, then it's hopefully XML
+                            json = JSON.parse(xhr.responseText);
+                        }
+                        catch (e) {}
+
+                        if (!!json)
+                        {
+                            file.atlasType = 'json';
+                            this.jsonLoadComplete(file, xhr);
+                        }
+                        else
+                        {
+                            file.atlasType = 'xml';
+                            this.xmlLoadComplete(file, xhr);
+                        }
+                    });
                 }
                 break;
 
@@ -2603,6 +2626,10 @@ Phaser.Loader.prototype = {
         {
             this.game.cache.addTilemap(file.key, file.url, data, file.format);
         }
+        else if (file.type === 'bitmapfont')
+        {
+            this.game.cache.addBitmapFont(file.key, file.url, file.data, data, file.atlasType, file.xSpacing, file.ySpacing);
+        }
         else if (file.type === 'json')
         {
             this.game.cache.addJSON(file.key, file.url, data);
@@ -2613,7 +2640,6 @@ Phaser.Loader.prototype = {
         }
 
         this.asyncComplete(file);
-
     },
 
     /**
@@ -2658,7 +2684,7 @@ Phaser.Loader.prototype = {
 
         if (file.type === 'bitmapfont')
         {
-            this.game.cache.addBitmapFont(file.key, file.url, file.data, xml, file.xSpacing, file.ySpacing);
+            this.game.cache.addBitmapFont(file.key, file.url, file.data, xml, file.atlasType, file.xSpacing, file.ySpacing);
         }
         else if (file.type === 'textureatlas')
         {

--- a/src/loader/LoaderParser.js
+++ b/src/loader/LoaderParser.js
@@ -12,7 +12,7 @@
 Phaser.LoaderParser = {
 
     /**
-    * Parse a Bitmap Font from an XML file.
+    * Alias for xmlBitmapFont, for backwards compatiblity.
     * 
     * @method Phaser.LoaderParser.bitmapFont
     * @param {Phaser.Game} game - A reference to the current game.
@@ -22,7 +22,20 @@ Phaser.LoaderParser = {
     * @param {number} [ySpacing=0] - Additional vertical spacing between the characters.
     */
     bitmapFont: function (game, xml, cacheKey, xSpacing, ySpacing) {
+        this.xmlBitmapFont(game, xml, cacheKey, xSpacing, ySpacing);
+    },
 
+    /**
+    * Parse a Bitmap Font from an XML file.
+    *
+    * @method Phaser.LoaderParser.xmlBitmapFont
+    * @param {Phaser.Game} game - A reference to the current game.
+    * @param {object} xml - XML data you want to parse.
+    * @param {string} cacheKey - The key of the texture this font uses in the cache.
+    * @param {number} [xSpacing=0] - Additional horizontal spacing between the characters.
+    * @param {number} [ySpacing=0] - Additional vertical spacing between the characters.
+    */
+    xmlBitmapFont: function (game, xml, cacheKey, xSpacing, ySpacing) {
         var data = {};
         var info = xml.getElementsByTagName('info')[0];
         var common = xml.getElementsByTagName('common')[0];
@@ -38,19 +51,15 @@ Phaser.LoaderParser = {
         {
             var charCode = parseInt(letters[i].getAttribute('id'), 10);
 
-            var textureRect = new PIXI.Rectangle(
-                parseInt(letters[i].getAttribute('x'), 10),
-                parseInt(letters[i].getAttribute('y'), 10),
-                parseInt(letters[i].getAttribute('width'), 10),
-                parseInt(letters[i].getAttribute('height'), 10)
-            );
-
             data.chars[charCode] = {
+                x: parseInt(letters[i].getAttribute('x'), 10),
+                y: parseInt(letters[i].getAttribute('y'), 10),
+                width: parseInt(letters[i].getAttribute('width'), 10),
+                height: parseInt(letters[i].getAttribute('height'), 10),
                 xOffset: parseInt(letters[i].getAttribute('xoffset'), 10),
                 yOffset: parseInt(letters[i].getAttribute('yoffset'), 10),
                 xAdvance: parseInt(letters[i].getAttribute('xadvance'), 10) + xSpacing,
-                kerning: {},
-                texture: new PIXI.Texture(PIXI.BaseTextureCache[cacheKey], textureRect)
+                kerning: {}
             };
         }
 
@@ -65,8 +74,74 @@ Phaser.LoaderParser = {
             data.chars[second].kerning[first] = amount;
         }
 
-        PIXI.BitmapText.fonts[cacheKey] = data;
+        this.finalizeBitmapFont(cacheKey, data);
+    },
 
+    /**
+    * Parse a Bitmap Font from a JSON file.
+    *
+    * @method Phaser.LoaderParser.jsonBitmapFont
+    * @param {Phaser.Game} game - A reference to the current game.
+    * @param {object} json - JSON data you want to parse.
+    * @param {string} cacheKey - The key of the texture this font uses in the cache.
+    * @param {number} [xSpacing=0] - Additional horizontal spacing between the characters.
+    * @param {number} [ySpacing=0] - Additional vertical spacing between the characters.
+    */
+    jsonBitmapFont: function (game, json, cacheKey, xSpacing, ySpacing) {
+        var data = {
+            font: json.font.info._font,
+            size: parseInt(json.font.info._size, 10),
+            lineHeight: parseInt(json.font.common._lineHeight, 10) + ySpacing,
+            chars: {}
+        };
+
+        json.font.chars["char"].forEach(
+            function parseChar(letter) {
+                var charCode = parseInt(letter._id, 10);
+
+                data.chars[charCode] = {
+                    x: parseInt(letter._x, 10),
+                    y: parseInt(letter._y, 10),
+                    width: parseInt(letter._width, 10),
+                    height: parseInt(letter._height, 10),
+                    xOffset: parseInt(letter._xoffset, 10),
+                    yOffset: parseInt(letter._yoffset, 10),
+                    xAdvance: parseInt(letter._xadvance, 10) + xSpacing,
+                    kerning: {}
+                };
+            }
+        );
+
+        json.font.kernings.kerning.forEach(
+            function parseKerning(kerning) {
+                data.chars[kerning._second].kerning[kerning._first] = parseInt(kerning._amount, 10);
+            }
+        );
+
+        this.finalizeBitmapFont(cacheKey, data);
+    },
+
+    /**
+    * Finalize Bitmap Font parsing.
+    *
+    * @method Phaser.LoaderParser.finalizeBitmapFont
+    * @private
+    * @param {string} cacheKey - The key of the texture this font uses in the cache.
+    * @param {object} bitmapFontData - Pre-parsed bitmap font data.
+   */
+    finalizeBitmapFont: function (cacheKey, bitmapFontData) {
+        Object.keys(bitmapFontData.chars).forEach(
+            function addTexture(charCode) {
+                var letter = bitmapFontData.chars[charCode];
+                var textureRect = new PIXI.Rectangle(
+                    letter.x, letter.y,
+                    letter.width, letter.height
+                );
+
+                letter.texture = new PIXI.Texture(PIXI.BaseTextureCache[cacheKey], textureRect);
     }
+        );
 
+        PIXI.BitmapText.fonts[cacheKey] = bitmapFontData;
+    }
 };

--- a/src/loader/LoaderParser.js
+++ b/src/loader/LoaderParser.js
@@ -139,7 +139,7 @@ Phaser.LoaderParser = {
                 );
 
                 letter.texture = new PIXI.Texture(PIXI.BaseTextureCache[cacheKey], textureRect);
-    }
+            }
         );
 
         PIXI.BitmapText.fonts[cacheKey] = bitmapFontData;


### PR DESCRIPTION
Since some environments (CocoonJS, I'm looking at you!) does not support parsing XML through DOMParser, this allows to bypass that by providing a pre-parsed JSON atlas instead. From what I've gathered there are quite a few people who have had this issue, and who have had to monkey patch their implementations in scary ways to resolve it.