### PR TITLE
Fix in typescript definition file: Pointer definition

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -3690,7 +3690,7 @@ declare module Phaser {
         isDown: boolean;
         isMouse: boolean;
         isUp: boolean;
-        leftButton: boolean;
+        leftButton:  Phaser.DeviceButton;
         middleButton: boolean;
         movementX: number;
         movementY: number;
@@ -3704,7 +3704,7 @@ declare module Phaser {
         previousTapTime: number;
         rawMovementX: number;
         rawMovementY: number;
-        rightButton: boolean;
+        rightButton: Phaser.DeviceButton;
         screenX: number;
         screenY: number;
         target: any;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -3690,7 +3690,7 @@ declare module Phaser {
         isDown: boolean;
         isMouse: boolean;
         isUp: boolean;
-        leftButton:  Phaser.DeviceButton;
+        leftButton: Phaser.DeviceButton;
         middleButton: boolean;
         movementX: number;
         movementY: number;


### PR DESCRIPTION
Pointer properties rightButton and LeftButton are DeviceButton objects instead of booleans (http://phaser.io/docs/2.4.4/Phaser.Pointer.html#rightButton)