### PR TITLE
Fixes for Cache::addBitmapFont(...)

### DIFF
--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -439,6 +439,7 @@ Phaser.Cache.prototype = {
     * @param {string} url - The URL the asset was loaded from. If the asset was not loaded externally set to `null`.
     * @param {object} data - Extra font data.
     * @param {object} atlasData - Texture atlas frames data.
+    * @param {string} [atlasType='xml'] - The format of the texture atlas ( 'json' or 'xml' ).
     * @param {number} [xSpacing=0] - If you'd like to add additional horizontal spacing between the characters then set the pixel value here.
     * @param {number} [ySpacing=0] - If you'd like to add additional vertical spacing between the lines then set the pixel value here.
     */

--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -451,7 +451,10 @@ Phaser.Cache.prototype = {
             font: null,
             base: new PIXI.BaseTexture(data)
         };
-
+        
+        if (xSpacing === undefined) { xSpacing = 0; }
+        if (ySpacing === undefined) { ySpacing = 0; }
+        
         if (atlasType === 'json')
         {
             obj.font = Phaser.LoaderParser.jsonBitmapFont(atlasData, obj.base, xSpacing, ySpacing);


### PR DESCRIPTION
- add missing API doc parameter "atlasType"
- apply default X/Y-Spacing when omitted as a parameter