### PR TITLE
Convenience function to remove a collision group from a P2 Body

### DIFF
--- a/src/physics/p2/Body.js
+++ b/src/physics/p2/Body.js
@@ -373,7 +373,7 @@ Phaser.Physics.P2.Body.prototype = {
     *
     * @method Phaser.Physics.P2.Body#removeCollisionGroup
     * @param {Phaser.Physics.CollisionGroup|array} group - The Collision Group or Array of Collision Groups that this Bodies shapes should not collide with anymore.
-    * @param {boolean} [clearCallback=false] - Clear the callback that will be triggered when this Body impacts with the given Group?
+    * @param {boolean} [clearCallback=true] - Clear the callback that will be triggered when this Body impacts with the given Group?
     * @param {p2.Shape} [shape] - An optional Shape. If not provided the updated collision mask will be added to all Shapes in this Body.
     */
     removeCollisionGroup: function (group, clearCallback, shape) {

--- a/src/physics/p2/Body.js
+++ b/src/physics/p2/Body.js
@@ -369,6 +369,70 @@ Phaser.Physics.P2.Body.prototype = {
     },
 
     /**
+    * Removes the given CollisionGroup, or array of CollisionGroups, from the list of groups that this body will collide with and updates the collision masks.
+    *
+    * @method Phaser.Physics.P2.Body#removeCollisionGroup
+    * @param {Phaser.Physics.CollisionGroup|array} group - The Collision Group or Array of Collision Groups that this Bodies shapes should not collide with anymore.
+    * @param {boolean} [clearCallback=false] - Clear the callback that will be triggered when this Body impacts with the given Group?
+    * @param {p2.Shape} [shape] - An optional Shape. If not provided the updated collision mask will be added to all Shapes in this Body.
+    */
+    removeCollisionGroup: function (group, clearCallback, shape) {
+
+        if (clearCallback === undefined) { clearCallback = true; }
+
+        var index;
+
+        if (Array.isArray(group))
+        {
+            for (var i = 0; i < group.length; i++)
+            {
+                index = this.collidesWith.indexOf(group[i]);
+
+                if (index > -1)
+                {
+                    this.collidesWith.splice(index, 1);
+
+                    if (clearCallback)
+                    {
+                        delete (this._groupCallbacks[group.mask]);
+                        delete (this._groupCallbackContext[group.mask]);
+                    }
+                }
+            }
+        }
+        else
+        {
+            index = this.collidesWith.indexOf(group);
+
+            if (index > -1)
+            {
+                this.collidesWith.splice(index, 1);
+
+                if (clearCallback)
+                {
+                    delete (this._groupCallbacks[group.mask]);
+                    delete (this._groupCallbackContext[group.mask]);
+                }
+            }
+        }
+
+        var mask = this.getCollisionMask();
+
+        if (shape === undefined)
+        {
+            for (var i = this.data.shapes.length - 1; i >= 0; i--)
+            {
+                this.data.shapes[i].collisionMask = mask;
+            }
+        }
+        else
+        {
+            shape.collisionMask = mask;
+        }
+
+    },
+
+    /**
     * Adds the given CollisionGroup, or array of CollisionGroups, to the list of groups that this body will collide with and updates the collision masks.
     *
     * @method Phaser.Physics.P2.Body#collides

--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -17975,6 +17975,15 @@ declare module Phaser {
                 postUpdate(): void;
 
                 /**
+                * Removes the given CollisionGroup, or array of CollisionGroups, from the list of groups that this body will collide with and updates the collision masks.
+                *
+                * @param group The Collision Group or Array of Collision Groups that this Bodies shapes should not collide with anymore.
+                * @param clearCallback Clear the callback that will be triggered when this Body impacts with the given Group? - Default: true
+                * @param shape An optional Shape. If not provided the updated collision mask will be added to all Shapes in this Body.
+                */
+                removeCollisionGroup(group: any, clearCallback?: boolean, shape?: p2.Shape): void;
+
+                /**
                 * Removes this physics body from the world.
                 */
                 removeFromWorld(): void;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -3188,6 +3188,7 @@ declare module Phaser {
                 moveUp(speed: number): void;
                 preUpdate(): void;
                 postUpdate(): void;
+                removeCollisionGroup(group: any, clearCallback?: boolean, shape?: p2.Shape): void;
                 removeFromWorld(): void;
                 removeShape(shape: p2.Shape): boolean;
                 reverse(speed: number): void;


### PR DESCRIPTION
This removes a given collision group or a list of collision groups from a P2 Body without removing the other collision groups. Collision masks are updated and callback functions are either removed or kept, depending on user choice.

We're currently in production of a game where the player can enter a "ghost mode" and doesn't collide with obstacles anymore. This reduces the hassle of removing a collision group and adding it back with body.collide().