### PR TITLE
Add typescript section to bower/npm configs to support `tsd link`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,5 +32,12 @@
     "bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "typescript": {
+    "definitions": [
+      "typescript/p2.d.ts",
+      "typescript/phaser.comments.d.ts",
+      "typescript/pixi.comments.d.ts"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -46,5 +46,12 @@
     "load-grunt-config": "~0.7.2",
     "typescript": "^1.4.1",
     "yuidocjs": "^0.3.50"
+  },
+  "typescript": {
+    "definitions": [
+      "typescript/p2.d.ts",
+      "typescript/phaser.comments.d.ts",
+      "typescript/pixi.comments.d.ts"
+    ]
   }
 }


### PR DESCRIPTION
As mentioned in https://github.com/photonstorm/phaser/issues/2180, tsd provides the ability to [link to bundled definitions](https://github.com/DefinitelyTyped/tsd#link-to-bundled-definitions) in bower and npm packages.  Since Phaser is available through both package managers, packages.json and bower.json have both been modified in this pull request to support tsd's linking ability.