### PR TITLE
Fixed pixel rounding in PIXI.TilingSprite.prototype._renderCanvas.

### DIFF
--- a/src/pixi/extras/TilingSprite.js
+++ b/src/pixi/extras/TilingSprite.js
@@ -289,10 +289,10 @@ PIXI.TilingSprite.prototype._renderCanvas = function(renderSession)
     //  Allow for pixel rounding
     if (renderSession.roundPixels)
     {
-        tx | 0;
-        ty | 0;
-        tw | 0;
-        th | 0;
+        tx |= 0;
+        ty |= 0;
+        tw |= 0;
+        th |= 0;
     }
 
     context.fillRect(tx, ty, tw, th);


### PR DESCRIPTION
Changed "x|0" to "x |= 0" in PIXI.TilingSprite.prototype._renderCanvas.

