### PR TITLE
Convenience function: Remove specific collision group(s) from a P2 Body

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 * TypeScript definitions fixes and updates (thanks @clark-stevenson @milkey-mouse @timotei @qdrj)
 * JSDoc typo fixes (thanks @rwrountree)
 * Math.average has been optimized (thanks @rwrountree #2025)
+* When calling GameObject.revive the `heal` method is called to apply the health value, allowing it to take into consideration a `maxHealth` value if set (thanks @bsparks #2027)
 * Change splice.call(arguments, ..) to use slice instead (thanks @pnstickne  #2034 #2032)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 ### New Features
 
 * Emitter.emitParticle now has 4 new optional arguments: `x`, `y`, `key` and `frame`. These allow you to override whatever the Emitter default values may be and emit the particle from the given coordinates and with a new texture.
+* Group.resetChild is a new method that allows you to call both `child.reset` and/or `child.loadTexture` on the given child object. This is used internally by `getFirstDead` and similar, but is made public so you can use it as a group iteration callback. Note that the child must have public `reset` and `loadTexture` methods to be valid for the call.
+* Group.getFirstDead, Group.getFirstAlive and Group.getFirstExists all have new optional arguments: `createIfNull`, `x`, `y`, `key` and `frame`. If the method you call cannot find a matching child (i.e. getFirstDead cannot find any dead children) then the optional `createIfNull` allows you to instantly create a new child in the group using the position and texture arguments to do so. This allows you to always get a child back from the Group and remove the need to do null checks and Group inserts from your game code. The same arguments can also be used in a different way: if `createIfNull` is false AND you provide the extra arguments AND a child is found then it will be passed to the new `Group.resetChild` method. This allows you to retrieve a child from the Group and have it reset and instantly ready for use in your game without any extra code.
 
 ### Updates
 

--- a/README.md
+++ b/README.md
@@ -260,8 +260,9 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 
 ### Updates
 
-* TypeScript definitions fixes and updates (thanks @clark-stevenson)
-* JSDoc typo fixes (thanks )
+* TypeScript definitions fixes and updates (thanks @clark-stevenson @milkey-mouse)
+* JSDoc typo fixes (thanks @rwrountree)
+* Math.average has been optimized (thanks @rwrountree #2025)
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 
 ### Bug Fixes
 
+* Loader.bitmapFont wouldn't automatically set the `atlasURL` value if just the key was given.
 
 For changes in previous releases please see the extensive [Version History](https://github.com/photonstorm/phaser/blob/master/CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Thousands of developers worldwide use it. From indies and multi-national digital
 ![div](http://www.phaser.io/images/github/div.png)
 
 <a name="whats-new"></a>
-## What's new in Phaser 2.4.3
+## What's new in Phaser 2.4.4
 
 <div align="center"><img src="http://phaser.io/images/github/news.jpg"></div>
 
 > 24th August 2015
 
-The release of Phaser 2.4.3 continues our work with bug fixes, new features and continued optimizations. As before it's a point-release, making it a safe upgrade for anyone using a previous 2.4 build.
+The release of Phaser 2.4.4 continues our work with bug fixes, new features and continued optimizations. As before it's a point-release, making it a safe upgrade for anyone using a previous 2.4 build.
 
 As well as working on this release we've also been busily writing tutorials for the first issue of [Interphase](http://phaser.io/interphase/), our new publication for Phaser developers. Packed full of exclusive content we've been coding games, writing tutorials and authoring deep-dive articles for the first issue. It's been a blast so far and I'm excited for it's release in early September - and if you [pre-order now](http://phaser.io/interphase) with the discount code 'earlybird' you can save 15% on the cover price.
 
@@ -101,15 +101,15 @@ Install via [npm](https://www.npmjs.com)
 
 [jsDelivr](http://www.jsdelivr.com/#!phaser) is a "super-fast CDN for developers". Include the following in your html:
 
-`<script src="//cdn.jsdelivr.net/phaser/2.4.3/phaser.js"></script>`
+`<script src="//cdn.jsdelivr.net/phaser/2.4.4/phaser.js"></script>`
 
 or the minified version:
 
-`<script src="//cdn.jsdelivr.net/phaser/2.4.3/phaser.min.js"></script>`
+`<script src="//cdn.jsdelivr.net/phaser/2.4.4/phaser.min.js"></script>`
 
 [cdnjs.com](https://cdnjs.com/libraries/phaser) also offers a free CDN service. They have all versions of Phaser and even the custom builds:
 
-`<script src="https://cdnjs.cloudflare.com/ajax/libs/phaser/2.4.3/phaser.js"></script>`
+`<script src="https://cdnjs.cloudflare.com/ajax/libs/phaser/2.4.4/phaser.js"></script>`
 
 ### Phaser Sandbox
 
@@ -254,58 +254,17 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 <a name="change-log"></a>
 ## Change Log
 
-## Version 2.4.3 - "Coramen" - 24th August 2015
+## Version 2.4.4 - "Amador" - in dev
 
 ### New Features
 
-* Loader.images is a new method that allows you to pass an array of image keys, and optionally the URLs to the Loader and have them all added to the load queue in one go.
-* TweenManager.frameBased allows you to control if all newly created Tweens update based on the physics step (i.e. frame based) or the system clock (time based). A frame based tween will use the physics elapsed timer when updating. This means it will retain the same consistent frame rate, regardless of the speed of the device. The duration value given should be given in frames. If the Tween uses a time based update (which is the default) then the duration is given in milliseconds. In this situation a 2000ms tween will last exactly 2 seconds, regardless of the device and how many visual updates the tween has actually been through.
-* Tween.frameBased does the same as TweenManager.frameBased but allows you to set the value on a per-tween basis.
-* BitmapText.smoothed is a new boolean property that allows you to set texture smoothing on a bitmap font or not. By default smoothing is always on, but you can turn it off which helps for bitmap fonts created from pixel art style character sets.
-* Text.addFontStyle and Text.addFontWeight allow you to apply font weights and styles to specific characters in a Text object. For example you can now include bold or italics within single Text objects (thanks @jdnichollsc #1950)
-* PIXI.CanvasPool is a new static global created to deal with the issue of resource leaks and continuous DOM node build-up when creating lots of Text or BitmapData objects, or when calling `generateTexture` on any display object. The CanvasPool will do its best to re-use out dated canvas elements rather than filling up the DOM with new ones.
-* Sprite.setTexture has a new `destroyBase` parameter - set this to `true` if you know the base used a generated texture that isn't being used by any other sprites. This will free-up the canvas for further re-use by other calls to `generateTexture` or Text objects.
-* Line.midPoint will return a Point object where the `x` and `y` values correspond to the center (or midpoint) of the Line segment.
-* Line.rotateAround allows you to rotate a Line around the given coordinates (in world space)
-* Line.centerOn will position the Line so that its midpoint lays on the coordinates given.
-* BitmapData.line draws a line to the BitmapData in the color and thickness specified.
-* BitmapData.op is a handy short-code to get and set the canvas global composite operator.
-* BitmapData.drawFull draws the given Game Object or Group to a BitmapData and then recursively iterates through all of its children, including children of Game Objects and Groups. It can draw Text, BitmapText, Sprites, Images, Emitters and Graphics objects. It's perfectly valid to pass in `game.world` as the parent object, and it will iterate through the entire display list.
-* Phaser.TilemapParser.INSERT_NULL is a new boolean that controls what happens when the parser encounters an empty tile: When scanning the Tiled map data the TilemapParser can either insert a null value (true) or a `Phaser.Tile` instance with an index of -1 (false, the default). Depending on your game type depends how this should be configured. If you've a large sparsely populated map and the tile data doesn't need to change then setting this value to `true` will help with memory consumption. However if your map is small, or you need to update the tiles (perhaps the map dynamically changes during the game) then leave the default value set (thanks #1982)
-
 ### Updates
 
-* TypeScript definitions fixes and updates (thanks @clark-stevenson @vrecluse @yahiko00 @cloakedninjas @qdrj)
-* JSDoc typo fixes (thanks @Cowa @yahiko00 @qdrj @STuFF)
-* VideoStream.active = false is used if the browser supports it, otherwise it falls back to VideoStream.stop.
-* Text can now accept `undefined` or `null` as the `text` argument in the constructor and will cast it as an empty string.
-* Point.rotate uses a faster and simpler rotation function when no distance argument is specified.
-* Setting a P2.Body from Static or Kinematic to Dynamic will now automatically adjust the Body.mass to be 1 (thanks @wayfu #2005)
-* Pointer.withinGame is no longer automatically set to `false` in the `Pointer.stop` method. Instead it will check if the Pointer actually is within the stage bounds and only set `withinGame` to `false` if it's outside the bounds.
-* MSPointer now has an `onPointerUpGlobal` handler for when the pointer is released outside of the canvas, but still within the browser window. This means that in IE11 a Sprites `onInputUp` event will now trigger even when outside the canvas (thanks @bvargish #2000)
-* MSPointer now has handlers for the pointer being over and outside of the canvas element, which sets the `Pointer.withinGame` booleans accordingly. It also triggers the `Mouse.mouseOutCallback` and `Mouse.mouseOverCallback` callbacks respectively.
-* The MSPointer event listeners have been renamed to all lower-case, i.e. 'pointerDown' is now 'pointerdown'.
+* TypeScript definitions fixes and updates (thanks @clark-stevenson)
+* JSDoc typo fixes (thanks )
 
 ### Bug Fixes
 
-* Pointer.isDown was reset before the `Input.onUp` event, meaning you couldn't get the Pointer duration from within the event.
-* Pointer.isDown was reset before the Input tap calculations, meaning `onTap` wouldn't dispatch (thanks @stovenator #1953)
-* InputHandler.pointerOver would get stuck in an 'isOver' state if the Sprite changed its visibility during an `onUp` callback (thanks @Cristy94 #1955)
-* If you override the P2 mpx functions, to define your own px to meters values, the P2 Debug Bodies would ignore it (thanks @vrecluse #1957)
-* ArrayUtils.numberArrayStep would return an empty array if a single parameter was given, instead of a single step array (thanks @pooya72 #1958)
-* Text with tints applied wouldn't update properly in Canvas mode.
-* Removed use of the deprecated `enterFullScreen` and `leaveFullScreen` signals from the Scale Manager (thanks @mmanlod #1972)
-* BitmapText with tints applied wouldn't update properly in Canvas mode (thanks @Pajamaman #1969)
-* Group.cacheAsBitmap would be incorrectly offset in Canvas mode (thanks @mkristo #1925)
-* Text.setTextBounds didn't add the x and y values to the width and height offsets.
-* Line.rotate used a calculation method which resulted in the line growing (or shrinking) in length over time the more it was rotated. The new method never changes the lines length.
-* BitmapText.font failed to pull the new font from the Phaser Cache, stopping it from updating properly (thanks @AbrahamAlcaina #2001)
-* Video.stop now removes the 'playing' event listener, which stop Videos set to loop from throwing errors after being destroyed.
-* Tilemap.createFromObjects has been strengthened so that will only create Sprites for matching gids/ids/names. It also only sets the Sprite width and height values if they are present in the Tiled data (thanks @pparke #2012)
-* TilingSprite._renderCanvas wasn't correctly allowing for pixel rounding (thanks @ximop #2022)
-* Cache.addSpriteSheet didn't include default values for the `frameMax`, `margin` and `spacing` arguments (thanks @vladkens #2017 #2018)
-* Tilemap.shuffle was calling the deprecated Phaser.Utils.shuffle, which has now moved to Phaser.ArrayUtils.shuffle.
-* Enabling a filter on a display object that had a multiply blend mode set would cause the object to become invisible. The two cannot be combined, so when you set a filter on a display object it now automatically resets the blend mode to `NORMAL`. The same does not happen in reverse however, so if you've got a filter set and then change the blend mode to multiply it will still break. Be careful to capture this yourself (thanks @wayfu #1994)
 
 For changes in previous releases please see the extensive [Version History](https://github.com/photonstorm/phaser/blob/master/CHANGELOG.md).
 
@@ -344,10 +303,10 @@ All rights reserved.
 
 [![Analytics](https://ga-beacon.appspot.com/UA-44006568-2/phaser/index)](https://github.com/igrigorik/ga-beacon)
 
-[get-js]: https://github.com/photonstorm/phaser/releases/download/v2.4.3/phaser.js
-[get-minjs]: https://github.com/photonstorm/phaser/releases/download/v2.4.3/phaser.min.js
-[get-zip]: https://github.com/photonstorm/phaser/archive/v2.4.3.zip
-[get-tgz]: https://github.com/photonstorm/phaser/archive/v2.4.3.tar.gz
+[get-js]: https://github.com/photonstorm/phaser/releases/download/v2.4.4/phaser.js
+[get-minjs]: https://github.com/photonstorm/phaser/releases/download/v2.4.4/phaser.min.js
+[get-zip]: https://github.com/photonstorm/phaser/archive/v2.4.4.zip
+[get-tgz]: https://github.com/photonstorm/phaser/archive/v2.4.4.tar.gz
 [clone-http]: https://github.com/photonstorm/phaser.git
 [clone-ssh]: git@github.com:photonstorm/phaser.git
 [clone-svn]: https://github.com/photonstorm/phaser

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 * JSDoc typo fixes (thanks @rwrountree)
 * Math.average has been optimized (thanks @rwrountree #2025)
 * Change splice.call(arguments, ..) to use slice instead (thanks @pnstickne  #2034 #2032)
+* RandomDataGenerator.float is a new alias for the method 'realInRange' and takes the same arguments.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 * JSDoc typo fixes (thanks @rwrountree)
 * Math.average has been optimized (thanks @rwrountree #2025)
 * Change splice.call(arguments, ..) to use slice instead (thanks @pnstickne  #2034 #2032)
-* RandomDataGenerator.float is a new alias for the method 'realInRange' and takes the same arguments.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -258,11 +258,14 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 
 ### New Features
 
+* Emitter.emitParticle now has 4 new optional arguments: `x`, `y`, `key` and `frame`. These allow you to override whatever the Emitter default values may be and emit the particle from the given coordinates and with a new texture.
+
 ### Updates
 
-* TypeScript definitions fixes and updates (thanks @clark-stevenson @milkey-mouse)
+* TypeScript definitions fixes and updates (thanks @clark-stevenson @milkey-mouse @timotei @qdrj)
 * JSDoc typo fixes (thanks @rwrountree)
 * Math.average has been optimized (thanks @rwrountree #2025)
+* Change splice.call(arguments, ..) to use slice instead (thanks @pnstickne  #2034 #2032)
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phaser",
-  "version": "2.4.3",
-  "release": "Coramen",
+  "version": "2.4.4",
+  "release": "Amador",
   "description": "A fast, free and fun HTML5 Game Framework for Desktop and Mobile web browsers.",
   "author": "Richard Davey <rdavey@gmail.com> (http://www.photonstorm.com)",
   "logo": "https://raw.github.com/photonstorm/phaser/master/phaser-logo-small.png",

--- a/resources/release-names.txt
+++ b/resources/release-names.txt
@@ -1,8 +1,9 @@
 Wheel of Time
-
-Nations of the Westlands
+-------------
 
 Anything marked * has been used as a release name already.
+
+Nations of the Westlands
 
 Altara *
 
@@ -12,7 +13,7 @@ POI: River Eldar, Sea of Storms
 
 Amadicia *
 
-Capital: Amador
+Capital: Amador *
 Cities: Abila, Bellon, Jeramel, Mardecin, Sienda
 POI: Mountains of Mist, River Eldar, River Sharia, Shadow Coast
 

--- a/src/Phaser.js
+++ b/src/Phaser.js
@@ -15,7 +15,7 @@ var Phaser = Phaser || {
     * @constant
     * @type {string}
     */
-    VERSION: '2.4.3',
+    VERSION: '2.4.4-dev',
 
     /**
     * An array of Phaser game instances.

--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -465,13 +465,13 @@ Phaser.Group.prototype.getAt = function (index) {
 /**
 * Creates a new Phaser.Sprite object and adds it to the top of this group.
 *
-* Use {@link #classType} to change the type of object creaded.
+* Use {@link #classType} to change the type of object created.
 *
 * @method Phaser.Group#create
 * @param {number} x - The x coordinate to display the newly created Sprite at. The value is in relation to the group.x point.
 * @param {number} y - The y coordinate to display the newly created Sprite at. The value is in relation to the group.y point.
-* @param {string} key - The Game.cache key of the image that this Sprite will use.
-* @param {integer|string} [frame] - If the Sprite image contains multiple frames you can specify which one to use here.
+* @param {string|Phaser.RenderTexture|Phaser.BitmapData|Phaser.Video|PIXI.Texture} [key] - This is the image or texture used by the Sprite during rendering. It can be a string which is a reference to the Cache Image entry, or an instance of a RenderTexture, BitmapData, Video or PIXI.Texture.
+* @param {string|number} [frame] - If this Sprite is using part of a sprite sheet or texture atlas you can specify the exact frame to use by giving a string or numeric index.
 * @param {boolean} [exists=true] - The default exists state of the Sprite.
 * @return {DisplayObject} The child that was created: will be a {@link Phaser.Sprite} unless {@link #classType} has been changed.
 */
@@ -1773,47 +1773,134 @@ Phaser.Group.prototype.iterate = function (key, value, returnType, callback, cal
 
 /**
 * Get the first display object that exists, or doesn't exist.
+* 
+* You can use the optional argument `createIfNull` to create a new Game Object if none matching your exists argument were found in this Group.
+*
+* It works by calling `Group.create` passing it the parameters given to this method, and returning the new child.
+*
+* If a child *was* found , `createIfNull` is `false` and you provided the additional arguments then the child
+* will be reset and/or have a new texture loaded on it. This is handled by `Group.resetChild`.
 *
 * @method Phaser.Group#getFirstExists
 * @param {boolean} [exists=true] - If true, find the first existing child; otherwise find the first non-existing child.
-* @return {any} The first child, or null if none found.
+* @param {boolean} [createIfNull=false] - If `true` and no alive children are found a new one is created.
+* @param {number} [x] - The x coordinate to reset the child to. The value is in relation to the group.x point.
+* @param {number} [y] - The y coordinate to reset the child to. The value is in relation to the group.y point.
+* @param {string|Phaser.RenderTexture|Phaser.BitmapData|Phaser.Video|PIXI.Texture} [key] - This is the image or texture used by the Sprite during rendering. It can be a string which is a reference to the Cache Image entry, or an instance of a RenderTexture, BitmapData, Video or PIXI.Texture.
+* @param {string|number} [frame] - If this Sprite is using part of a sprite sheet or texture atlas you can specify the exact frame to use by giving a string or numeric index.
+* @return {DisplayObject} The first child, or `null` if none found and `createIfNull` was false.
 */
-Phaser.Group.prototype.getFirstExists = function (exists) {
+Phaser.Group.prototype.getFirstExists = function (exists, createIfNull, x, y, key, frame) {
+
+    if (createIfNull === undefined) { createIfNull = false; }
 
     if (typeof exists !== 'boolean')
     {
         exists = true;
     }
 
-    return this.iterate('exists', exists, Phaser.Group.RETURN_CHILD);
+    var child = this.iterate('exists', exists, Phaser.Group.RETURN_CHILD);
+
+    return (child === null && createIfNull) ? this.create(x, y, key, frame) : this.resetChild(child, x, y, key, frame);
 
 };
 
 /**
 * Get the first child that is alive (`child.alive === true`).
 *
-* This is handy for checking if everything has been wiped out, or choosing a squad leader, etc.
+* This is handy for choosing a squad leader, etc.
+*
+* You can use the optional argument `createIfNull` to create a new Game Object if no alive ones were found in this Group.
+*
+* It works by calling `Group.create` passing it the parameters given to this method, and returning the new child.
+*
+* If a child *was* found , `createIfNull` is `false` and you provided the additional arguments then the child
+* will be reset and/or have a new texture loaded on it. This is handled by `Group.resetChild`.
 *
 * @method Phaser.Group#getFirstAlive
-* @return {any} The first alive child, or null if none found.
+* @param {boolean} [createIfNull=false] - If `true` and no alive children are found a new one is created.
+* @param {number} [x] - The x coordinate to reset the child to. The value is in relation to the group.x point.
+* @param {number} [y] - The y coordinate to reset the child to. The value is in relation to the group.y point.
+* @param {string|Phaser.RenderTexture|Phaser.BitmapData|Phaser.Video|PIXI.Texture} [key] - This is the image or texture used by the Sprite during rendering. It can be a string which is a reference to the Cache Image entry, or an instance of a RenderTexture, BitmapData, Video or PIXI.Texture.
+* @param {string|number} [frame] - If this Sprite is using part of a sprite sheet or texture atlas you can specify the exact frame to use by giving a string or numeric index.
+* @return {DisplayObject} The alive dead child, or `null` if none found and `createIfNull` was false.
 */
-Phaser.Group.prototype.getFirstAlive = function () {
+Phaser.Group.prototype.getFirstAlive = function (createIfNull, x, y, key, frame) {
 
-    return this.iterate('alive', true, Phaser.Group.RETURN_CHILD);
+    if (createIfNull === undefined) { createIfNull = false; }
+
+    var child = this.iterate('alive', true, Phaser.Group.RETURN_CHILD);
+
+    return (child === null && createIfNull) ? this.create(x, y, key, frame) : this.resetChild(child, x, y, key, frame);
 
 };
 
 /**
 * Get the first child that is dead (`child.alive === false`).
 *
-* This is handy for checking if everything has been wiped out, or choosing a squad leader, etc.
+* This is handy for checking if everything has been wiped out and adding to the pool as needed.
+*
+* You can use the optional argument `createIfNull` to create a new Game Object if no dead ones were found in this Group.
+*
+* It works by calling `Group.create` passing it the parameters given to this method, and returning the new child.
+*
+* If a child *was* found , `createIfNull` is `false` and you provided the additional arguments then the child
+* will be reset and/or have a new texture loaded on it. This is handled by `Group.resetChild`.
 *
 * @method Phaser.Group#getFirstDead
-* @return {any} The first dead child, or null if none found.
+* @param {boolean} [createIfNull=false] - If `true` and no dead children are found a new one is created.
+* @param {number} [x] - The x coordinate to reset the child to. The value is in relation to the group.x point.
+* @param {number} [y] - The y coordinate to reset the child to. The value is in relation to the group.y point.
+* @param {string|Phaser.RenderTexture|Phaser.BitmapData|Phaser.Video|PIXI.Texture} [key] - This is the image or texture used by the Sprite during rendering. It can be a string which is a reference to the Cache Image entry, or an instance of a RenderTexture, BitmapData, Video or PIXI.Texture.
+* @param {string|number} [frame] - If this Sprite is using part of a sprite sheet or texture atlas you can specify the exact frame to use by giving a string or numeric index.
+* @return {DisplayObject} The first dead child, or `null` if none found and `createIfNull` was false.
 */
-Phaser.Group.prototype.getFirstDead = function () {
+Phaser.Group.prototype.getFirstDead = function (createIfNull, x, y, key, frame) {
 
-    return this.iterate('alive', false, Phaser.Group.RETURN_CHILD);
+    if (createIfNull === undefined) { createIfNull = false; }
+
+    var child = this.iterate('alive', false, Phaser.Group.RETURN_CHILD);
+
+    return (child === null && createIfNull) ? this.create(x, y, key, frame) : this.resetChild(child, x, y, key, frame);
+
+};
+
+/**
+* Takes a child and if the `x` and `y` arguments are given it calls `child.reset(x, y)` on it.
+*
+* If the `key` and optionally the `frame` arguments are given, it calls `child.loadTexture(key, frame)` on it.
+*
+* The two operations are separate. For example if you just wish to load a new texture then pass `null` as the x and y values.
+*
+* @method Phaser.Group#resetChild
+* @param {DisplayObject} child - The child to reset and/or load the texture on.
+* @param {number} [x] - The x coordinate to reset the child to. The value is in relation to the group.x point.
+* @param {number} [y] - The y coordinate to reset the child to. The value is in relation to the group.y point.
+* @param {string|Phaser.RenderTexture|Phaser.BitmapData|Phaser.Video|PIXI.Texture} [key] - This is the image or texture used by the Sprite during rendering. It can be a string which is a reference to the Cache Image entry, or an instance of a RenderTexture, BitmapData, Video or PIXI.Texture.
+* @param {string|number} [frame] - If this Sprite is using part of a sprite sheet or texture atlas you can specify the exact frame to use by giving a string or numeric index.
+* @return {DisplayObject} The child that was reset: usually a {@link Phaser.Sprite}.
+*/
+Phaser.Group.prototype.resetChild = function (child, x, y, key, frame) {
+
+    if (child === null)
+    {
+        return null;
+    }
+
+    if (x === undefined) { x = null; }
+    if (y === undefined) { y = null; }
+
+    if (x !== null && y !== null)
+    {
+        child.reset(x, y);
+    }
+
+    if (key !== undefined)
+    {
+        child.loadTexture(key, frame);
+    }
+
+    return child;
 
 };
 

--- a/src/core/PluginManager.js
+++ b/src/core/PluginManager.js
@@ -52,7 +52,7 @@ Phaser.PluginManager.prototype = {
     */
     add: function (plugin) {
 
-        var args = Array.prototype.splice.call(arguments, 1);
+        var args = Array.prototype.slice.call(arguments, 1);
         var result = false;
 
         //  Prototype?

--- a/src/core/StateManager.js
+++ b/src/core/StateManager.js
@@ -308,7 +308,7 @@ Phaser.StateManager.prototype = {
 
         if (arguments.length > 2)
         {
-            this._args = Array.prototype.splice.call(arguments, 2);
+            this._args = Array.prototype.slice.call(arguments, 2);
         }
 
     },

--- a/src/gameobjects/GameObjectCreator.js
+++ b/src/gameobjects/GameObjectCreator.js
@@ -414,7 +414,7 @@ Phaser.GameObjectCreator.prototype = {
     */
     filter: function (filter) {
 
-        var args = Array.prototype.splice.call(arguments, 1);
+        var args = Array.prototype.slice.call(arguments, 1);
 
         var filter = new Phaser.Filter[filter](this.game);
 

--- a/src/gameobjects/GameObjectFactory.js
+++ b/src/gameobjects/GameObjectFactory.js
@@ -531,7 +531,7 @@ Phaser.GameObjectFactory.prototype = {
     */
     filter: function (filter) {
 
-        var args = Array.prototype.splice.call(arguments, 1);
+        var args = Array.prototype.slice.call(arguments, 1);
 
         var filter = new Phaser.Filter[filter](this.game);
 

--- a/src/gameobjects/components/LifeSpan.js
+++ b/src/gameobjects/components/LifeSpan.js
@@ -38,10 +38,10 @@ Phaser.Component.LifeSpan.prototype = {
 
     /**
     * A useful flag to control if the Game Object is alive or dead.
-    * 
+    *
     * This is set automatically by the Health components `damage` method should the object run out of health.
     * Or you can toggle it via your game code.
-    * 
+    *
     * This property is mostly just provided to be used by your game - it doesn't effect rendering or logic updates.
     * However you can use `Group.getFirstAlive` in conjunction with this property for fast object pooling and recycling.
     * @property {boolean} alive
@@ -51,12 +51,12 @@ Phaser.Component.LifeSpan.prototype = {
 
     /**
     * The lifespan allows you to give a Game Object a lifespan in milliseconds.
-    * 
+    *
     * Once the Game Object is 'born' you can set this to a positive value.
-    * 
+    *
     * It is automatically decremented by the millisecond equivalent of `game.time.physicsElapsed` each frame.
     * When it reaches zero it will call the `kill` method.
-    * 
+    *
     * Very handy for particles, bullets, collectibles, or any other short-lived entity.
     *
     * @property {number} lifespan
@@ -66,9 +66,9 @@ Phaser.Component.LifeSpan.prototype = {
 
     /**
     * Brings a 'dead' Game Object back to life, optionally resetting its health value in the process.
-    * 
+    *
     * A resurrected Game Object has its `alive`, `exists` and `visible` properties all set to true.
-    * 
+    *
     * It will dispatch the `onRevived` event. Listen to `events.onRevived` for the signal.
     *
     * @method
@@ -82,10 +82,10 @@ Phaser.Component.LifeSpan.prototype = {
         this.alive = true;
         this.exists = true;
         this.visible = true;
- 
-        if (typeof this.health === 'number')
+
+        if (typeof this.heal === 'function')
         {
-            this.health = health;
+            this.heal(health);
         }
 
         if (this.events)
@@ -99,12 +99,12 @@ Phaser.Component.LifeSpan.prototype = {
 
     /**
     * Kills a Game Object. A killed Game Object has its `alive`, `exists` and `visible` properties all set to false.
-    * 
+    *
     * It will dispatch the `onKilled` event. You can listen to `events.onKilled` for the signal.
-    * 
-    * Note that killing a Game Object is a way for you to quickly recycle it in an object pool, 
+    *
+    * Note that killing a Game Object is a way for you to quickly recycle it in an object pool,
     * it doesn't destroy the object or free it up from memory.
-    * 
+    *
     * If you don't need this Game Object any more you should call `destroy` instead.
     *
     * @method

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1278,15 +1278,15 @@ Phaser.Loader.prototype = {
     * 
     * If the textureURL isn't specified then the Loader will take the key and create a filename from that.
     * For example if the key is "megaFont" and textureURL is null then the Loader will set the URL to be "megaFont.png".
-    * The same is true for the xmlURL. If xmlURL isn't specified and no xmlData has been provided then the Loader will
-    * set the xmlURL to be the key. For example if the key is "megaFont" the xmlURL will be set to "megaFont.xml".
+    * The same is true for the atlasURL. If atlasURL isn't specified and no atlasData has been provided then the Loader will
+    * set the atlasURL to be the key. For example if the key is "megaFont" the atlasURL will be set to "megaFont.xml".
     * 
     * If you do not desire this action then provide URLs and / or a data object.
     *
     * @method Phaser.Loader#bitmapFont
     * @param {string} key - Unique asset key of the bitmap font.
     * @param {string} textureURL -  URL of the Bitmap Font texture file. If undefined or `null` the url will be set to `<key>.png`, i.e. if `key` was "megaFont" then the URL will be "megaFont.png".
-    * @param {string} atlasURL - URL of the Bitmap Font atlas file (xml/json).
+    * @param {string} atlasURL - URL of the Bitmap Font atlas file (xml/json). If undefined or `null` AND `atlasData` is null, the url will be set to `<key>.xml`, i.e. if `key` was "megaFont" then the URL will be "megaFont.xml".
     * @param {object} atlasData - An optional Bitmap Font atlas in string form (stringified xml/json).
     * @param {number} [xSpacing=0] - If you'd like to add additional horizontal spacing between the characters then set the pixel value here.
     * @param {number} [ySpacing=0] - If you'd like to add additional vertical spacing between the lines then set the pixel value here.
@@ -1301,6 +1301,12 @@ Phaser.Loader.prototype = {
 
         if (atlasURL === undefined) { atlasURL = null; }
         if (atlasData === undefined) { atlasData = null; }
+
+        if (atlasURL === null && atlasData === null)
+        {
+            atlasURL = key + '.xml';
+        }
+
         if (xSpacing === undefined) { xSpacing = 0; }
         if (ySpacing === undefined) { ySpacing = 0; }
 
@@ -1336,6 +1342,7 @@ Phaser.Loader.prototype = {
         }
 
         return this;
+
     },
 
     /**

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -2012,7 +2012,8 @@ Phaser.Loader.prototype = {
 
     /**
     * Transforms the asset URL.
-    * The default implementation prepends the baseURL if the url doesn't being with http or //
+    * 
+    * The default implementation prepends the baseURL if the url doesn't begin with http or //
     *
     * @method Phaser.Loader#transformUrl
     * @protected

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -70,7 +70,7 @@ Phaser.Math = {
     *
     * @param {number} val
     * @param {number} [epsilon=(small value)]
-    * @return {boolean} ceiling(val-epsilon)
+    * @return {number} ceiling(val-epsilon)
     */
     fuzzyCeil: function (val, epsilon) {
         if (epsilon === undefined) { epsilon = 0.0001; }
@@ -82,7 +82,7 @@ Phaser.Math = {
     *
     * @param {number} val
     * @param {number} [epsilon=(small value)]
-    * @return {boolean} floor(val-epsilon)
+    * @return {number} floor(val+epsilon)
     */
     fuzzyFloor: function (val, epsilon) {
         if (epsilon === undefined) { epsilon = 0.0001; }
@@ -98,13 +98,14 @@ Phaser.Math = {
     */
     average: function () {
 
-        var sum = 0;
+        var sum = 0,
+            argumentsLength = arguments.length;
 
-        for (var i = 0; i < arguments.length; i++) {
+        for (var i = 0; i < argumentsLength; i++) {
             sum += (+arguments[i]);
         }
 
-        return sum / arguments.length;
+        return sum / argumentsLength;
 
     },
 
@@ -146,7 +147,7 @@ Phaser.Math = {
     /**
     * Snap a value to nearest grid slice, using floor.
     *
-    * Example: if you have an interval gap of 5 and a position of 12... you will snap to 10. 
+    * Example: if you have an interval gap of 5 and a position of 12... you will snap to 10.
     * As will 14 snap to 10... but 16 will snap to 15.
     *
     * @method Phaser.Math#snapToFloor

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -27,66 +27,83 @@ Phaser.Math = {
     * Two number are fuzzyEqual if their difference is less than epsilon.
     *
     * @method Phaser.Math#fuzzyEqual
-    * @param {number} a
-    * @param {number} b
-    * @param {number} [epsilon=(small value)]
+    * @param {number} a - The first number to compare.
+    * @param {number} b - The second number to compare.
+    * @param {number} [epsilon=0.0001] - The epsilon (a small value used in the calculation)
     * @return {boolean} True if |a-b|<epsilon
     */
     fuzzyEqual: function (a, b, epsilon) {
+
         if (epsilon === undefined) { epsilon = 0.0001; }
+
         return Math.abs(a - b) < epsilon;
+
     },
 
     /**
     * `a` is fuzzyLessThan `b` if it is less than b + epsilon.
     *
     * @method Phaser.Math#fuzzyLessThan
-    * @param {number} a
-    * @param {number} b
-    * @param {number} [epsilon=(small value)]
+    * @param {number} a - The first number to compare.
+    * @param {number} b - The second number to compare.
+    * @param {number} [epsilon=0.0001] - The epsilon (a small value used in the calculation)
     * @return {boolean} True if a<b+epsilon
     */
     fuzzyLessThan: function (a, b, epsilon) {
+
         if (epsilon === undefined) { epsilon = 0.0001; }
+
         return a < b + epsilon;
+
     },
 
     /**
     * `a` is fuzzyGreaterThan `b` if it is more than b - epsilon.
     *
     * @method Phaser.Math#fuzzyGreaterThan
-    * @param {number} a
-    * @param {number} b
-    * @param {number} [epsilon=(small value)]
+    * @param {number} a - The first number to compare.
+    * @param {number} b - The second number to compare.
+    * @param {number} [epsilon=0.0001] - The epsilon (a small value used in the calculation)
     * @return {boolean} True if a>b+epsilon
     */
     fuzzyGreaterThan: function (a, b, epsilon) {
+
         if (epsilon === undefined) { epsilon = 0.0001; }
+
         return a > b - epsilon;
+
     },
 
     /**
+    * Applies a fuzzy ceil to the given value.
+    * 
     * @method Phaser.Math#fuzzyCeil
-    *
-    * @param {number} val
-    * @param {number} [epsilon=(small value)]
+    * @param {number} val - The value to ceil.
+    * @param {number} [epsilon=0.0001] - The epsilon (a small value used in the calculation)
     * @return {number} ceiling(val-epsilon)
     */
     fuzzyCeil: function (val, epsilon) {
+
         if (epsilon === undefined) { epsilon = 0.0001; }
+
         return Math.ceil(val - epsilon);
+
     },
 
     /**
+    * Applies a fuzzy floor to the given value.
+    * 
     * @method Phaser.Math#fuzzyFloor
-    *
-    * @param {number} val
-    * @param {number} [epsilon=(small value)]
+    * @param {number} val - The value to floor.
+    * @param {number} [epsilon=0.0001] - The epsilon (a small value used in the calculation)
     * @return {number} floor(val+epsilon)
     */
     fuzzyFloor: function (val, epsilon) {
+
         if (epsilon === undefined) { epsilon = 0.0001; }
+
         return Math.floor(val + epsilon);
+
     },
 
     /**
@@ -98,14 +115,15 @@ Phaser.Math = {
     */
     average: function () {
 
-        var sum = 0,
-            argumentsLength = arguments.length;
+        var sum = 0;
+        var len = arguments.length;
 
-        for (var i = 0; i < argumentsLength; i++) {
+        for (var i = 0; i < len; i++)
+        {
             sum += (+arguments[i]);
         }
 
-        return sum / argumentsLength;
+        return sum / len;
 
     },
 

--- a/src/math/RandomDataGenerator.js
+++ b/src/math/RandomDataGenerator.js
@@ -205,21 +205,6 @@ Phaser.RandomDataGenerator.prototype = {
 
     /**
     * Returns a random real number between min and max.
-    * This method is an alias for RandomDataGenerator.realInRange.
-    *
-    * @method Phaser.RandomDataGenerator#float
-    * @param {number} min - The minimum value in the range.
-    * @param {number} max - The maximum value in the range.
-    * @return {number} A random number between min and max.
-    */
-    float: function (min, max) {
-
-        return this.realInRange(min, max);
-
-    },
-
-    /**
-    * Returns a random real number between min and max.
     *
     * @method Phaser.RandomDataGenerator#realInRange
     * @param {number} min - The minimum value in the range.

--- a/src/math/RandomDataGenerator.js
+++ b/src/math/RandomDataGenerator.js
@@ -205,6 +205,21 @@ Phaser.RandomDataGenerator.prototype = {
 
     /**
     * Returns a random real number between min and max.
+    * This method is an alias for RandomDataGenerator.realInRange.
+    *
+    * @method Phaser.RandomDataGenerator#float
+    * @param {number} min - The minimum value in the range.
+    * @param {number} max - The maximum value in the range.
+    * @return {number} A random number between min and max.
+    */
+    float: function (min, max) {
+
+        return this.realInRange(min, max);
+
+    },
+
+    /**
+    * Returns a random real number between min and max.
     *
     * @method Phaser.RandomDataGenerator#realInRange
     * @param {number} min - The minimum value in the range.

--- a/src/particles/arcade/Emitter.js
+++ b/src/particles/arcade/Emitter.js
@@ -536,12 +536,23 @@ Phaser.Particles.Arcade.Emitter.prototype.start = function (explode, lifespan, f
 };
 
 /**
-* This function can be used both internally and externally to emit the next particle in the queue.
+* This function is used internally to emit the next particle in the queue.
+*
+* However it can also be called externally to emit a particle.
+*
+* When called externally you can use the arguments to override any defaults the Emitter has set.
 *
 * @method Phaser.Particles.Arcade.Emitter#emitParticle
+* @param {number} [x] - The x coordinate to emit the particle from. If `null` or `undefined` it will use `Emitter.emitX` or if the Emitter has a width > 1 a random value between `Emitter.left` and `Emitter.right`.
+* @param {number} [y] - The y coordinate to emit the particle from. If `null` or `undefined` it will use `Emitter.emitY` or if the Emitter has a height > 1 a random value between `Emitter.top` and `Emitter.bottom`.
+* @param {string|Phaser.RenderTexture|Phaser.BitmapData|Phaser.Video|PIXI.Texture} [key] - This is the image or texture used by the Particle during rendering. It can be a string which is a reference to the Cache Image entry, or an instance of a RenderTexture, BitmapData, Video or PIXI.Texture.
+* @param {string|number} [frame] - If this Particle is using part of a sprite sheet or texture atlas you can specify the exact frame to use by giving a string or numeric index.
 * @return {boolean} True if a particle was emitted, otherwise false.
 */
-Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function () {
+Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, frame) {
+
+    if (x === undefined) { x = null; }
+    if (y === undefined) { y = null; }
 
     var particle = this.getFirstExists(false);
 
@@ -550,14 +561,40 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function () {
         return false;
     }
 
-    if (this.width > 1 || this.height > 1)
+    if (key !== undefined && frame !== undefined)
     {
-        particle.reset(this.game.rnd.integerInRange(this.left, this.right), this.game.rnd.integerInRange(this.top, this.bottom));
+        particle.loadTexture(key, frame);
     }
-    else
+    else if (key !== undefined)
     {
-        particle.reset(this.emitX, this.emitY);
+        particle.loadTexture(key);
     }
+
+    var rndInt = this.game.rnd.between;
+    var rndFloat = this.game.rnd.realInRange;
+
+    var emitX = this.emitX;
+    var emitY = this.emitY;
+
+    if (x !== null)
+    {
+        emitX = x;
+    }
+    else if (this.width > 1)
+    {
+        emitX = rndInt(this.left, this.right);
+    }
+
+    if (y !== null)
+    {
+        emitY = y;
+    }
+    else if (this.height > 1)
+    {
+        emitY = rndInt(this.top, this.bottom);
+    }
+
+    particle.reset(this.emitX, this.emitY);
 
     particle.angle = 0;
     particle.lifespan = this.lifespan;
@@ -577,20 +614,23 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function () {
     }
     else if (this.minParticleScale !== 1 || this.maxParticleScale !== 1)
     {
-        particle.scale.set(this.game.rnd.realInRange(this.minParticleScale, this.maxParticleScale));
+        particle.scale.set(rndFloat(this.minParticleScale, this.maxParticleScale));
     }
     else if ((this._minParticleScale.x !== this._maxParticleScale.x) || (this._minParticleScale.y !== this._maxParticleScale.y))
     {
-        particle.scale.set(this.game.rnd.realInRange(this._minParticleScale.x, this._maxParticleScale.x), this.game.rnd.realInRange(this._minParticleScale.y, this._maxParticleScale.y));
+        particle.scale.set(rndFloat(this._minParticleScale.x, this._maxParticleScale.x), rndFloat(this._minParticleScale.y, this._maxParticleScale.y));
     }
 
-    if (Array.isArray(this._frames === 'object'))
+    if (frame === undefined)
     {
-        particle.frame = this.game.rnd.pick(this._frames);
-    }
-    else
-    {
-        particle.frame = this._frames;
+        if (Array.isArray(this._frames))
+        {
+            particle.frame = this.game.rnd.pick(this._frames);
+        }
+        else
+        {
+            particle.frame = this._frames;
+        }
     }
 
     if (this.autoAlpha)
@@ -599,25 +639,29 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function () {
     }
     else
     {
-        particle.alpha = this.game.rnd.realInRange(this.minParticleAlpha, this.maxParticleAlpha);
+        particle.alpha = rndFloat(this.minParticleAlpha, this.maxParticleAlpha);
     }
 
     particle.blendMode = this.blendMode;
 
-    particle.body.updateBounds();
+    var body = particle.body;
 
-    particle.body.bounce.setTo(this.bounce.x, this.bounce.y);
+    body.updateBounds();
 
-    particle.body.velocity.x = this.game.rnd.between(this.minParticleSpeed.x, this.maxParticleSpeed.x);
-    particle.body.velocity.y = this.game.rnd.between(this.minParticleSpeed.y, this.maxParticleSpeed.y);
-    particle.body.angularVelocity = this.game.rnd.between(this.minRotation, this.maxRotation);
+    // body.bounce.setTo(this.bounce.x, this.bounce.y);
+    body.bounce.copyFrom(this.bounce);
 
-    particle.body.gravity.y = this.gravity;
+    body.velocity.x = rndInt(this.minParticleSpeed.x, this.maxParticleSpeed.x);
+    body.velocity.y = rndInt(this.minParticleSpeed.y, this.maxParticleSpeed.y);
+    body.angularVelocity = rndInt(this.minRotation, this.maxRotation);
 
-    particle.body.drag.x = this.particleDrag.x;
-    particle.body.drag.y = this.particleDrag.y;
+    body.gravity.y = this.gravity;
 
-    particle.body.angularDrag = this.angularDrag;
+    body.drag.copyFrom(this.particleDrag);
+    // body.drag.x = this.particleDrag.x;
+    // body.drag.y = this.particleDrag.y;
+
+    body.angularDrag = this.angularDrag;
 
     particle.onEmit();
 

--- a/src/particles/arcade/Emitter.js
+++ b/src/particles/arcade/Emitter.js
@@ -593,7 +593,7 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
         emitY = rnd.between(this.top, this.bottom);
     }
 
-    particle.reset(this.emitX, this.emitY);
+    particle.reset(emitX, emitY);
 
     particle.angle = 0;
     particle.lifespan = this.lifespan;
@@ -647,19 +647,14 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
 
     body.updateBounds();
 
-    // body.bounce.setTo(this.bounce.x, this.bounce.y);
     body.bounce.copyFrom(this.bounce);
+    body.drag.copyFrom(this.particleDrag);
 
     body.velocity.x = rnd.between(this.minParticleSpeed.x, this.maxParticleSpeed.x);
     body.velocity.y = rnd.between(this.minParticleSpeed.y, this.maxParticleSpeed.y);
     body.angularVelocity = rnd.between(this.minRotation, this.maxRotation);
 
     body.gravity.y = this.gravity;
-
-    body.drag.copyFrom(this.particleDrag);
-    // body.drag.x = this.particleDrag.x;
-    // body.drag.y = this.particleDrag.y;
-
     body.angularDrag = this.angularDrag;
 
     particle.onEmit();

--- a/src/particles/arcade/Emitter.js
+++ b/src/particles/arcade/Emitter.js
@@ -613,11 +613,11 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
     }
     else if (this.minParticleScale !== 1 || this.maxParticleScale !== 1)
     {
-        particle.scale.set(rnd.float(this.minParticleScale, this.maxParticleScale));
+        particle.scale.set(rnd.realInRange(this.minParticleScale, this.maxParticleScale));
     }
     else if ((this._minParticleScale.x !== this._maxParticleScale.x) || (this._minParticleScale.y !== this._maxParticleScale.y))
     {
-        particle.scale.set(rnd.float(this._minParticleScale.x, this._maxParticleScale.x), rnd.float(this._minParticleScale.y, this._maxParticleScale.y));
+        particle.scale.set(rnd.realInRange(this._minParticleScale.x, this._maxParticleScale.x), rnd.realInRange(this._minParticleScale.y, this._maxParticleScale.y));
     }
 
     if (frame === undefined)
@@ -638,7 +638,7 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
     }
     else
     {
-        particle.alpha = rnd.float(this.minParticleAlpha, this.maxParticleAlpha);
+        particle.alpha = rnd.realInRange(this.minParticleAlpha, this.maxParticleAlpha);
     }
 
     particle.blendMode = this.blendMode;

--- a/src/particles/arcade/Emitter.js
+++ b/src/particles/arcade/Emitter.js
@@ -561,6 +561,8 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
         return false;
     }
 
+    var rnd = this.game.rnd;
+
     if (key !== undefined && frame !== undefined)
     {
         particle.loadTexture(key, frame);
@@ -569,9 +571,6 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
     {
         particle.loadTexture(key);
     }
-
-    var rndInt = this.game.rnd.between;
-    var rndFloat = this.game.rnd.realInRange;
 
     var emitX = this.emitX;
     var emitY = this.emitY;
@@ -582,7 +581,7 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
     }
     else if (this.width > 1)
     {
-        emitX = rndInt(this.left, this.right);
+        emitX = rnd.between(this.left, this.right);
     }
 
     if (y !== null)
@@ -591,7 +590,7 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
     }
     else if (this.height > 1)
     {
-        emitY = rndInt(this.top, this.bottom);
+        emitY = rnd.between(this.top, this.bottom);
     }
 
     particle.reset(this.emitX, this.emitY);
@@ -614,11 +613,11 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
     }
     else if (this.minParticleScale !== 1 || this.maxParticleScale !== 1)
     {
-        particle.scale.set(rndFloat(this.minParticleScale, this.maxParticleScale));
+        particle.scale.set(rnd.float(this.minParticleScale, this.maxParticleScale));
     }
     else if ((this._minParticleScale.x !== this._maxParticleScale.x) || (this._minParticleScale.y !== this._maxParticleScale.y))
     {
-        particle.scale.set(rndFloat(this._minParticleScale.x, this._maxParticleScale.x), rndFloat(this._minParticleScale.y, this._maxParticleScale.y));
+        particle.scale.set(rnd.float(this._minParticleScale.x, this._maxParticleScale.x), rnd.float(this._minParticleScale.y, this._maxParticleScale.y));
     }
 
     if (frame === undefined)
@@ -639,7 +638,7 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
     }
     else
     {
-        particle.alpha = rndFloat(this.minParticleAlpha, this.maxParticleAlpha);
+        particle.alpha = rnd.float(this.minParticleAlpha, this.maxParticleAlpha);
     }
 
     particle.blendMode = this.blendMode;
@@ -651,9 +650,9 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
     // body.bounce.setTo(this.bounce.x, this.bounce.y);
     body.bounce.copyFrom(this.bounce);
 
-    body.velocity.x = rndInt(this.minParticleSpeed.x, this.maxParticleSpeed.x);
-    body.velocity.y = rndInt(this.minParticleSpeed.y, this.maxParticleSpeed.y);
-    body.angularVelocity = rndInt(this.minRotation, this.maxRotation);
+    body.velocity.x = rnd.between(this.minParticleSpeed.x, this.maxParticleSpeed.x);
+    body.velocity.y = rnd.between(this.minParticleSpeed.y, this.maxParticleSpeed.y);
+    body.angularVelocity = rnd.between(this.minRotation, this.maxRotation);
 
     body.gravity.y = this.gravity;
 

--- a/src/physics/p2/Body.js
+++ b/src/physics/p2/Body.js
@@ -369,6 +369,70 @@ Phaser.Physics.P2.Body.prototype = {
     },
 
     /**
+    * Removes the given CollisionGroup, or array of CollisionGroups, from the list of groups that this body will collide with and updates the collision masks.
+    *
+    * @method Phaser.Physics.P2.Body#removeCollisionGroup
+    * @param {Phaser.Physics.CollisionGroup|array} group - The Collision Group or Array of Collision Groups that this Bodies shapes should not collide with anymore.
+    * @param {boolean} [clearCallback=false] - Clear the callback that will be triggered when this Body impacts with the given Group?
+    * @param {p2.Shape} [shape] - An optional Shape. If not provided the updated collision mask will be added to all Shapes in this Body.
+    */
+    removeCollisionGroup: function (group, clearCallback, shape) {
+
+        if (clearCallback === undefined) { clearCallback = true; }
+
+        var index;
+
+        if (Array.isArray(group))
+        {
+            for (var i = 0; i < group.length; i++)
+            {
+                index = this.collidesWith.indexOf(group[i]);
+
+                if (index > -1)
+                {
+                    this.collidesWith.splice(index, 1);
+
+                    if (clearCallback)
+                    {
+                        delete (this._groupCallbacks[group.mask]);
+                        delete (this._groupCallbackContext[group.mask]);
+                    }
+                }
+            }
+        }
+        else
+        {
+            index = this.collidesWith.indexOf(group);
+
+            if (index > -1)
+            {
+                this.collidesWith.splice(index, 1);
+
+                if (clearCallback)
+                {
+                    delete (this._groupCallbacks[group.mask]);
+                    delete (this._groupCallbackContext[group.mask]);
+                }
+            }
+        }
+
+        var mask = this.getCollisionMask();
+
+        if (shape === undefined)
+        {
+            for (var i = this.data.shapes.length - 1; i >= 0; i--)
+            {
+                this.data.shapes[i].collisionMask = mask;
+            }
+        }
+        else
+        {
+            shape.collisionMask = mask;
+        }
+
+    },
+
+    /**
     * Adds the given CollisionGroup, or array of CollisionGroups, to the list of groups that this body will collide with and updates the collision masks.
     *
     * @method Phaser.Physics.P2.Body#collides

--- a/src/time/Timer.js
+++ b/src/time/Timer.js
@@ -242,7 +242,7 @@ Phaser.Timer.prototype = {
     */
     add: function (delay, callback, callbackContext) {
 
-        return this.create(delay, false, 0, callback, callbackContext, Array.prototype.splice.call(arguments, 3));
+        return this.create(delay, false, 0, callback, callbackContext, Array.prototype.slice.call(arguments, 3));
 
     },
 
@@ -264,7 +264,7 @@ Phaser.Timer.prototype = {
     */
     repeat: function (delay, repeatCount, callback, callbackContext) {
 
-        return this.create(delay, false, repeatCount, callback, callbackContext, Array.prototype.splice.call(arguments, 4));
+        return this.create(delay, false, repeatCount, callback, callbackContext, Array.prototype.slice.call(arguments, 4));
 
     },
 
@@ -285,7 +285,7 @@ Phaser.Timer.prototype = {
     */
     loop: function (delay, callback, callbackContext) {
 
-        return this.create(delay, true, 0, callback, callbackContext, Array.prototype.splice.call(arguments, 3));
+        return this.create(delay, true, 0, callback, callbackContext, Array.prototype.slice.call(arguments, 3));
 
     },
 

--- a/src/utils/ArraySet.js
+++ b/src/utils/ArraySet.js
@@ -168,7 +168,7 @@ Phaser.ArraySet.prototype = {
     */
     callAll: function (key) {
 
-        var args = Array.prototype.splice.call(arguments, 1);
+        var args = Array.prototype.slice.call(arguments, 1);
 
         var i = this.list.length;
 

--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -17975,6 +17975,15 @@ declare module Phaser {
                 postUpdate(): void;
 
                 /**
+                * Removes the given CollisionGroup, or array of CollisionGroups, from the list of groups that this body will collide with and updates the collision masks.
+                *
+                * @param group The Collision Group or Array of Collision Groups that this Bodies shapes should not collide with anymore.
+                * @param clearCallback Clear the callback that will be triggered when this Body impacts with the given Group? - Default: true
+                * @param shape An optional Shape. If not provided the updated collision mask will be added to all Shapes in this Body.
+                */
+                removeCollisionGroup(group: any, clearCallback?: boolean, shape?: p2.Shape): void;
+
+                /**
                 * Removes this physics body from the world.
                 */
                 removeFromWorld(): void;

--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -11114,7 +11114,7 @@ declare module Phaser {
         * @param keys A key mapping object, i.e. `{ 'up': Phaser.Keyboard.W, 'down': Phaser.Keyboard.S }` or `{ 'up': 52, 'down': 53 }`.
         * @return An object containing user selected properties
         */
-        addKeys(keys: any[]): any;
+        addKeys(keys: any): any;
 
         /**
         * By default when a key is pressed Phaser will not stop the event from propagating up to the browser.

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1,7 +1,7 @@
 /// <reference path="pixi.d.ts" />
 /// <reference path="p2.d.ts" />
 
-// Type definitions for Phaser 2.4.3 2015-Aug-24
+// Type definitions for Phaser 2.4.4+ 2015-Aug-25
 // Project: https://github.com/photonstorm/phaser
 
 declare class Phaser {
@@ -250,6 +250,7 @@ declare module Phaser {
         copy(source?: any, x?: number, y?: number, width?: number, height?: number, tx?: number, ty?: number, newWidth?: number, newHeight?: number, rotate?: number, anchorX?: number, anchorY?: number, scaleX?: number, scaleY?: number, alpha?: number, blendMode?: number, roundPx?: boolean): Phaser.BitmapData;
         copyPixels(source: any, area: Phaser.Rectangle, x: number, y: number, alpha?: number): void;
         copyRect(source: any, area: Phaser.Rectangle, x?: number, y?: number, alpha?: number, blendMode?: number, roundPx?: boolean): Phaser.BitmapData;
+        destroy(): void;
         draw(source: any, x?: number, y?: number, width?: number, height?: number, blendMode?: number, roundPx?: boolean): Phaser.BitmapData;
         drawFull(parent: any, blendMode?: number, roundPx?: boolean): Phaser.BitmapData;
         drawGroup(group: Phaser.Group, blendMode?: number, roundPx?: boolean): Phaser.BitmapData;
@@ -582,7 +583,7 @@ declare module Phaser {
     class Canvas {
 
         static addToDOM(canvas: HTMLCanvasElement, parent: HTMLElement, overflowHidden?: boolean): HTMLCanvasElement;
-        static create(width?: number, height?: number, id?: string): HTMLCanvasElement;
+        static create(parent: HTMLDivElement, width?: number, height?: number, id?: string, skipPool?: boolean): HTMLCanvasElement;
         static getSmoothngEnabled(context: CanvasRenderingContext2D): boolean;
         static removeFromDOM(canvas: HTMLCanvasElement): void;
         static setBackgroundColor(canvas: HTMLCanvasElement, color: string): HTMLCanvasElement;
@@ -4817,6 +4818,7 @@ declare module Phaser {
         type: number;
         wrap: boolean;
 
+        destroy(): void;
         getRayCastTiles(line: Phaser.Line, stepRate?: number, collides?: boolean, interestingFace?: boolean): Phaser.Tile[];
         getTiles(x: number, y: number, width: number, height: number, collides?: boolean, interestingFace?: boolean): Phaser.Tile[];
         getTileX(x: number): number;
@@ -5208,6 +5210,7 @@ declare module Phaser {
             box2dBody(body: Phaser.Sprite, color?: string): void;
             box2dWorld(): void;
             cameraInfo(camera: Phaser.Camera, x: number, y: number, color?: string): void;
+            destroy(): void;
             geom(object: any, color?: string, fiiled?: boolean, forceType?: number): void;
             inputInfo(x: number, y: number, color?: string): void;
             lineInfo(line: Phaser.Line, x: number, y: number, color?: string): void;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -3188,6 +3188,7 @@ declare module Phaser {
                 moveUp(speed: number): void;
                 preUpdate(): void;
                 postUpdate(): void;
+                removeCollisionGroup(group: any, clearCallback?: boolean, shape?: p2.Shape): void;
                 removeFromWorld(): void;
                 removeShape(shape: p2.Shape): boolean;
                 reverse(speed: number): void;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -272,7 +272,7 @@ declare module Phaser {
         processPixelRGB(callback: Function, callbackContext: any, x?: number, y?: Number, width?: number, height?: number): Phaser.BitmapData;
         rect(x: number, y: number, width: number, height: number, fillStyle?: string): Phaser.BitmapData;
         render(): Phaser.BitmapData;
-        replaceRGB(r1: number, g1: number, b1: number, a1: number, r2: number, g2: number, b2: number, a2: number, region: Phaser.Rectangle): Phaser.BitmapData;
+        replaceRGB(r1: number, g1: number, b1: number, a1: number, r2: number, g2: number, b2: number, a2: number, region?: Phaser.Rectangle): Phaser.BitmapData;
         resize(width: number, height: number): Phaser.BitmapData;
         resizeFrame(parent: any, width: number, height: number): void;
         setHSL(h?: number, s?: number, l?: number, region?: Phaser.Rectangle): Phaser.BitmapData;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -523,12 +523,12 @@ declare module Phaser {
 
     interface CachedImage {
 
-        key: string,
-        url: string,
-        data: HTMLImageElement,
-        base: PIXI.BaseTexture,
-        frame: Phaser.Frame,
-        frameData: Phaser.FrameData
+        key: string;
+        url: string;
+        data: HTMLImageElement;
+        base: PIXI.BaseTexture;
+        frame: Phaser.Frame;
+        frameData: Phaser.FrameData;
 
     }
 
@@ -1377,7 +1377,7 @@ declare module Phaser {
         audio(key: string, volume?: number, loop?: boolean, connect?: boolean): Phaser.Sound;
         audioSprite(key: string): Phaser.AudioSprite;
         bitmapData(width?: number, height?: number, key?: string, addToCache?: boolean): Phaser.BitmapData;
-        bitmapText(x: number, y: number, font: string, text?: string, size?: number, align?: string, group?: Phaser.Group): Phaser.BitmapText;
+        bitmapText(x: number, y: number, font: string, text?: string, size?: number, group?: Phaser.Group): Phaser.BitmapText;
         button(x?: number, y?: number, key?: string, callback?: Function, callbackContext?: any, overFrame?: any, outFrame?: any, downFrame?: any, upFrame?: any, group?: Phaser.Group): Phaser.Button;
         emitter(x?: number, y?: number, maxParticles?: number): Phaser.Particles.Arcade.Emitter;
         existing(object: any): any;
@@ -1692,7 +1692,7 @@ declare module Phaser {
 
     class Image extends PIXI.Sprite {
 
-        constructor(game: Phaser.Game, x: number, y: number, key: string|Phaser.RenderTexture|Phaser.BitmapData|PIXI.Texture, frame: string|number);
+        constructor(game: Phaser.Game, x: number, y: number, key: string|Phaser.RenderTexture|Phaser.BitmapData|PIXI.Texture, frame?: string|number);
 
         alive: boolean;
         angle: number;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1,7 +1,7 @@
 /// <reference path="pixi.d.ts" />
 /// <reference path="p2.d.ts" />
 
-// Type definitions for Phaser 2.4.4+ 2015-Aug-25
+// Type definitions for Phaser 2.4.4+ 2015-Aug-28
 // Project: https://github.com/photonstorm/phaser
 
 declare class Phaser {
@@ -1641,7 +1641,7 @@ declare module Phaser {
         checkProperty(child: any, key: string[], value: any, force?: boolean): boolean;
         countDead(): number;
         countLiving(): number;
-        create(x: number, y: number, key: string, frame?: any, exists?: boolean): any;
+        create(x: number, y: number, key?: string | Phaser.RenderTexture | Phaser.BitmapData | Phaser.Video | PIXI.Texture, frame?: string | number, exists?: boolean): any;
         createMultiple(quantity: number, key: string, frame?: any, exists?: boolean): void;
         customSort(sortHandler: Function, context?: any): void;
         destroy(destroyChildren?: boolean, soft?: boolean): void;
@@ -1653,9 +1653,9 @@ declare module Phaser {
         filter(predicate: Function, checkExists?: boolean): ArraySet;
         getAt(index: number): PIXI.DisplayObject | number;
         getBottom(): any;
-        getFirstAlive(): any;
-        getFirstDead(): any;
-        getFirstExists(exists: boolean): any;
+        getFirstAlive(createIfNull?: boolean, x?: number, y?: number, key?: string | Phaser.RenderTexture | Phaser.BitmapData | Phaser.Video | PIXI.Texture, frame?: string | number): any;
+        getFirstDead(createIfNull?: boolean, x?: number, y?: number, key?: string | Phaser.RenderTexture | Phaser.BitmapData | Phaser.Video | PIXI.Texture, frame?: string | number): any;
+        getFirstExists(exists: boolean, createIfNull?: boolean, x?: number, y?: number, key?: string | Phaser.RenderTexture | Phaser.BitmapData | Phaser.Video | PIXI.Texture, frame?: string | number): any;
         getIndex(child: any): number;
         getRandom(startIndex?: number, length?: number): any;
         getTop(): any;
@@ -1674,6 +1674,7 @@ declare module Phaser {
         removeBetween(startIndex: number, endIndex?: number, destroy?: boolean, silent?: boolean): void;
         removeFromHash(child: PIXI.DisplayObject): boolean;
         replace(oldChild: any, newChild: any): any;
+        resetChild(child: any, x?: number, y?: number, key?: string | Phaser.RenderTexture | Phaser.BitmapData | Phaser.Video | PIXI.Texture, frame?: string | number): any;
         resetCursor(index?: number): any;
         reverse(): void;
         sendToBack(child: any): any;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2092,7 +2092,7 @@ declare module Phaser {
 
         addCallbacks(context: any, onDown?: Function, onUp?: Function, onPress?: Function): void;
         addKey(keycode: number): Phaser.Key;
-        addKeys(keys: any[]): any;
+        addKeys(keys: any): any;
         addKeyCapture(keycode: any): void;
         createCursorKeys(): Phaser.CursorKeys;
         clearCaptures(): void;

--- a/typescript/pixi.d.ts
+++ b/typescript/pixi.d.ts
@@ -335,8 +335,20 @@ declare module PIXI {
         height: number;
         width: number;
 
+        destroy(): void;
         clear(): void;
         resize(width: number, height: number): void;
+
+    }
+
+    export class CanvasPool {
+
+        static create(parent: HTMLElement, width?: number, height?: number): HTMLCanvasElement;
+        static getFirst(): HTMLCanvasElement;
+        static remove(parent: HTMLElement): void;
+        static removeByCanvas(canvas: HTMLCanvasElement): HTMLCanvasElement;
+        static getTotal(): number;
+        static getFree(): number;
 
     }
 
@@ -1010,7 +1022,7 @@ declare module PIXI {
         texture: Texture;
         tint: number;
 
-        setTexture(texture: Texture): void;
+        setTexture(texture: Texture, destroyBase?: boolean): void;
 
     }
 


### PR DESCRIPTION
This removes a given collision group or a list of collision groups from a P2 Body without removing the other collision groups. Collision masks are updated and callback functions are either removed or kept, depending on user choice.

We're currently in production of a game where the player can enter a "ghost mode" and doesn't collide with obstacles anymore. This reduces the hassle of removing a collision group and adding it back with body.collide().