### PR TITLE
Fix mask combine filter bug

### DIFF
--- a/src/pixi/renderers/webgl/utils/WebGLFilterManager.js
+++ b/src/pixi/renderers/webgl/utils/WebGLFilterManager.js
@@ -73,7 +73,14 @@ PIXI.WebGLFilterManager.prototype.pushFilter = function(filterBlock)
     var offset = this.renderSession.offset;
 
     filterBlock._filterArea = filterBlock.target.filterArea || filterBlock.target.getBounds();
-
+    
+    // >>> modify by nextht
+    filterBlock._previous_stencil_mgr = this.renderSession.stencilManager;
+    this.renderSession.stencilManager = new PIXI.WebGLStencilManager();
+    this.renderSession.stencilManager.setContext(gl);
+    gl.disable(gl.STENCIL_TEST);
+    // <<<  modify by nextht 
+   
     // filter program
     // OPTIMISATION - the first filter is free if its a simple color change?
     this.filterStack.push(filterBlock);
@@ -297,6 +304,20 @@ PIXI.WebGLFilterManager.prototype.popFilter = function()
     // set texture
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, texture.texture);
+
+    // >>> modify by nextht
+    if (this.renderSession.stencilManager) {
+        this.renderSession.stencilManager.destroy();
+    }
+    this.renderSession.stencilManager = filterBlock._previous_stencil_mgr;
+    filterBlock._previous_stencil_mgr = null;
+    if (this.renderSession.stencilManager.count > 0) {
+        gl.enable(gl.STENCIL_TEST);
+    }
+    else {
+        gl.disable(gl.STENCIL_TEST);
+    }    
+    // <<< modify by nextht
 
     // apply!
     this.applyFilterPass(filter, filterArea, sizeX, sizeY);


### PR DESCRIPTION
In the demo (code below), i create a group with a rect mask, and create a sprite as group's child with a blurXY filter, then nothing is displayed. 

So i hack WebGLFilterManager's pushFilter and popFilter method, in pushFilter method i create a new stencilManager instance and save the old one, in popFilter i destroy the new stencilManager and restore the old one, then this workaround works rightly as i expect.

I think this is a bug for PIXI, so i hope @photonstorm or @englercj can help me checking whether this fixing is right or not, thanks.
 
	var game = new Phaser.Game(800, 600, Phaser.WEBGL, 'phaser-example', { preload: preload, create: create });

	function preload() {
		game.load.image('phaser', 'assets/sprites/phaser2.png');
		game.load.script('filterX', '../filters/BlurX.js');
		game.load.script('filterY', '../filters/BlurY.js');
	}

	function create() {
		var logo = game.add.sprite(game.world.centerX, game.world.centerY, 'phaser');
		logo.anchor.setTo(0.5, 0.5);

		var blurX = game.add.filter('BlurX');
		var blurY = game.add.filter('BlurY');

		logo.filters = [blurX, blurY];
		var group = game.add.group();
			group.addChild(logo);
			group.mask = game.add.graphics();
			group.mask.beginFill(0xff);
			group.mask.drawRect(0,0,500,500);
	}
After i hack WebGLFilterManager's code, i can get the right effect like below:
![filter-mask-bug](https://cloud.githubusercontent.com/assets/9689063/8035362/7d01ac5e-0e22-11e5-9f70-e8caae5bd0b8.jpg)

