### PR TITLE
Asset packs are now correctly spliced between waiting files.

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -657,7 +657,7 @@ Phaser.Loader.prototype = {
 
             if (!file || (!file.loaded && !file.loading && file.type !== 'packfile'))
             {
-                this._fileList.splice(i, 1, pack);
+                this._fileList.splice(i, 0, pack);
                 this._totalPackCount++;
                 break;
             }


### PR DESCRIPTION
#2203 Pull request for this issue. Sorry for the two issues. Dont use github that often. :(