### PR TITLE
Fixes edge case when TilingSprite removed before render

### DIFF
--- a/src/pixi/extras/TilingSprite.js
+++ b/src/pixi/extras/TilingSprite.js
@@ -492,9 +492,13 @@ PIXI.TilingSprite.prototype.getBounds = function()
 
 PIXI.TilingSprite.prototype.destroy = function () {
 
-    this.canvasBuffer.destroy();
-
     PIXI.Sprite.prototype.destroy.call(this);
+
+    if (this.canvasBuffer)
+    {
+        this.canvasBuffer.destroy();
+        this.canvasBuffer = null;
+    }
 
     this.tileScale = null;
     this.tileScaleOffset = null;


### PR DESCRIPTION
- Issues caused when TilingSprite is destroyed before it has
  ever been rendered because `canvasBuffer` not created yet.

Fixes #2092