### PR TITLE
Changes for nw.js-like environment detection code

### DIFF
--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -88,6 +88,12 @@ Phaser.Device = function () {
     this.nodeWebkit = false;
     
     /**
+    * @property {boolean} electron - Is the game running under GitHub Electron?
+    * @default
+    */
+    this.electron = false;
+    
+    /**
     * @property {boolean} ejecta - Is the game running under Ejecta?
     * @default
     */
@@ -912,6 +918,8 @@ Phaser.Device._initialize = function () {
         if (device.node)
         {
             device.nodeWebkit = (window.process.versions && window.process.versions['node-webkit']);
+            
+            device.electron = (window.process.versions && window.process.versions.electron);
         }
         
         if (navigator['isCocoonJS'])

--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -915,11 +915,11 @@ Phaser.Device._initialize = function () {
             device.node = true;
         }
         
-        if (device.node)
+        if (device.node && typeof window.process.versions === 'object')
         {
-            device.nodeWebkit = (window.process.versions && window.process.versions['node-webkit']);
+            device.nodeWebkit = !!window.process.versions['node-webkit'];
             
-            device.electron = (window.process.versions && window.process.versions.electron);
+            device.electron = !!window.process.versions.electron;
         }
         
         if (navigator['isCocoonJS'])

--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -911,13 +911,7 @@ Phaser.Device._initialize = function () {
         
         if (device.node)
         {
-            try {
-                device.nodeWebkit = (typeof require('nw.gui') !== "undefined");
-            }
-            catch(error)
-            {
-                device.nodeWebkit = false;
-            }
+            device.nodeWebkit = (window.process.versions && window.process.versions['node-webkit']);
         }
         
         if (navigator['isCocoonJS'])


### PR DESCRIPTION
This pull request proposes two small changes in the Device class:

1.  An alternative way to detect when Phaser is running under a NW.js (formerly Node-WebKit) environment, using feature detection, instead of relying on a guarded `require` statement.

    The former way is the source of a known incompatibility with `browserify` an similar tools.

2.  Add a complementary check for GitHub Electron.

References:

1.  [Changes related to node — nw.js Wiki][1]
2.  [Process object — Electron Documentation][2]

----
[1]: https://github.com/nwjs/nw.js/wiki/Changes-related-to-node#process
[2]: http://electron.atom.io/docs/v0.27.0/api/process/
