### PR TITLE
Add support for TiledJSON with base64 encoding

### DIFF
--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -232,6 +232,19 @@ Phaser.TilemapParser = {
             }
 
             var curl = json.layers[i];
+            
+            // Base64 decode data if necessary
+            // NOTE: uncompressed base64 only. 
+            if (!curl.compression && curl.encoding && curl.encoding === "base64") {
+                var binary_string =  window.atob(curl.data);
+                var len = binary_string.length;
+                var bytes = new Array( len );
+                for (var i = 0; i < len; i+=4) {
+                    bytes[i/4] = binary_string.charCodeAt(i);
+                }
+                curl.data = bytes;
+            }
+
 
             var layer = {
 

--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -236,11 +236,11 @@ Phaser.TilemapParser = {
             // Base64 decode data if necessary
             // NOTE: uncompressed base64 only. 
             if (!curl.compression && curl.encoding && curl.encoding === "base64") {
-                var binary_string =  window.atob(curl.data);
-                var len = binary_string.length;
+                var binaryString =  window.atob(curl.data);
+                var len = binaryString.length;
                 var bytes = new Array( len );
                 for (var i = 0; i < len; i+=4) {
-                    bytes[i/4] = binary_string.charCodeAt(i);
+                    bytes[i/4] = binaryString.charCodeAt(i);
                 }
                 curl.data = bytes;
             }


### PR DESCRIPTION
Tiled 0.13.0 added support for layer data compression when exporting as LUA or JSON. This means that any .tmx stored unsing base64 encoding will start exporting layer data as a base64 encoded string rather than a native array. 
Phaser would try to load the level anyway without emitting any errors, resulting in a corrupted level while playing. 
This PR adds detection and support for base64 encoded levels as long as they don't use compression.

Tiled commit adding base64 encoding: https://github.com/bjorn/tiled/commit/26a4675929e1622331a9b316291ee9283fc52a65