### PR TITLE
Change splice.call(arguments, ..) to use slice

### DIFF
--- a/src/core/PluginManager.js
+++ b/src/core/PluginManager.js
@@ -52,7 +52,7 @@ Phaser.PluginManager.prototype = {
     */
     add: function (plugin) {
 
-        var args = Array.prototype.splice.call(arguments, 1);
+        var args = Array.prototype.slice.call(arguments, 1);
         var result = false;
 
         //  Prototype?

--- a/src/core/StateManager.js
+++ b/src/core/StateManager.js
@@ -308,7 +308,7 @@ Phaser.StateManager.prototype = {
 
         if (arguments.length > 2)
         {
-            this._args = Array.prototype.splice.call(arguments, 2);
+            this._args = Array.prototype.slice.call(arguments, 2);
         }
 
     },

--- a/src/gameobjects/GameObjectCreator.js
+++ b/src/gameobjects/GameObjectCreator.js
@@ -414,7 +414,7 @@ Phaser.GameObjectCreator.prototype = {
     */
     filter: function (filter) {
 
-        var args = Array.prototype.splice.call(arguments, 1);
+        var args = Array.prototype.slice.call(arguments, 1);
 
         var filter = new Phaser.Filter[filter](this.game);
 

--- a/src/gameobjects/GameObjectFactory.js
+++ b/src/gameobjects/GameObjectFactory.js
@@ -531,7 +531,7 @@ Phaser.GameObjectFactory.prototype = {
     */
     filter: function (filter) {
 
-        var args = Array.prototype.splice.call(arguments, 1);
+        var args = Array.prototype.slice.call(arguments, 1);
 
         var filter = new Phaser.Filter[filter](this.game);
 

--- a/src/time/Timer.js
+++ b/src/time/Timer.js
@@ -242,7 +242,7 @@ Phaser.Timer.prototype = {
     */
     add: function (delay, callback, callbackContext) {
 
-        return this.create(delay, false, 0, callback, callbackContext, Array.prototype.splice.call(arguments, 3));
+        return this.create(delay, false, 0, callback, callbackContext, Array.prototype.slice.call(arguments, 3));
 
     },
 
@@ -264,7 +264,7 @@ Phaser.Timer.prototype = {
     */
     repeat: function (delay, repeatCount, callback, callbackContext) {
 
-        return this.create(delay, false, repeatCount, callback, callbackContext, Array.prototype.splice.call(arguments, 4));
+        return this.create(delay, false, repeatCount, callback, callbackContext, Array.prototype.slice.call(arguments, 4));
 
     },
 
@@ -285,7 +285,7 @@ Phaser.Timer.prototype = {
     */
     loop: function (delay, callback, callbackContext) {
 
-        return this.create(delay, true, 0, callback, callbackContext, Array.prototype.splice.call(arguments, 3));
+        return this.create(delay, true, 0, callback, callbackContext, Array.prototype.slice.call(arguments, 3));
 
     },
 

--- a/src/utils/ArraySet.js
+++ b/src/utils/ArraySet.js
@@ -168,7 +168,7 @@ Phaser.ArraySet.prototype = {
     */
     callAll: function (key) {
 
-        var args = Array.prototype.splice.call(arguments, 1);
+        var args = Array.prototype.slice.call(arguments, 1);
 
         var i = this.list.length;
 


### PR DESCRIPTION
- Addresses concerns in #2032 and 'slight optimization'

- Bypasses issue of usage incorrectly omitting 2nd argument to `splice`

- More clear of intent; `slice` does not modifify `arguments`

- `slice` *on `arguments`*, with practical lengths, is faster across all desktop browsers by varying degrees
  - Probably due to parameter-aliasing and de-opts when modified.
  - Both `slice` and `splice` create a new Array object
