### PR TITLE
Added `lifespan` argument to Particles.Arcade.Emitter.emitParticle.

### DIFF
--- a/src/particles/arcade/Emitter.js
+++ b/src/particles/arcade/Emitter.js
@@ -547,9 +547,10 @@ Phaser.Particles.Arcade.Emitter.prototype.start = function (explode, lifespan, f
 * @param {number} [y] - The y coordinate to emit the particle from. If `null` or `undefined` it will use `Emitter.emitY` or if the Emitter has a height > 1 a random value between `Emitter.top` and `Emitter.bottom`.
 * @param {string|Phaser.RenderTexture|Phaser.BitmapData|Phaser.Video|PIXI.Texture} [key] - This is the image or texture used by the Particle during rendering. It can be a string which is a reference to the Cache Image entry, or an instance of a RenderTexture, BitmapData, Video or PIXI.Texture.
 * @param {string|number} [frame] - If this Particle is using part of a sprite sheet or texture atlas you can specify the exact frame to use by giving a string or numeric index.
+* @param {number} [lifespan] - The lifespan of the particle to emit.
 * @return {boolean} True if a particle was emitted, otherwise false.
 */
-Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, frame) {
+Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, frame, lifespan) {
 
     if (x === undefined) { x = null; }
     if (y === undefined) { y = null; }
@@ -596,7 +597,7 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
     particle.reset(emitX, emitY);
 
     particle.angle = 0;
-    particle.lifespan = this.lifespan;
+    particle.lifespan = (lifespan !== undefined) ? lifespan : this.lifespan;
 
     if (this.particleBringToTop)
     {

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -901,8 +901,8 @@ Phaser.TilemapLayer.prototype.renderDeltaScroll = function (shiftX, shiftY) {
     var scrollX = this._mc.scrollX;
     var scrollY = this._mc.scrollY;
 
-    var renderW = this.canvas.width;
-    var renderH = this.canvas.height;
+    var renderW = this.game.camera.width;
+    var renderH = this.game.camera.height;
 
     var tw = this._mc.tileWidth;
     var th = this._mc.tileHeight;
@@ -978,8 +978,8 @@ Phaser.TilemapLayer.prototype.renderFull = function () {
     var scrollX = this._mc.scrollX;
     var scrollY = this._mc.scrollY;
 
-    var renderW = this.canvas.width;
-    var renderH = this.canvas.height;
+    var renderW = this.game.camera.width;
+    var renderH = this.game.camera.height;
 
     var tw = this._mc.tileWidth;
     var th = this._mc.tileHeight;


### PR DESCRIPTION
This change enables a single particle to be emitted with a custom lifespan.

The change adds flexibility for users who may be using one emitter over a big sprite sheet.