### PR TITLE
Issue #1885: 

### DIFF
--- a/src/physics/p2/World.js
+++ b/src/physics/p2/World.js
@@ -337,7 +337,9 @@ Phaser.Physics.P2.prototype = {
         {
             object.body = new Phaser.Physics.P2.Body(this.game, object, object.x, object.y, 1);
             object.body.debug = debug;
-            object.anchor.set(0.5);
+			if (typeof object.anchor !== 'undefined') {
+				object.anchor.set(0.5);
+			}
         }
 
     },


### PR DESCRIPTION
P2.enableBody now checks if an anchor exists on target object before attempting to set its value.

The sprite.anchor property isn't used internally by P2, so it should be safe to simply skip trying to set it if it doesn't exist, as in the case of non-sprite objects like Ropes.