### PR TITLE
Correctly interpret binaryString as a sequence of uint32-le values

### DIFF
--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -239,8 +239,13 @@ Phaser.TilemapParser = {
                 var binaryString =  window.atob(curl.data);
                 var len = binaryString.length;
                 var bytes = new Array( len );
+                // Interpret binaryString as an array of bytes representing
+                // little-endian encoded uint32 values. 
                 for (var i = 0; i < len; i+=4) {
-                    bytes[i/4] = binaryString.charCodeAt(i);
+                    bytes[i/4] = binaryString.charCodeAt(i) |
+                                 binaryString.charCodeAt(i+1) << 8 |
+                                 binaryString.charCodeAt(i+2) << 16 |
+                                 binaryString.charCodeAt(i+3) << 24;
                 }
                 curl.data = bytes;
             }


### PR DESCRIPTION
The previous implementation was ignoring the 3 most significant bytes of each value and would result on improper parsing of any map with tile ids higher than 255