### PR TITLE
SinglePad.callbackContext is now set through addCallbacks method.

### DIFF
--- a/src/input/SinglePad.js
+++ b/src/input/SinglePad.js
@@ -138,6 +138,10 @@ Phaser.SinglePad.prototype = {
             this.onFloatCallback = (typeof callbacks.onFloat === 'function') ? callbacks.onFloat : this.onFloatCallback;
         }
 
+        if (typeof context !== 'undefined')
+        {
+            this.callbackContext = context;
+        }
     },
 
     /**

--- a/src/input/SinglePad.js
+++ b/src/input/SinglePad.js
@@ -136,10 +136,7 @@ Phaser.SinglePad.prototype = {
             this.onUpCallback = (typeof callbacks.onUp === 'function') ? callbacks.onUp : this.onUpCallback;
             this.onAxisCallback = (typeof callbacks.onAxis === 'function') ? callbacks.onAxis : this.onAxisCallback;
             this.onFloatCallback = (typeof callbacks.onFloat === 'function') ? callbacks.onFloat : this.onFloatCallback;
-        }
 
-        if (typeof context !== 'undefined')
-        {
             this.callbackContext = context;
         }
     },


### PR DESCRIPTION
This fix is essentially the SinglePad version of #1285.