### PR TITLE
Prevent 'data:' URLs from being prefixed

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -2028,7 +2028,7 @@ Phaser.Loader.prototype = {
             return false;
         }
 
-        if (url.substr(0, 4) === 'http' || url.substr(0, 2) === '//')
+        if (url.substr(0, 5) === 'data:' || url.substr(0, 4) === 'http' || url.substr(0, 2) === '//')
         {
             return url;
         }

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -2028,7 +2028,7 @@ Phaser.Loader.prototype = {
             return false;
         }
 
-        if (url.substr(0, 5) === 'data:' || url.substr(0, 4) === 'http' || url.substr(0, 2) === '//')
+        if (url.match(/^(?:blob:|data:|http:\/\/|https:\/\/|\/\/)/))
         {
             return url;
         }


### PR DESCRIPTION
Fixes an issue where 'data:' URLs may get prefixed by `#baseURL` and `#path` properties making these URLs invalid.