### PR TITLE
Update BitmapData.setHSL to accept 0

### DIFF
--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -782,9 +782,10 @@ Phaser.BitmapData.prototype = {
     * @return {Phaser.BitmapData} This BitmapData object for method chaining.
     */
     setHSL: function (h, s, l, region) {
-        var bHaveH = typeof(h) === "number",
-            bHaveS = typeof(s) === "number",
-            bHaveL = typeof(l) === "number";
+        
+        var bHaveH = h || h === 0;
+        var bHaveS = s || s === 0;
+        var bHaveL = l || l === 0;
 
         if (!bHaveH && !bHaveS && !bHaveL)
         {

--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -782,12 +782,11 @@ Phaser.BitmapData.prototype = {
     * @return {Phaser.BitmapData} This BitmapData object for method chaining.
     */
     setHSL: function (h, s, l, region) {
+        var bHaveH = typeof(h) === "number",
+            bHaveS = typeof(s) === "number",
+            bHaveL = typeof(l) === "number";
 
-        if (h === undefined || h === null) { h = false; }
-        if (s === undefined || s === null) { s = false; }
-        if (l === undefined || l === null) { l = false; }
-
-        if (!h && !s && !l)
+        if (!bHaveH && !bHaveS && !bHaveL)
         {
             return;
         }
@@ -805,17 +804,17 @@ Phaser.BitmapData.prototype = {
             {
                 Phaser.Color.unpackPixel(this.getPixel32(x, y), pixel, true);
 
-                if (h)
+                if (bHaveH)
                 {
                     pixel.h = h;
                 }
 
-                if (s)
+                if (bHaveS)
                 {
                     pixel.s = s;
                 }
 
-                if (l)
+                if (bHaveL)
                 {
                     pixel.l = l;
                 }


### PR DESCRIPTION
Checking `if (h)` yields `false` when `h = 0`, but 0 is an acceptable value here. Had to decide between caching HSL verification and doing `typeof` 3x/pixel and opted for the temporary variables.