### PR TITLE
Fix unmatched context.save() & context.restore() calls

### DIFF
--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -997,8 +997,6 @@ Phaser.TilemapLayer.prototype.render = function () {
         return;
     }
 
-    this.context.save();
-
     if (this.dirty || this.layer.dirty)
     {
         this.layer.dirty = false;
@@ -1024,6 +1022,8 @@ Phaser.TilemapLayer.prototype.render = function () {
         return;
     }
 
+    this.context.save();
+    
     mc.scrollX = scrollX;
     mc.scrollY = scrollY;
 


### PR DESCRIPTION
Fix unmatched context.save() & context.restore() calls in the redraw optimization return

```
    if (!redrawAll &&
        shiftX === 0 && shiftY === 0 &&
        mc.renderWidth === renderWidth && mc.renderHeight === renderHeight)
    {
        //  No reason to redraw map, looking at same thing and not invalidated.
        return;
    }
```

As a optimization, I have moved the save after the return instead of adding a restore before the return because there are no state changes until later.