### PR TITLE
Add method to angle Display Objects relative to world

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1698,4 +1698,21 @@ Phaser.Physics.Arcade.prototype = {
 
     }
 
+    /**
+    * Find the angle in radians between a display object (like a Sprite) and a Pointer, taking their x/y and center into account relative to the world.
+    *
+    * @method Phaser.Physics.Arcade#worldAngleToPointer
+    * @param {any} displayObject - The DisplayObjerct to test from.
+    * @param {Phaser.Pointer} [pointer] - The Phaser.Pointer to test to. If none is given then Input.activePointer is used.
+    * @return {number} The angle in radians between displayObject.x/y to Pointer.x/y
+    */
+     worldAngleToPointer: function (displayObject, pointer) {
+        pointer = pointer || game.input.activePointer;
+
+        var dx = pointer.worldX - displayObject.world.x;
+        var dy = pointer.worldY - displayObject.world.y;
+
+        return Math.atan2(dy, dx);
+    }
+
 };


### PR DESCRIPTION
Display Objects are not angled properly when they are children of other objects. This method gets their position relative to world and angles them properly to cursor. Another option is to replace angleToCursor() with the method attached to always angle them relative to the world.