### PR TITLE
Fix for AudioBufferSourceNode listener memory leak.

### DIFF
--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -392,6 +392,7 @@ Phaser.Sound.prototype = {
     */
     onEndedHandler: function () {
 
+        this._sound.onended = null;
         this.isPlaying = false;
         this.stop();
 


### PR DESCRIPTION
In Chrome, the AudioBufferSourceNode onended listeners were never being garbage collected. This frees up the listener for collection.

More information here: http://www.html5gamedevs.com/topic/16903-problem-with-listeners-using-phasersoundonplayadd/