### PR TITLE
Better default value for suggestedFps

### DIFF
--- a/src/time/Time.js
+++ b/src/time/Time.js
@@ -113,12 +113,13 @@ Phaser.Time = function (game) {
     * The suggested frame rate for your game, based on an averaged real frame rate.
     * This value is only populated if `Time.advancedTiming` is enabled.
     *
-    * _Note:_ This is not available until after a few frames have passed; use it after a few seconds (eg. after the menus)
+    * _Note:_ This is not available until after a few frames have passed; until then
+    * it's set to the same value as desiredFps.
     *
     * @property {number} suggestedFps
     * @default
     */
-    this.suggestedFps = null;
+    this.suggestedFps = this.desiredFps;
 
     /**
     * Scaling factor to make the game move smoothly in slow motion


### PR DESCRIPTION
In any game that handles fps issues as seen in http://phaser.io/examples/v2/time/slow-down-time the game will hang if game.fpsProblemNotifier fires early on, before game.time.suggestedFps has any value other than null. 

The docs recommend waiting a few seconds before accesing suggestedFps. Since it's hard to tell exactly how long "a few seconds" is, shouldn't suggestedFps be initialized to the same value as desidedFps? 

I think it's better to get an inaccurate value for a few frames than an invalid value. It means users don't have to care about the specifics of how and when suggestedFps gets its value.