### PR TITLE
Fix reference error for process

### DIFF
--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -923,11 +923,11 @@ Phaser.Device._initialize = function () {
             device.node = true;
         }
         
-        if (device.node && typeof window.process.versions === 'object')
+        if (device.node && typeof process.versions === 'object')
         {
-            device.nodeWebkit = !!window.process.versions['node-webkit'];
+            device.nodeWebkit = !!process.versions['node-webkit'];
             
-            device.electron = !!window.process.versions.electron;
+            device.electron = !!process.versions.electron;
         }
         
         if (navigator['isCocoonJS'])


### PR DESCRIPTION
Previous code checked if *process* was defined, and later usages was on *window.process* which wasn't defined.

See https://github.com/mkristo/phaser/blob/da6d7a58e3c9828e6556157927d3a376c8042da8/src/system/Device.js#L921-L931