### PR TITLE
Fix tile index being off by one

### DIFF
--- a/src/tilemap/Tileset.js
+++ b/src/tilemap/Tileset.js
@@ -37,7 +37,7 @@ Phaser.Tileset = function (name, firstgid, width, height, margin, spacing, prope
     * This is the starting index of the first tile index this Tileset contains.
     * @property {integer} firstgid
     */
-    this.firstgid = firstgid | 0;
+    this.firstgid = firstgid | 1;
 
     /**
     * The width of each tile (in pixels).


### PR DESCRIPTION
With this.firstgid defaulting to 0 the tile index of every tile rendered is one more than it should be. With this.firstgid defaulting to 1 the problem seems fixed. 

It is true that the first tile id of a Tiled tileset is 0 but for phaser the same tile was always referenced by tile index 1.