### PR TITLE
Round linePositionX, to prevent placement of text on subpixel level which may cause blurriness

### DIFF
--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -389,6 +389,8 @@ Phaser.Text.prototype.updateText = function () {
         {
             linePositionX += (maxLineWidth - lineWidths[i]) / 2;
         }
+        
+        linePositionX = Math.round(linePositionX);
 
         if (this.colors.length > 0)
         {


### PR DESCRIPTION
When a multiline text object has align as 'center', text on lines other than the first one might be positioned at subpixel level, causing it to look blurry in low resolution rendering.