### PR TITLE
Fix TypeScript `addKeys` declaration

### DIFF
--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -11114,7 +11114,7 @@ declare module Phaser {
         * @param keys A key mapping object, i.e. `{ 'up': Phaser.Keyboard.W, 'down': Phaser.Keyboard.S }` or `{ 'up': 52, 'down': 53 }`.
         * @return An object containing user selected properties
         */
-        addKeys(keys: any[]): any;
+        addKeys(keys: any): any;
 
         /**
         * By default when a key is pressed Phaser will not stop the event from propagating up to the browser.

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2092,7 +2092,7 @@ declare module Phaser {
 
         addCallbacks(context: any, onDown?: Function, onUp?: Function, onPress?: Function): void;
         addKey(keycode: number): Phaser.Key;
-        addKeys(keys: any[]): any;
+        addKeys(keys: any): any;
         addKeyCapture(keycode: any): void;
         createCursorKeys(): Phaser.CursorKeys;
         clearCaptures(): void;


### PR DESCRIPTION
Since we expect an object that's `any`
instead of an array `any[]`