### PR TITLE
Feature: Add support for loading single-layer Pyxel Edit TileMap as an Atlas

### DIFF
--- a/src/animation/AnimationParser.js
+++ b/src/animation/AnimationParser.js
@@ -147,6 +147,65 @@ Phaser.AnimationParser = {
     /**
     * Parse the JSON data and extract the animation frame data from it.
     *
+<<<<<<< HEAD
+=======
+    * @method Phaser.AnimationParser.JSONData
+    * @param {Phaser.Game} game - A reference to the currently running game.
+    * @param {object} json - The JSON data from the Texture Atlas. Must be in Pyxel JSON format.
+    * @return {Phaser.FrameData} A FrameData object containing the parsed frames.
+    */
+    JSONDataPyxel: function (game, json) {
+
+        //  Malformed? There are a few keys to check here.
+        var signature = ['layers', 'tilewidth','tileheight','tileswide', 'tileshigh'];
+
+        signature.forEach( function(key, index) {
+          if (!json[key])
+          {
+              console.warn("Phaser.AnimationParser.JSONDataPyxel: Invalid Pyxel Tilemap JSON given, missing '" + key + "' key.");
+              console.log(json);
+              return;
+          }
+        });
+
+        // For this purpose, I only care about parsing tilemaps with a single layer.
+        if(json['layers'].length != 1) {
+          console.warn("Phaser.AnimationParser.JSONDataPyxel: Too many layers, this parser only supports flat Tilemaps.");
+          console.log(json);
+          return;
+        }
+
+        var data = new Phaser.FrameData();
+
+        var tileheight = json['tileheight'];
+        var tilewidth = json['tilewidth'];
+
+        var frames = json['layers'][0]['tiles'];
+        var newFrame;
+
+        for (var i = 0; i < frames.length; i++)
+        {
+            newFrame = data.addFrame(new Phaser.Frame(
+                i,
+                frames[i].x,
+                frames[i].y,
+                tilewidth,
+                tileheight,
+                "frame_" + i  // No names are included in pyxel tilemap data.
+            ));
+
+            // No trim data is included.
+            newFrame.setTrim(false);
+        }
+
+        return data;
+
+    },
+
+    /**
+    * Parse the JSON data and extract the animation frame data from it.
+    *
+>>>>>>> 247064f... fixed some typos and explicitly setTrim to false
     * @method Phaser.AnimationParser.JSONDataHash
     * @param {Phaser.Game} game - A reference to the currently running game.
     * @param {object} json - The JSON data from the Texture Atlas. Must be in JSON Hash format.

--- a/src/animation/AnimationParser.js
+++ b/src/animation/AnimationParser.js
@@ -157,20 +157,20 @@ Phaser.AnimationParser = {
         //  Malformed? There are a few keys to check here.
         var signature = ['layers', 'tilewidth','tileheight','tileswide', 'tileshigh'];
 
-        signature.forEach( function(key, index) {
-          if (!json[key])
-          {
-              console.warn("Phaser.AnimationParser.JSONDataPyxel: Invalid Pyxel Tilemap JSON given, missing '" + key + "' key.");
-              console.log(json);
-              return;
-          }
+        signature.forEach( function(key) {
+            if (!json[key])
+            {
+                console.warn("Phaser.AnimationParser.JSONDataPyxel: Invalid Pyxel Tilemap JSON given, missing '" + key + "' key.");
+                console.log(json);
+                return;
+            }
         });
 
         // For this purpose, I only care about parsing tilemaps with a single layer.
         if(json['layers'].length != 1) {
-          console.warn("Phaser.AnimationParser.JSONDataPyxel: Too many layers, this parser only supports flat Tilemaps.");
-          console.log(json);
-          return;
+            console.warn("Phaser.AnimationParser.JSONDataPyxel: Too many layers, this parser only supports flat Tilemaps.");
+            console.log(json);
+            return;
         }
 
         var data = new Phaser.FrameData();

--- a/src/animation/AnimationParser.js
+++ b/src/animation/AnimationParser.js
@@ -147,9 +147,7 @@ Phaser.AnimationParser = {
     /**
     * Parse the JSON data and extract the animation frame data from it.
     *
-<<<<<<< HEAD
-=======
-    * @method Phaser.AnimationParser.JSONData
+    * @method Phaser.AnimationParser.JSONDataPyxel
     * @param {Phaser.Game} game - A reference to the currently running game.
     * @param {object} json - The JSON data from the Texture Atlas. Must be in Pyxel JSON format.
     * @return {Phaser.FrameData} A FrameData object containing the parsed frames.
@@ -205,7 +203,6 @@ Phaser.AnimationParser = {
     /**
     * Parse the JSON data and extract the animation frame data from it.
     *
->>>>>>> 247064f... fixed some typos and explicitly setTrim to false
     * @method Phaser.AnimationParser.JSONDataHash
     * @param {Phaser.Game} game - A reference to the currently running game.
     * @param {object} json - The JSON data from the Texture Atlas. Must be in JSON Hash format.
@@ -296,7 +293,7 @@ Phaser.AnimationParser = {
         for (var i = 0; i < frames.length; i++)
         {
             frame = frames[i].attributes;
-            
+
             name = frame.name.value;
             x = parseInt(frame.x.value, 10);
             y = parseInt(frame.y.value, 10);

--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -6,12 +6,12 @@
 
 /**
 * Phaser has one single cache in which it stores all assets.
-* 
+*
 * The cache is split up into sections, such as images, sounds, video, json, etc. All assets are stored using
 * a unique string-based key as their identifier. Assets stored in different areas of the cache can have the
 * same key, for example 'playerWalking' could be used as the key for both a sprite sheet and an audio file,
 * because they are unique data types.
-* 
+*
 * The cache is automatically populated by the Phaser.Loader. When you use the loader to pull in external assets
 * such as images they are automatically placed into their respective cache. Most common Game Objects, such as
 * Sprites and Videos automatically query the cache to extract the assets they need on instantiation.
@@ -604,13 +604,10 @@ Phaser.Cache.prototype = {
         {
             obj.frameData = Phaser.AnimationParser.XMLData(this.game, atlasData, key);
         }
-<<<<<<< HEAD
-=======
         else if (format === Phaser.Loader.TEXTURE_ATLAS_JSON_PYXEL)
         {
             obj.frameData = Phaser.AnimationParser.JSONDataPyxel(this.game, atlasData, key);
         }
->>>>>>> 247064f... fixed some typos and explicitly setTrim to false
         else
         {
             //  Let's just work it out from the frames array
@@ -993,7 +990,7 @@ Phaser.Cache.prototype = {
 
     /**
     * Get an item from a cache based on the given key and property.
-    * 
+    *
     * This method is mostly used internally by other Cache methods such as `getImage` but is exposed
     * publicly for your own use as well.
     *
@@ -1024,16 +1021,16 @@ Phaser.Cache.prototype = {
                 return this._cacheMap[cache][key][property];
             }
         }
-        
+
         return null;
 
     },
 
     /**
     * Gets a Canvas object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getCanvas
@@ -1048,13 +1045,13 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a Image object from the cache. This returns a DOM Image object, not a Phaser.Image object.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
-    * 
+    *
     * Only the Image cache is searched, which covers images loaded via Loader.image, Sprite Sheets and Texture Atlases.
-    * 
+    *
     * If you need the image used by a bitmap font or similar then please use those respective 'get' methods.
     *
     * @method Phaser.Cache#getImage
@@ -1091,7 +1088,7 @@ Phaser.Cache.prototype = {
 
     /**
     * Get a single texture frame by key.
-    * 
+    *
     * You'd only do this to get the default Frame created for a non-atlas / spritesheet image.
     *
     * @method Phaser.Cache#getTextureFrame
@@ -1106,9 +1103,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a Phaser.Sound object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getSound
@@ -1123,9 +1120,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a raw Sound data object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getSoundData
@@ -1140,9 +1137,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a Text object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getText
@@ -1157,11 +1154,11 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a Physics Data object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
-    * 
+    *
     * You can get either the entire data set, a single object or a single fixture of an object from it.
     *
     * @method Phaser.Cache#getPhysicsData
@@ -1219,9 +1216,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a raw Tilemap data object from the cache. This will be in either CSV or JSON format.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getTilemapData
@@ -1236,9 +1233,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a binary object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getBinary
@@ -1253,9 +1250,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a BitmapData object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getBitmapData
@@ -1270,9 +1267,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a Bitmap Font object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getBitmapFont
@@ -1287,11 +1284,11 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a JSON object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
-    * 
+    *
     * You can either return the object by reference (the default), or return a clone
     * of it by setting the `clone` argument to `true`.
     *
@@ -1324,9 +1321,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets an XML object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getXML
@@ -1341,9 +1338,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a Phaser.Video object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getVideo
@@ -1358,9 +1355,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a fragment shader object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getShader
@@ -1375,9 +1372,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a RenderTexture object from the cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getRenderTexture
@@ -1451,9 +1448,9 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a Phaser.FrameData object from the Image Cache.
-    * 
+    *
     * The object is looked-up based on the key given.
-    * 
+    *
     * Note: If the object cannot be found a `console.warn` message is displayed.
     *
     * @method Phaser.Cache#getFrameData
@@ -1587,7 +1584,7 @@ Phaser.Cache.prototype = {
 
     /**
     * Gets a PIXI.BaseTexture by key from the PIXI.BaseTextureCache.
-    * 
+    *
     * If the texture isn't found in the cache, then it searches the Phaser Image Cache.
     *
     * @method Phaser.Cache#getPixiBaseTexture
@@ -1691,7 +1688,7 @@ Phaser.Cache.prototype = {
 
     /**
     * Removes an image from the cache.
-    * 
+    *
     * You can optionally elect to destroy it as well. This calls BaseTexture.destroy on it.
     *
     * Note that this only removes it from the Phaser and PIXI Caches. If you still have references to the data elsewhere

--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -604,6 +604,13 @@ Phaser.Cache.prototype = {
         {
             obj.frameData = Phaser.AnimationParser.XMLData(this.game, atlasData, key);
         }
+<<<<<<< HEAD
+=======
+        else if (format === Phaser.Loader.TEXTURE_ATLAS_JSON_PYXEL)
+        {
+            obj.frameData = Phaser.AnimationParser.JSONDataPyxel(this.game, atlasData, key);
+        }
+>>>>>>> 247064f... fixed some typos and explicitly setTrim to false
         else
         {
             //  Let's just work it out from the frames array

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -296,6 +296,15 @@ Phaser.Loader.TEXTURE_ATLAS_XML_STARLING = 2;
 * @constant
 * @type {number}
 */
+<<<<<<< HEAD
+=======
+Phaser.Loader.TEXTURE_ATLAS_JSON_PYXEL = 3;
+
+/**
+* @constant
+* @type {number}
+*/
+>>>>>>> 247064f... fixed some typos and explicitly setTrim to false
 Phaser.Loader.PHYSICS_LIME_CORONA_JSON = 3;
 
 /**
@@ -2605,7 +2614,7 @@ Phaser.Loader.prototype = {
                     //  Load the JSON or XML before carrying on with the next file
                     loadNext = false;
 
-                    if (file.format == Phaser.Loader.TEXTURE_ATLAS_JSON_ARRAY || file.format == Phaser.Loader.TEXTURE_ATLAS_JSON_HASH)
+                    if (file.format == Phaser.Loader.TEXTURE_ATLAS_JSON_ARRAY || file.format == Phaser.Loader.TEXTURE_ATLAS_JSON_HASH || file.format == Phaser.Loader.TEXTURE_ATLAS_JSON_PYXEL)
                     {
                         this.xhrLoad(file, this.transformUrl(file.atlasURL, file), 'text', this.jsonLoadComplete);
                     }

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -84,18 +84,18 @@ Phaser.Loader = function (game) {
 
     /**
     * The value of `path`, if set, is placed before any _relative_ file path given. For example:
-    * 
+    *
     * `load.path = "images/sprites/";
     * load.image("ball", "ball.png");
     * load.image("tree", "level1/oaktree.png");
     * load.image("boom", "http://server.com/explode.png");`
     *
-    * Would load the `ball` file from `images/sprites/ball.png` and the tree from 
-    * `images/sprites/level1/oaktree.png` but the file `boom` would load from the URL 
+    * Would load the `ball` file from `images/sprites/ball.png` and the tree from
+    * `images/sprites/level1/oaktree.png` but the file `boom` would load from the URL
     * given as it's an absolute URL.
     *
     * Please note that the path is added before the filename but *after* the baseURL (if set.)
-    * 
+    *
     * The string _must_ end with a "/".
     *
     * @property {string} path
@@ -146,11 +146,11 @@ Phaser.Loader = function (game) {
     * progress, file key, success?, total loaded files, total files
     *
     * Where progress is a number between 1 and 100 (inclusive) representing the percentage of the load.
-    * 
+    *
     * @property {Phaser.Signal} onFileComplete
     */
     this.onFileComplete = new Phaser.Signal();
-   
+
     /**
     * This event is dispatched when a file (or pack) errors as a result of the load request.
     *
@@ -257,7 +257,7 @@ Phaser.Loader = function (game) {
     * @private
     */
     this._totalFileCount = 0;
-    
+
     /**
     * Total packs loaded - adjusted just prior to `onPackComplete`.
     * @property {integer} _loadedPackCount
@@ -296,15 +296,12 @@ Phaser.Loader.TEXTURE_ATLAS_XML_STARLING = 2;
 * @constant
 * @type {number}
 */
-<<<<<<< HEAD
-=======
 Phaser.Loader.TEXTURE_ATLAS_JSON_PYXEL = 3;
 
 /**
 * @constant
 * @type {number}
 */
->>>>>>> 247064f... fixed some typos and explicitly setTrim to false
 Phaser.Loader.PHYSICS_LIME_CORONA_JSON = 3;
 
 /**
@@ -508,7 +505,7 @@ Phaser.Loader.prototype = {
     addToFileList: function (type, key, url, properties, overwrite, extension) {
 
         if (overwrite === undefined) { overwrite = false; }
-        
+
         if (key === undefined || key === '')
         {
             console.warn("Phaser.Loader: Invalid or no key given of type " + type);
@@ -549,7 +546,7 @@ Phaser.Loader.prototype = {
         }
 
         var fileIndex = this.getAssetIndex(type, key);
-        
+
         if (overwrite && fileIndex > -1)
         {
             var currentFile = this._fileList[fileIndex];
@@ -597,10 +594,10 @@ Phaser.Loader.prototype = {
     * Please see the example 'loader/asset pack' in the Phaser Examples repository.
     *
     * Packs are always put before the first non-pack file that is not loaded / loading.
-    * 
+    *
     * This means that all packs added before any loading has started are added to the front
     * of the file queue, in the order added.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * The URL of the packfile can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
@@ -645,13 +642,13 @@ Phaser.Loader.prototype = {
             {
                 data = JSON.parse(data);
             }
-            
+
             pack.data = data || {};
 
             //  Already consider 'loaded'
             pack.loaded = true;
         }
-        
+
         // Add before first non-pack/no-loaded ~ last pack from start prior to loading
         // (Read one past for splice-to-end)
         for (var i = 0; i < this._fileList.length + 1; i++)
@@ -672,17 +669,17 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds an Image to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * Phaser can load all common image types: png, jpg, gif and any other format the browser can natively handle.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * Retrieve the image via `Cache.getImage(key)`
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified the Loader will take the key and create a filename from that. For example if the key is "alien"
     * and no URL is given then the Loader will set the URL to be "alien.png". It will always add `.png` as the extension.
     * If you do not desire this action then provide a URL.
@@ -703,17 +700,17 @@ Phaser.Loader.prototype = {
     * Adds an array of images to the current load queue.
     *
     * It works by passing each element of the array to the Loader.image method.
-    * 
+    *
     * The files are **not** loaded immediately after calling this method. The files are added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * Phaser can load all common image types: png, jpg, gif and any other format the browser can natively handle.
-    * 
+    *
     * The keys must be unique Strings. They are used to add the files to the Phaser.Cache upon successful load.
     *
     * Retrieve the images via `Cache.getImage(key)`
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified the Loader will take the key and create a filename from that. For example if the key is "alien"
     * and no URL is given then the Loader will set the URL to be "alien.png". It will always add `.png` as the extension.
     * If you do not desire this action then provide a URL.
@@ -746,15 +743,15 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds a Text file to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * Retrieve the file via `Cache.getText(key)`
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified the Loader will take the key and create a filename from that. For example if the key is "alien"
     * and no URL is given then the Loader will set the URL to be "alien.txt". It will always add `.txt` as the extension.
     * If you do not desire this action then provide a URL.
@@ -773,16 +770,16 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds a JSON file to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * Retrieve the file via `Cache.getJSON(key)`. JSON files are automatically parsed upon load.
     * If you need to control when the JSON is parsed then use `Loader.text` instead and parse the text file as needed.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified the Loader will take the key and create a filename from that. For example if the key is "alien"
     * and no URL is given then the Loader will set the URL to be "alien.json". It will always add `.json` as the extension.
     * If you do not desire this action then provide a URL.
@@ -801,15 +798,15 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds a fragment shader file to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * Retrieve the file via `Cache.getShader(key)`.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified the Loader will take the key and create a filename from that. For example if the key is "blur"
     * and no URL is given then the Loader will set the URL to be "blur.frag". It will always add `.frag` as the extension.
     * If you do not desire this action then provide a URL.
@@ -828,15 +825,15 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds an XML file to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * Retrieve the file via `Cache.getXML(key)`.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified the Loader will take the key and create a filename from that. For example if the key is "alien"
     * and no URL is given then the Loader will set the URL to be "alien.xml". It will always add `.xml` as the extension.
     * If you do not desire this action then provide a URL.
@@ -855,13 +852,13 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds a JavaScript file to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * The key must be a unique String.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified the Loader will take the key and create a filename from that. For example if the key is "alien"
     * and no URL is given then the Loader will set the URL to be "alien.js". It will always add `.js` as the extension.
     * If you do not desire this action then provide a URL.
@@ -890,15 +887,15 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds a binary file to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * Retrieve the file via `Cache.getBinary(key)`.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified the Loader will take the key and create a filename from that. For example if the key is "alien"
     * and no URL is given then the Loader will set the URL to be "alien.bin". It will always add `.bin` as the extension.
     * If you do not desire this action then provide a URL.
@@ -928,22 +925,22 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds a Sprite Sheet to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
     *
     * To clarify the terminology that Phaser uses: A Sprite Sheet is an image containing frames, usually of an animation, that are all equal
-    * dimensions and often in sequence. For example if the frame size is 32x32 then every frame in the sprite sheet will be that size. 
+    * dimensions and often in sequence. For example if the frame size is 32x32 then every frame in the sprite sheet will be that size.
     * Sometimes (outside of Phaser) the term "sprite sheet" is used to refer to a texture atlas.
     * A Texture Atlas works by packing together images as best it can, using whatever frame sizes it likes, often with cropping and trimming
     * the frames in the process. Software such as Texture Packer, Flash CC or Shoebox all generate texture atlases, not sprite sheets.
     * If you've got an atlas then use `Loader.atlas` instead.
-    * 
+    *
     * The key must be a unique String. It is used to add the image to the Phaser.Cache upon successful load.
     *
     * Retrieve the file via `Cache.getImage(key)`. Sprite sheets, being image based, live in the same Cache as all other Images.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified the Loader will take the key and create a filename from that. For example if the key is "alien"
     * and no URL is given then the Loader will set the URL to be "alien.png". It will always add `.png` as the extension.
     * If you do not desire this action then provide a URL.
@@ -970,13 +967,13 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds an audio file to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * Retrieve the file via `Cache.getSound(key)`.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
     *
     * Mobile warning: There are some mobile devices (certain iPad 2 and iPad Mini revisions) that cannot play 48000 Hz audio.
@@ -1013,17 +1010,17 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds an audio sprite file to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * Audio Sprites are a combination of audio files and a JSON configuration.
-    * 
+    *
     * The JSON follows the format of that created by https://github.com/tonistiigi/audiosprite
-    * 
+    *
     * Retrieve the file via `Cache.getSoundData(key)`.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
     *
     * @method Phaser.Loader#audiosprite
@@ -1073,13 +1070,13 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds a video file to the current load queue.
-    * 
+    *
     * The file is **not** loaded immediately after calling this method. The file is added to the queue ready to be loaded when the loader starts.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * Retrieve the file via `Cache.getVideo(key)`.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
     *
     * You don't need to preload a video in order to play it in your game. See `Video.createVideoFromURL` for details.
@@ -1131,20 +1128,20 @@ Phaser.Loader.prototype = {
     * You can choose to either load the data externally, by providing a URL to a json file.
     * Or you can pass in a JSON object or String via the `data` parameter.
     * If you pass a String the data is automatically run through `JSON.parse` and then immediately added to the Phaser.Cache.
-    * 
+    *
     * If a URL is provided the file is **not** loaded immediately after calling this method, but is added to the load queue.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
-    * 
+    *
     * Retrieve the file via `Cache.getTilemapData(key)`. JSON files are automatically parsed upon load.
     * If you need to control when the JSON is parsed then use `Loader.text` instead and parse the text file as needed.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified and no data is given then the Loader will take the key and create a filename from that.
     * For example if the key is "level1" and no URL or data is given then the Loader will set the URL to be "level1.json".
     * If you set the format to be Tilemap.CSV it will set the URL to be "level1.csv" instead.
-    * 
+    *
     * If you do not desire this action then provide a URL or data object.
     *
     * @method Phaser.Loader#tilemap
@@ -1206,24 +1203,24 @@ Phaser.Loader.prototype = {
     * Adds a physics data file to the current load queue.
     *
     * The data must be in `Lime + Corona` JSON format. [Physics Editor](https://www.codeandweb.com) by code'n'web exports in this format natively.
-    * 
+    *
     * You can choose to either load the data externally, by providing a URL to a json file.
     * Or you can pass in a JSON object or String via the `data` parameter.
     * If you pass a String the data is automatically run through `JSON.parse` and then immediately added to the Phaser.Cache.
-    * 
+    *
     * If a URL is provided the file is **not** loaded immediately after calling this method, but is added to the load queue.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
     *
     * Retrieve the file via `Cache.getJSON(key)`. JSON files are automatically parsed upon load.
     * If you need to control when the JSON is parsed then use `Loader.text` instead and parse the text file as needed.
-    * 
+    *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the URL isn't specified and no data is given then the Loader will take the key and create a filename from that.
     * For example if the key is "alien" and no URL or data is given then the Loader will set the URL to be "alien.json".
     * It will always use `.json` as the extension.
-    * 
+    *
     * If you do not desire this action then provide a URL or data object.
     *
     * @method Phaser.Loader#physics
@@ -1265,7 +1262,7 @@ Phaser.Loader.prototype = {
 
     /**
     * Adds Bitmap Font files to the current load queue.
-    * 
+    *
     * To create the Bitmap Font files you can use:
     *
     * BMFont (Windows, free): http://www.angelcode.com/products/bmfont/
@@ -1275,21 +1272,21 @@ Phaser.Loader.prototype = {
     * You can choose to either load the data externally, by providing a URL to an xml file.
     * Or you can pass in an XML object or String via the `xmlData` parameter.
     * If you pass a String the data is automatically run through `Loader.parseXML` and then immediately added to the Phaser.Cache.
-    * 
+    *
     * If URLs are provided the files are **not** loaded immediately after calling this method, but are added to the load queue.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
-    * 
+    *
     * Retrieve the file via `Cache.getBitmapFont(key)`. XML files are automatically parsed upon load.
     * If you need to control when the XML is parsed then use `Loader.text` instead and parse the XML file as needed.
-    * 
+    *
     * The URLs can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the textureURL isn't specified then the Loader will take the key and create a filename from that.
     * For example if the key is "megaFont" and textureURL is null then the Loader will set the URL to be "megaFont.png".
     * The same is true for the atlasURL. If atlasURL isn't specified and no atlasData has been provided then the Loader will
     * set the atlasURL to be the key. For example if the key is "megaFont" the atlasURL will be set to "megaFont.xml".
-    * 
+    *
     * If you do not desire this action then provide URLs and / or a data object.
     *
     * @method Phaser.Loader#bitmapFont
@@ -1358,33 +1355,33 @@ Phaser.Loader.prototype = {
     * Adds a Texture Atlas file to the current load queue.
     *
     * Unlike `Loader.atlasJSONHash` this call expects the atlas data to be in a JSON Array format.
-    * 
+    *
     * To create the Texture Atlas you can use tools such as:
     *
     * [Texture Packer](https://www.codeandweb.com/texturepacker/phaser)
     * [Shoebox](http://renderhjs.net/shoebox/)
-    * 
+    *
     * If using Texture Packer we recommend you enable "Trim sprite names".
     * If your atlas software has an option to "rotate" the resulting frames, you must disable it.
     *
     * You can choose to either load the data externally, by providing a URL to a json file.
     * Or you can pass in a JSON object or String via the `atlasData` parameter.
     * If you pass a String the data is automatically run through `JSON.parse` and then immediately added to the Phaser.Cache.
-    * 
+    *
     * If URLs are provided the files are **not** loaded immediately after calling this method, but are added to the load queue.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
-    * 
+    *
     * Retrieve the file via `Cache.getImage(key)`. JSON files are automatically parsed upon load.
     * If you need to control when the JSON is parsed then use `Loader.text` instead and parse the JSON file as needed.
-    * 
+    *
     * The URLs can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the textureURL isn't specified then the Loader will take the key and create a filename from that.
     * For example if the key is "player" and textureURL is null then the Loader will set the URL to be "player.png".
     * The same is true for the atlasURL. If atlasURL isn't specified and no atlasData has been provided then the Loader will
     * set the atlasURL to be the key. For example if the key is "player" the atlasURL will be set to "player.json".
-    * 
+    *
     * If you do not desire this action then provide URLs and / or a data object.
     *
     * @method Phaser.Loader#atlasJSONArray
@@ -1404,33 +1401,33 @@ Phaser.Loader.prototype = {
     * Adds a Texture Atlas file to the current load queue.
     *
     * Unlike `Loader.atlas` this call expects the atlas data to be in a JSON Hash format.
-    * 
+    *
     * To create the Texture Atlas you can use tools such as:
     *
     * [Texture Packer](https://www.codeandweb.com/texturepacker/phaser)
     * [Shoebox](http://renderhjs.net/shoebox/)
-    * 
+    *
     * If using Texture Packer we recommend you enable "Trim sprite names".
     * If your atlas software has an option to "rotate" the resulting frames, you must disable it.
     *
     * You can choose to either load the data externally, by providing a URL to a json file.
     * Or you can pass in a JSON object or String via the `atlasData` parameter.
     * If you pass a String the data is automatically run through `JSON.parse` and then immediately added to the Phaser.Cache.
-    * 
+    *
     * If URLs are provided the files are **not** loaded immediately after calling this method, but are added to the load queue.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
-    * 
+    *
     * Retrieve the file via `Cache.getImage(key)`. JSON files are automatically parsed upon load.
     * If you need to control when the JSON is parsed then use `Loader.text` instead and parse the JSON file as needed.
-    * 
+    *
     * The URLs can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the textureURL isn't specified then the Loader will take the key and create a filename from that.
     * For example if the key is "player" and textureURL is null then the Loader will set the URL to be "player.png".
     * The same is true for the atlasURL. If atlasURL isn't specified and no atlasData has been provided then the Loader will
     * set the atlasURL to be the key. For example if the key is "player" the atlasURL will be set to "player.json".
-    * 
+    *
     * If you do not desire this action then provide URLs and / or a data object.
     *
     * @method Phaser.Loader#atlasJSONHash
@@ -1450,7 +1447,7 @@ Phaser.Loader.prototype = {
     * Adds a Texture Atlas file to the current load queue.
     *
     * This call expects the atlas data to be in the Starling XML data format.
-    * 
+    *
     * To create the Texture Atlas you can use tools such as:
     *
     * [Texture Packer](https://www.codeandweb.com/texturepacker/phaser)
@@ -1458,25 +1455,25 @@ Phaser.Loader.prototype = {
     *
     * If using Texture Packer we recommend you enable "Trim sprite names".
     * If your atlas software has an option to "rotate" the resulting frames, you must disable it.
-    * 
+    *
     * You can choose to either load the data externally, by providing a URL to an xml file.
     * Or you can pass in an XML object or String via the `atlasData` parameter.
     * If you pass a String the data is automatically run through `Loader.parseXML` and then immediately added to the Phaser.Cache.
-    * 
+    *
     * If URLs are provided the files are **not** loaded immediately after calling this method, but are added to the load queue.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
-    * 
+    *
     * Retrieve the file via `Cache.getImage(key)`. XML files are automatically parsed upon load.
     * If you need to control when the XML is parsed then use `Loader.text` instead and parse the XML file as needed.
-    * 
+    *
     * The URLs can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the textureURL isn't specified then the Loader will take the key and create a filename from that.
     * For example if the key is "player" and textureURL is null then the Loader will set the URL to be "player.png".
     * The same is true for the atlasURL. If atlasURL isn't specified and no atlasData has been provided then the Loader will
     * set the atlasURL to be the key. For example if the key is "player" the atlasURL will be set to "player.xml".
-    * 
+    *
     * If you do not desire this action then provide URLs and / or a data object.
     *
     * @method Phaser.Loader#atlasXML
@@ -1514,21 +1511,21 @@ Phaser.Loader.prototype = {
     * You can choose to either load the data externally, by providing a URL to a json file.
     * Or you can pass in a JSON object or String via the `atlasData` parameter.
     * If you pass a String the data is automatically run through `JSON.parse` and then immediately added to the Phaser.Cache.
-    * 
+    *
     * If URLs are provided the files are **not** loaded immediately after calling this method, but are added to the load queue.
-    * 
+    *
     * The key must be a unique String. It is used to add the file to the Phaser.Cache upon successful load.
-    * 
+    *
     * Retrieve the file via `Cache.getImage(key)`. JSON files are automatically parsed upon load.
     * If you need to control when the JSON is parsed then use `Loader.text` instead and parse the JSON file as needed.
-    * 
+    *
     * The URLs can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
-    * 
+    *
     * If the textureURL isn't specified then the Loader will take the key and create a filename from that.
     * For example if the key is "player" and textureURL is null then the Loader will set the URL to be "player.png".
     * The same is true for the atlasURL. If atlasURL isn't specified and no atlasData has been provided then the Loader will
     * set the atlasURL to be the key. For example if the key is "player" the atlasURL will be set to "player.json".
-    * 
+    *
     * If you do not desire this action then provide URLs and / or a data object.
     *
     * @method Phaser.Loader#atlas
@@ -1634,7 +1631,7 @@ Phaser.Loader.prototype = {
     /**
     * Add a synchronization point to a specific file/asset in the load queue.
     *
-    * This has no effect on already loaded assets.    
+    * This has no effect on already loaded assets.
     *
     * @method Phaser.Loader#addSyncPoint
     * @param {string} type - The type of resource to turn into a sync point (image, audio, xml, etc).
@@ -1738,7 +1735,7 @@ Phaser.Loader.prototype = {
         for (var i = 0; i < this._flightQueue.length; i++)
         {
             var file = this._flightQueue[i];
-            
+
             if (file.loaded || file.error)
             {
                 this._flightQueue.splice(i, 1);
@@ -1818,7 +1815,7 @@ Phaser.Loader.prototype = {
                     this._flightQueue.push(file);
                     file.loading = true;
                     this.onFileStart.dispatch(this.progress, file.key, file.url);
-                    
+
                     this.loadFile(file);
                 }
             }
@@ -2021,7 +2018,7 @@ Phaser.Loader.prototype = {
 
     /**
     * Transforms the asset URL.
-    * 
+    *
     * The default implementation prepends the baseURL if the url doesn't begin with http or //
     *
     * @method Phaser.Loader#transformUrl
@@ -2169,7 +2166,7 @@ Phaser.Loader.prototype = {
         {
             file.data.crossOrigin = this.crossOrigin;
         }
-        
+
         file.data.onload = function () {
             if (file.data.onload)
             {
@@ -2189,7 +2186,7 @@ Phaser.Loader.prototype = {
         };
 
         file.data.src = this.transformUrl(file.url, file);
-        
+
         // Image is immediately-available/cached
         if (file.data.complete && file.data.width && file.data.height)
         {
@@ -2212,7 +2209,7 @@ Phaser.Loader.prototype = {
         file.data.name = file.key;
         file.data.controls = false;
         file.data.autoplay = false;
-        
+
         var videoLoadEvent = function () {
 
             file.data.removeEventListener(file.loadEvent, videoLoadEvent, false);
@@ -2228,7 +2225,7 @@ Phaser.Loader.prototype = {
             file.data.canplay = false;
             _this.fileError(file);
         };
-       
+
         file.data.addEventListener(file.loadEvent, videoLoadEvent, false);
 
         file.data.src = this.transformUrl(file.url, file);
@@ -2258,7 +2255,7 @@ Phaser.Loader.prototype = {
         {
             file.data = new Audio();
             file.data.name = file.key;
-            
+
             var playThroughEvent = function () {
                 file.data.removeEventListener('canplaythrough', playThroughEvent, false);
                 file.data.onerror = null;
@@ -2366,7 +2363,7 @@ Phaser.Loader.prototype = {
     /**
     * Starts the xhr loader - using XDomainRequest.
     * This should _only_ be used with IE 9. Phaser does not support IE 8 and XDR is deprecated in IE 10.
-    * 
+    *
     * This is designed specifically to use with asset file processing.
     *
     * @method Phaser.Loader#xhrLoad
@@ -2587,7 +2584,7 @@ Phaser.Loader.prototype = {
         switch (file.type)
         {
             case 'packfile':
-                
+
                 // Pack data must never be false-ish after it is fetched without error
                 var data = JSON.parse(xhr.responseText);
                 file.data = data || {};
@@ -2676,7 +2673,7 @@ Phaser.Loader.prototype = {
                         throw new Error("Phaser.Loader. Unable to parse video file as Blob: " + file.key);
                     }
                 }
-                
+
                 this.cache.addVideo(file.key, file.url, file.data, file.asBlob);
                 break;
 


### PR DESCRIPTION
I'm working on a small project using Phaser and Pyxel Edit for coder-art. I was looking for a way to import my Pyxel Edit TileMaps as an atlas. After failing at lot, I stumbled upon [this discussion](https://pyxeledit.com/forum/discussion/217/pyxel-edit-and-phaser-framework).

I then set out attempting to write a plugin that would provide this integration, though it didn't seem to be possible with the current plugin architecture.

In the end I decided to fork, add feature support for it and offer it to the community if you, the maintainer, feel it appropriate. I attempted to follow your guidelines as best I could(jshint etc.) and can provide a test project to demonstrate the functionality if requested.

NB: I accidentally made changes on the master branch but have since reverted and cherry picked said changes to master. You'll see that nothing too sinister has happened in the diff :smile:.
