### PR TITLE
Fix cache.GetKeys() - Use _cacheMap to map from constant to _cache.

### DIFF
--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -1611,9 +1611,9 @@ Phaser.Cache.prototype = {
 
         var out = [];
 
-        if (this._cache[cache])
+        if (this._cacheMap[cache])
         {
-            for (var key in this._cache[cache])
+            for (var key in this._cacheMap[cache])
             {
                 if (key !== '__default' && key !== '__missing')
                 {


### PR DESCRIPTION
Fix cache.getKeys(), correctly use _cacheMap instead of _cache with the passed in constant.