### PR TITLE
Bugfix, reuse emitter when parameter explode=false

### DIFF
--- a/src/particles/arcade/Emitter.js
+++ b/src/particles/arcade/Emitter.js
@@ -528,7 +528,7 @@ Phaser.Particles.Arcade.Emitter.prototype.start = function (explode, lifespan, f
     else
     {
         this.on = true;
-        this._quantity += quantity;
+        this._quantity = quantity;
         this._counter = 0;
         this._timer = this.game.time.time + frequency * this.game.time.slowMotion;
     }


### PR DESCRIPTION
There is a bug when calling emitter.start() consecutively with parameter explode=false. The bug will cummulatively add particles, so for example when quantity=10, the first call to .start() will emit 10 particles, but the next call also with quantity=10 will spawn 20 particles, then 30, 40 etc.

Also see forum post here
http://www.html5gamedevs.com/topic/3920-repeated-calls-to-emitterstart-spawns-increasing-number-of-particles/