### PR TITLE
Added updateLayout method definition

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -4442,6 +4442,7 @@ declare module Phaser {
         scaleSprite(sprite: Image, width?: number, height?: number, letterBox?: boolean): Sprite;
         startFullScreen(antialias?: boolean, allowTrampoline?: boolean): boolean;
         stopFullScreen(): boolean;
+        updateLayout(): void;
 
     }
 


### PR DESCRIPTION
ScaleManager.updateLayout is present in phaser.js, but missing from the typescript definition. Not sure if that was intentional, but from what I read in the release notes ScaleManager.updateLayout is meant to replace ScaleManager.setScreenSize.