### PR TITLE
AABB vs AABB collision support for Ninja

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -228,6 +228,16 @@ module.exports = function (grunt) {
         grunt.task.run('custom');
 
     });
+	grunt.registerTask('fullNinja', 'Phaser complete with ninja physics', function() {
+
+        grunt.option('exclude', 'creature');
+        grunt.option('filename', 'phaser');
+        grunt.option('sourcemap', true);
+        grunt.option('copy', true);
+
+        grunt.task.run('custom');
+
+    });
 
     grunt.registerTask('arcadephysics', 'Phaser with Arcade Physics, Tilemaps and Particles', function() {
 

--- a/src/physics/ninja/AABB.js
+++ b/src/physics/ninja/AABB.js
@@ -124,18 +124,17 @@ Phaser.Physics.Ninja.AABB.prototype = {
         this.oldpos.set(px, py);
 
     },
-
+    
     /**
-    * Process a world collision and apply the resulting forces.
-    *
-    * @method Phaser.Physics.Ninja.AABB#reportCollisionVsWorld
-    * @param {number} px - The tangent velocity
-    * @param {number} py - The tangent velocity
-    * @param {number} dx - Collision normal
-    * @param {number} dy - Collision normal
-    * @param {number} obj - Object this AABB collided with
-    */
-    reportCollisionVsWorld: function (px, py, dx, dy) {
+     * Process a collision partner-agnostic collision response and apply the resulting forces.
+     * 
+     * @method Phaser.Phyiscs.Ninja.AABB#reportCollision
+     * @param {number} px - The tangent velocity
+     * @param {number} py - The tangent velocity
+     * @param {number} dx - Collision normal
+     * @param {number} dy - Collision normal
+     */
+    reportCollision: function(px, py, dx, dy) {
 
         var p = this.pos;
         var o = this.oldpos;
@@ -150,7 +149,7 @@ Phaser.Physics.Ninja.AABB.prototype = {
 
         var ny = dp * dy;   //nx,ny is normal velocity
 
-        var tx = vx - nx;   //px,py is tangent velocity
+        var tx = vx - nx;   //tx,ty is tangent velocity
         var ty = vy - ny;
 
         //  We only want to apply collision response forces if the object is travelling into, and not out of, the collision
@@ -198,6 +197,20 @@ Phaser.Physics.Ninja.AABB.prototype = {
         o.x += px + bx + fx;
         o.y += py + by + fy;
 
+    },
+
+    /**
+    * Process a world collision and apply the resulting forces.
+    *
+    * @method Phaser.Physics.Ninja.AABB#reportCollisionVsWorld
+    * @param {number} px - The tangent velocity
+    * @param {number} py - The tangent velocity
+    * @param {number} dx - Collision normal
+    * @param {number} dy - Collision normal
+    */
+    reportCollisionVsWorld: function (px, py, dx, dy) {
+
+        this.reportCollision(px,py,dx,dy);
     },
 
     reverse: function () {
@@ -266,32 +279,16 @@ Phaser.Physics.Ninja.AABB.prototype = {
             px *= 0.5;
             py *= 0.5;
 
-            this.pos.add(px, py);
-            obj.pos.subtract(px, py);
-
-            if (dp1 < 0)
-            {
-                this.reverse();
-                obj.reverse();
-            }
+            this.reportCollision(px, py, dx, dy);
+            obj.reportCollision(-px, -py, -dx, -dy);
         }
         else if (!this.body.immovable)
         {
-            this.pos.subtract(px, py);
-
-            if (dp1 < 0)
-            {
-                this.reverse();
-            }
+            this.reportCollision(px,py,dx,dy);
         }
         else if (!obj.body.immovable)
         {
-            obj.pos.subtract(px, py);
-
-            if (dp1 < 0)
-            {
-                obj.reverse();
-            }
+            obj.reportCollision(-px, -py, -dx, -dy);
         }
 
     },

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -84,7 +84,7 @@ Phaser.TilemapLayer = function (game, tilemap, index, width, height) {
     * @property {Phaser.Frame} textureFrame
     * @protected
     */
-    this.textureFrame = new Phaser.Frame(0, 0, 0, width, height, 'tilemapLayer', game.rnd.uuid());
+    this.textureFrame = new Phaser.Frame(0, 0, 0, width, height, 'tilemapLayer');
 
     /**
     * The const type of this object.
@@ -310,8 +310,6 @@ Phaser.TilemapLayer.prototype.postUpdate = function () {
 
     Phaser.Component.FixedToCamera.postUpdate.call(this);
 
-    // this.postUpdateCore();
-
     //  Stops you being able to auto-scroll the camera if it's not following a sprite
     var camera = this.game.camera;
 
@@ -319,6 +317,27 @@ Phaser.TilemapLayer.prototype.postUpdate = function () {
     this.scrollY = camera.y * this.scrollFactorY / this.scale.y;
 
     this.render();
+
+};
+
+/**
+* Resizes the internal canvas and texture frame used by this TilemapLayer.
+*
+* This is an expensive call, so don't bind it to a window resize event or similar!
+* 
+* @method Phaser.TilemapLayer#resize
+* @param {number} width - The new width of the TilemapLayer
+* @param {number} height - The new height of the TilemapLayer
+*/
+Phaser.TilemapLayer.resize = function (width, height) {
+
+    this.baseTexture.width = width;
+    this.baseTexture.height = height;
+
+    this.resizeFrame(width, height);
+
+    this.textureFrame.resize(width, height);
+
 
 };
 
@@ -558,6 +577,7 @@ Phaser.TilemapLayer.prototype.getTiles = function (x, y, width, height, collides
         for (var wx = tx; wx < tx + tw; wx++)
         {
             var row = this.layer.data[wy];
+
             if (row && row[wx])
             {
                 if (fetchAll || row[wx].isInteresting(collides, interestingFace))
@@ -573,27 +593,6 @@ Phaser.TilemapLayer.prototype.getTiles = function (x, y, width, height, collides
 };
 
 /**
-* Flag controlling if the layer tiles wrap at the edges. Only works if the World size matches the Map size.
-*
-* @property {boolean} wrap
-* @memberof Phaser.TilemapLayer
-* @public
-* @default false
-*/
-Object.defineProperty(Phaser.TilemapLayer.prototype, "wrap", {
-
-    get: function () {
-        return this._wrap;
-    },
-
-    set: function (value) {
-        this._wrap = value;
-        this.dirty = true;
-    }
-
-});
-
-/**
 * Returns the appropriate tileset for the index, updating the internal cache as required.
 * This should only be called if `tilesets[index]` evaluates to undefined.
 *
@@ -602,8 +601,8 @@ Object.defineProperty(Phaser.TilemapLayer.prototype, "wrap", {
 * @param {integer} Tile index
 * @return {Phaser.Tileset|null} Returns the associated tileset or null if there is no such mapping.
 */
-Phaser.TilemapLayer.prototype.resolveTileset = function (tileIndex)
-{
+Phaser.TilemapLayer.prototype.resolveTileset = function (tileIndex) {
+
     var tilesets = this._mc.tilesets;
 
     //  Try for dense array if reasonable
@@ -639,8 +638,7 @@ Phaser.TilemapLayer.prototype.resolveTileset = function (tileIndex)
 * @method Phaser.TilemapLayer#resetTilesetCache
 * @public
 */
-Phaser.TilemapLayer.prototype.resetTilesetCache = function ()
-{
+Phaser.TilemapLayer.prototype.resetTilesetCache = function () {
 
     var tilesets = this._mc.tilesets;
 
@@ -658,7 +656,7 @@ Phaser.TilemapLayer.prototype.resetTilesetCache = function ()
  * @param {number} [xScale=1] - The scale factor along the X-plane 
  * @param {number} [yScale] - The scale factor along the Y-plane
  */
-Phaser.TilemapLayer.prototype.setScale = function(xScale, yScale) {
+Phaser.TilemapLayer.prototype.setScale = function (xScale, yScale) {
 
     xScale = xScale || 1;
     yScale = yScale || xScale;
@@ -694,8 +692,8 @@ Phaser.TilemapLayer.prototype.setScale = function(xScale, yScale) {
 * @param {integer} x
 * @param {integer} y
 */
-Phaser.TilemapLayer.prototype.shiftCanvas = function (context, x, y)
-{
+Phaser.TilemapLayer.prototype.shiftCanvas = function (context, x, y) {
+
     var canvas = context.canvas;
     var copyW = canvas.width - Math.abs(x);
     var copyH = canvas.height - Math.abs(y);
@@ -945,6 +943,7 @@ Phaser.TilemapLayer.prototype.renderDeltaScroll = function (shiftX, shiftY) {
         var trueBottom = Math.floor((renderH - 1 + scrollY) / th);
         this.renderRegion(scrollX, scrollY, left, trueTop, right, trueBottom);
     }
+
     if (top <= bottom)
     {
         // Clear top or bottom edge
@@ -963,8 +962,7 @@ Phaser.TilemapLayer.prototype.renderDeltaScroll = function (shiftX, shiftY) {
 * @method Phaser.TilemapLayer#renderFull
 * @private
 */
-Phaser.TilemapLayer.prototype.renderFull = function ()
-{
+Phaser.TilemapLayer.prototype.renderFull = function () {
     
     var scrollX = this._mc.scrollX;
     var scrollY = this._mc.scrollY;
@@ -1177,6 +1175,27 @@ Phaser.TilemapLayer.prototype.renderDebug = function () {
     }
 
 };
+
+/**
+* Flag controlling if the layer tiles wrap at the edges. Only works if the World size matches the Map size.
+*
+* @property {boolean} wrap
+* @memberof Phaser.TilemapLayer
+* @public
+* @default false
+*/
+Object.defineProperty(Phaser.TilemapLayer.prototype, "wrap", {
+
+    get: function () {
+        return this._wrap;
+    },
+
+    set: function (value) {
+        this._wrap = value;
+        this.dirty = true;
+    }
+
+});
 
 /**
 * Scrolls the map horizontally or returns the current x position.


### PR DESCRIPTION
Nearly all of the work required to get AABB vs. AABBs to work in Ninja was already present.

reportCollisionVsWorld already worked, and contained all of the logic required to resolve a collision once the appropriate vectors had been established. reportCollisionVsBody was refactored to use that function (now generically named reportCollision), and now AABBs can collide properly, including bouncing and friction. reportCollisionVsWorld is now just a wrapper around reportCollision to maintain compatibility.

The gruntfile was also updated to include a "fullNinja" task, because the generic way of making a custom build based on exclusion fails when no modules are actually excluded. There are certainly other ways to deal with that, it just seemed like a ninja-inclusive task for repeatedly testing/building with Ninja was sensible.

You can grab a testfile based on the phaser tutorial demo [here](https://github.com/standardgaussian/phaserDemos/blob/master/phaserDemoNinja.js). All the entities are Ninja AABBs.
