### PR TITLE
Allow direct import of Phaser.Image for RetroFont

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 
 * Buttons (or any Sprites) that don't have a texture, but have children, would incorrectly render the children under WebGL due to the baseTexture.skipRender property (thanks @puzzud #2141)
 * TilemapParser accidentally redeclared `i` when parsing the ImageCollections which would cause an infinite loop (thanks DanHett)
+* BitmapData.update causes a snowballing memory leak under WebGL due to a Context.getImageData call. BitmapData.clear used to call update automatically but no longer does. This resolves the issue of the Debug class causing excessive memory build-up in Chrome. Firefox and IE were unaffected (thanks @kingjerod #2208)
 
 ### Pixi Updates
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Thousands of developers worldwide use it. From indies and multi-national digital
 ![div](http://www.phaser.io/images/github/div.png)
 
 <a name="whats-new"></a>
-## What's new in Phaser 2.4.4
+## What's new in Phaser 2.4.5
 
 <div align="center"><img src="http://phaser.io/images/github/news.jpg"></div>
 
@@ -107,15 +107,15 @@ Install via [npm](https://www.npmjs.com)
 
 [jsDelivr](http://www.jsdelivr.com/#!phaser) is a "super-fast CDN for developers". Include the following in your html:
 
-`<script src="//cdn.jsdelivr.net/phaser/2.4.4/phaser.js"></script>`
+`<script src="//cdn.jsdelivr.net/phaser/2.4.5/phaser.js"></script>`
 
 or the minified version:
 
-`<script src="//cdn.jsdelivr.net/phaser/2.4.4/phaser.min.js"></script>`
+`<script src="//cdn.jsdelivr.net/phaser/2.4.5/phaser.min.js"></script>`
 
 [cdnjs.com](https://cdnjs.com/libraries/phaser) also offers a free CDN service. They have all versions of Phaser and even the custom builds:
 
-`<script src="https://cdnjs.cloudflare.com/ajax/libs/phaser/2.4.4/phaser.js"></script>`
+`<script src="https://cdnjs.cloudflare.com/ajax/libs/phaser/2.4.5/phaser.js"></script>`
 
 ### Phaser Sandbox
 
@@ -265,89 +265,22 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 <a name="change-log"></a>
 ## Change Log
 
-## Version 2.4.4 - "Amador" - 15th October 2015
+## Version 2.4.5 - "Sienda" - in dev
 
 ### New Features
 
-* Emitter.emitParticle now has 4 new optional arguments: `x`, `y`, `key` and `frame`. These allow you to override whatever the Emitter default values may be and emit the particle from the given coordinates and with a new texture.
-* Group.resetChild is a new method that allows you to call both `child.reset` and/or `child.loadTexture` on the given child object. This is used internally by `getFirstDead` and similar, but is made public so you can use it as a group iteration callback. Note that the child must have public `reset` and `loadTexture` methods to be valid for the call.
-* Group.getFirstDead, Group.getFirstAlive and Group.getFirstExists all have new optional arguments: `createIfNull`, `x`, `y`, `key` and `frame`. If the method you call cannot find a matching child (i.e. getFirstDead cannot find any dead children) then the optional `createIfNull` allows you to instantly create a new child in the group using the position and texture arguments to do so. This allows you to always get a child back from the Group and remove the need to do null checks and Group inserts from your game code. The same arguments can also be used in a different way: if `createIfNull` is false AND you provide the extra arguments AND a child is found then it will be passed to the new `Group.resetChild` method. This allows you to retrieve a child from the Group and have it reset and instantly ready for use in your game without any extra code.
-* P2.Body.removeCollisionGroup allows you to remove the given CollisionGroup, or array of CollisionGroups, from the list of groups that a body will collide with and updates the collision masks (thanks @Garbanas #2047)
-* Filter.addToWorld allows you to quickly create a Phaser.Image object at the given position and size, with the Filter ready applied to it. This can eliminate lots of duplicate code.
-* Tiled 0.13.0 added support for layer data compression when exporting as JSON. This means that any .tmx stored using base64 encoding will start exporting layer data as a base64 encoded string rather than a native array. This update adds in automatic support for this as long as the data isn't compressed. For IE9 support you'll need to use the new polyfill found in the resources folder (thanks @noidexe #2084)
-* You can now load single layer Pyxel Edit TileMaps as an atlas (thanks @joshpmcghee #2050)
-* Canvas.getSmoothingPrefix will return the vendor prefixed smoothing enabled value from the context if set, otherwise null.
-* The Random Number Generator can now get and set its state via rnd.state. This allows you to do things like saving the state of the generator to a string that can be part of a save-game file and load it back in again (thanks @luckylooke #2056 #1900)
-* Device.iOSVersion now contains the major version number of iOS.
-* The new `PointerMode` enumeration value has been added for better simple input discrimination in the future, between active pointers such as touch screens and passive pointers, such as mouse cursors (thanks @pnstickne #2062)
-* Button.justReleasedPreventsOver controls if a just-release event
-on a pointer prevents it from being able to trigger an over event.
-* Button.forceOut expanded to accept a PointerMode value such that it
-can be controlled per-input mode.
-* Phaser.KeyCode is a new pseudo-type used by the Keyboard class (and your code) to allow for separation of all the Keyboard constants to their own file. This stops the JSDocs from becoming 'polluted' and allows for easier future expansion (thanks @pnstickne #2118 #2031)
-
 ### Updates
 
-* TypeScript definitions fixes and updates (thanks @clark-stevenson @milkey-mouse @timotei @qdrj @Garbanas @cloakedninjas)
-* Docs typo fixes (thanks @rwrountree @yeluoqiuzhi @pnstickne @fonsecas72 @JackMorganNZ @caryanne)
-* Math.average has been optimized (thanks @rwrountree #2025)
-* When calling GameObject.revive the `heal` method is called to apply the health value, allowing it to take into consideration a `maxHealth` value if set (thanks @bsparks #2027)
-* Change splice.call(arguments, ..) to use slice instead (thanks @pnstickne #2034 #2032)
-* BitmapData.move, moveH and moveV have a new optional `wrap` argument allowing you to control if the contents of the BitmapData are wrapped around the edges (true) or simply scrolled off (false).
-* Time.desiredFps has moved to a getter / setter.
-* Time.physicsElapsed and Time.physicsElapsedMS are no longer calculated every frame, but only when the desiredFps is changed.
-* Time.update has been streamlined and the `updateSetTimeout` and `updateRAF` methods merged and duplicate code removed.
-* Time.desiredFpsMult is a pre-calculated multiplier used in Game.update.
-* Time.refresh updates the `Time.time` and `Time.elapsedMS` values and is called automatically by Game.update.
-* DeviceButton was setting a `duration` property on itself, which went against the read only getter of duration (thanks @winstonwolff)
-* Added Node.js v4 stable to Travis config (thanks @phillipalexander #2070)
-* Optimised Canvas.getSmoothingEnabled, Canvas.setSmoothingEnabled and Canvas.setImageRenderingCrisp.
-* The Physics Editor Exporter (found in the resources folder of the repo) has had an option to prefix shape names and optimize JSON output added to it (thanks @Garbanas #2093)
-* Touch.addTouchLockCallback has a new argument `onEnd` which allows the callback to fire either on a touchstart or a touchend event.
-* The SoundManager now detects if the browser is running under iOS9 and uses a touchend callback to unlock the audio subsystem. Previous versions of iOS (and Android) still use touchstart. This fixes Apple's screw-up with regard to changing the way Web Audio should be triggered in Mobile Safari. Thanks Apple (thanks @MyCatCarlos for the heads-up #2095)
-* InputHandler.validForInput now checks if the game object has `input.enabled` set to `false` and doesn't validate it for input if that's the case.
-* The default Button.onOverMouseOnly value has changed from `false` to `true`. If you used this in your touch enabled games then please be aware of this change (#2083)
-* BitmapData.clear now automatically calls BitmapData.update at the end of it.
-* New Color stub added for the custom build process. Contains just the bare minimum of functions that Phaser needs to work. Cuts file size from 48.7KB to 7.4KB. Note: Do not stub this out if using BitmapData objects.
-* New DOM stub added for the custom build process. Contains just the bare minimum of functions that Phaser needs to work. Cuts file size from 14.8KB to 2.4KB. Note: Do not stub this out if using the full Scale Manager.
-* New Scale Manager stub added. Removes all Scale Manager handling from Phaser! But saves 75KB in the process. If you know you don't need to scale the Phaser canvas, or are handling that externally, then you can safely stub it out in a custom build.
-* Added the PIXI.PolyK, PIXI.WebGLGraphics and PIXI.CanvasGraphics files to the Graphics custom build option. They weren't used anyway and this removes an extra 40.2KB from the build size.
-* Phaser.Create no longer automatically creates a BitmapData object when it starts. It now only does it when you first make a texture or grid.
-* New Create stub added for the custom build process. Cuts file size by 8KB.
-* You can now exclude the FlexGrid from custom builds, saving 15KB.
-* The ScaleManager no longer creates a Phaser.FlexGrid if the class isn't available (i.e. excluded via a custom build)
-* Time.suggestedFps is now defaulted to `Time.desiredFps` for the first few frames until things have settled down (previously it was `null`) (thanks @noidexe #2130)
-* Text with anchor 0.5 and word wrap would have an extra space added to its width calculations, this is now adjusted for (thanks @nickryall #2052 #1990)
-* ScaleManager.getParentBounds now checks if `parentNode` has an `offsetParent` before calling `getBoundingClientRect` on it (thanks @McFarts #2134)
+* TypeScript definitions fixes and updates (thanks @clark-stevenson)
+* Docs typo fixes (thanks ...)
 
 ### Bug Fixes
 
-* Loader.bitmapFont wouldn't automatically set the `atlasURL` value if just the key was given.
-* The Loader would put the baseURL and/or path in front of `data:` and `blob` URLs (thanks @rblopes #2044)
-* When the Text width was being calculated it would add the `strokeThickness` value twice, causing an alignment offset (thanks @nickryall #2039)
-* Sound.onEndedHandler has a fix for AudioBufferSourceNode listener memory leak (thanks @Pappa #2069)
-* Game.update could call `updateLogic` multiple times in a single frame when catching up with slow device frame rates. This would cause Tweens to advance at twice the speed they should have done (thanks @mkristo)
-* Added useCapture flags to removeEventListener in MSPointer class (thanks @pmcmonagle #2055)
-* Under setTimeOut (or when `forceSetTimeOut` was true) the Time was incorrectly setting `Time.timeExpected` causing game updates to lag (thanks @satan6 #2087)
-* Fixes edge case when TilingSprite is removed before render (thanks @pnstickne #2097 #2092)
-* Camera.setBoundsToWorld only adjusts the bounds if it exists (thanks @prudolfs #2099)
-* Keyboard.addCallbacks didn't check to see if the arguments were `null`, only if they were `undefined` making the jsdocs misleading.
-* ScaleManager.getParentBounds now takes any transforms into account to get the correct parent bounds (thanks @jdnichollsc #2111 #2098)
-* Cache.addBitmapFont now applies a default value for the x and y spacing if the arguments are omitted (thanks @nlotz #2128)
-* Removed use of the `tilePosition` property in the Phaser.Rope class as it isn't implemented and caused calls to `Rope.reset` to crash (thanks @spayton #2135)
-* ScaleMin and ScaleMax stopped working in Phaser 2.3.0 due to an incorrect transform callback scope (thanks @brianbunch #2132)
 
 ### Pixi Updates
 
 Please note that Phaser uses a custom build of Pixi and always has done. The following changes have been made to our custom build, not to Pixi in general.
 
-* CanvasRenderer.mapBlendModes optimised to cut down on file size.
-* PIXI.WebGLRenderer.updateTexture now returns a boolean depending on if the texture was successfully bound to the gl context or not.
-* PIXI.WebGLSpriteBatch.renderBatch would still try and render a texture even if `updateTexture` failed to bind it. It now checks the return value from `updateTexture` and ignores failed binds.
-* WebGLRenderer.mapBlendModes optimised to cut down on file size.
-* Sprite.getBounds would report an inaccurate value if the sprite was negatively scaled (causing things like generateTexture to be cut off) (thanks @DavidAPC #2108)
-* Removed DisplayObject.transformCallback as it's a Game Object component.
-* BaseTexture.skipRender is a new boolean that can be set to skip the rendering phase in the WebGL Sprite Batch. You may want to do this if you have a parent Sprite with no visible texture (i.e. uses the internal `__default` texture) that has children that you do want to render, without causing a batch flush in the process.
 
 For changes in previous releases please see the extensive [Version History](https://github.com/photonstorm/phaser/blob/master/CHANGELOG.md).
 
@@ -386,10 +319,10 @@ All rights reserved.
 
 [![Analytics](https://ga-beacon.appspot.com/UA-44006568-2/phaser/index)](https://github.com/igrigorik/ga-beacon)
 
-[get-js]: https://github.com/photonstorm/phaser/releases/download/v2.4.4/phaser.js
-[get-minjs]: https://github.com/photonstorm/phaser/releases/download/v2.4.4/phaser.min.js
-[get-zip]: https://github.com/photonstorm/phaser/archive/v2.4.4.zip
-[get-tgz]: https://github.com/photonstorm/phaser/archive/v2.4.4.tar.gz
+[get-js]: https://github.com/photonstorm/phaser/releases/download/v2.4.5/phaser.js
+[get-minjs]: https://github.com/photonstorm/phaser/releases/download/v2.4.5/phaser.min.js
+[get-zip]: https://github.com/photonstorm/phaser/archive/v2.4.5.zip
+[get-tgz]: https://github.com/photonstorm/phaser/archive/v2.4.5.tar.gz
 [clone-http]: https://github.com/photonstorm/phaser.git
 [clone-ssh]: git@github.com:photonstorm/phaser.git
 [clone-svn]: https://github.com/photonstorm/phaser

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 
 ### Bug Fixes
 
+* Buttons (or any Sprites) that don't have a texture, but have children, would incorrectly render the children under WebGL due to the baseTexture.skipRender property (thanks @puzzud #2141)
 
 ### Pixi Updates
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 
 ### New Features
 
+* You can use the new const `Phaser.PENDING_ATLAS` as the texture key for any sprite. Doing this then sets the key to be the `frame` argument (the frame is set to zero). This allows you to create sprites using `load.image` during development, and then change them to use a Texture Atlas later in development by simply searching your code for 'PENDING_ATLAS' and swapping it to be the key of the atlas data.
+
 ### Updates
 
 * TypeScript definitions fixes and updates (thanks @clark-stevenson)

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ If you are an exceptional JavaScript developer and would like to join the Phaser
 ### Bug Fixes
 
 * Buttons (or any Sprites) that don't have a texture, but have children, would incorrectly render the children under WebGL due to the baseTexture.skipRender property (thanks @puzzud #2141)
+* TilemapParser accidentally redeclared `i` when parsing the ImageCollections which would cause an infinite loop (thanks DanHett)
 
 ### Pixi Updates
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phaser",
-  "version": "2.4.4",
-  "release": "Amador",
+  "version": "2.4.5",
+  "release": "Sienda",
   "description": "A fast, free and fun HTML5 Game Framework for Desktop and Mobile web browsers.",
   "author": "Richard Davey <rdavey@gmail.com> (http://www.photonstorm.com)",
   "logo": "https://raw.github.com/photonstorm/phaser/master/phaser-logo-small.png",

--- a/resources/release-names.txt
+++ b/resources/release-names.txt
@@ -14,7 +14,7 @@ POI: River Eldar, Sea of Storms
 Amadicia *
 
 Capital: Amador *
-Cities: Abila, Bellon, Jeramel, Mardecin, Sienda
+Cities: Abila, Bellon, Jeramel, Mardecin, Sienda *
 POI: Mountains of Mist, River Eldar, River Sharia, Shadow Coast
 
 Andor

--- a/src/Phaser.js
+++ b/src/Phaser.js
@@ -15,7 +15,7 @@ var Phaser = Phaser || {
     * @constant
     * @type {string}
     */
-    VERSION: '2.4.4',
+    VERSION: '2.4.5-dev',
 
     /**
     * An array of Phaser game instances.

--- a/src/Phaser.js
+++ b/src/Phaser.js
@@ -291,6 +291,13 @@ var Phaser = Phaser || {
     VIDEO: 28,
 
     /**
+    * Game Object type.
+    * @constant
+    * @type {integer}
+    */
+    PENDING_ATLAS: -1,
+
+    /**
      * Various blend modes supported by Pixi.
      * 
      * IMPORTANT: The WebGL renderer only supports the NORMAL, ADD, MULTIPLY and SCREEN blend modes.

--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -765,7 +765,7 @@ Phaser.Group.prototype.xy = function (index, x, y) {
 /**
 * Reverses all children in this group.
 *
-* This operaation applies only to immediate children and does not propagate to subgroups.
+* This operation applies only to immediate children and does not propagate to subgroups.
 *
 * @method Phaser.Group#reverse
 */

--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -441,6 +441,9 @@ Phaser.BitmapData.prototype = {
     * You can optionally define the area to clear.
     * If the arguments are left empty it will clear the entire canvas.
     *
+    * You may need to call BitmapData.update after this in order to clear out the pixel data, 
+    * but Phaser will not do this automatically for you.
+    *
     * @method Phaser.BitmapData#clear
     * @param {number} [x=0] - The x coordinate of the top-left of the area to clear.
     * @param {number} [y=0] - The y coordinate of the top-left of the area to clear.
@@ -456,8 +459,6 @@ Phaser.BitmapData.prototype = {
         if (height === undefined) { height = this.height; }
 
         this.context.clearRect(x, y, width, height);
-
-        this.update();
 
         this.dirty = true;
 
@@ -566,6 +567,8 @@ Phaser.BitmapData.prototype = {
     * This re-creates the BitmapData.imageData from the current context.
     * It then re-builds the ArrayBuffer, the data Uint8ClampedArray reference and the pixels Int32Array.
     * If not given the dimensions defaults to the full size of the context.
+    *
+    * Warning: This is a very expensive operation, so use it sparingly.
     *
     * @method Phaser.BitmapData#update
     * @param {number} [x=0] - The x coordinate of the top-left of the image data area to grab from.

--- a/src/gameobjects/RetroFont.js
+++ b/src/gameobjects/RetroFont.js
@@ -12,7 +12,7 @@
 * @extends Phaser.RenderTexture
 * @constructor
 * @param {Phaser.Game} game - Current game instance.
-* @param {string} key - The font set graphic set as stored in the Game.Cache.
+* @param {string | Phaser.Image} key - The font set graphic set's key as stored in the Game.Cache, or an image to use for the graphic set.
 * @param {number} characterWidth - The width of each character in the font set.
 * @param {number} characterHeight - The height of each character in the font set.
 * @param {string} chars - The characters used in the font set, in display order. You can use the TEXT_SET consts for common font set arrangements.
@@ -24,14 +24,27 @@
 */
 Phaser.RetroFont = function (game, key, characterWidth, characterHeight, chars, charsPerRow, xSpacing, ySpacing, xOffset, yOffset) {
 
-    if (!game.cache.checkImageKey(key))
+     /**
+    * @property {Image} fontSet - A reference to the image stored in the Game.Cache that contains the font.
+    */
+    this.fontSet = null;
+
+    if(typeof key === Phaser.Image)
+    {
+        this.fontSet = key;
+    }
+    else if (!game.cache.checkImageKey(key))
     {
         return false;
+    }
+    else
+    {
+        this.fontSet = game.cache.getImage(key);
     }
 
     if (charsPerRow === undefined || charsPerRow === null)
     {
-        charsPerRow = game.cache.getImage(key).width / characterWidth;
+        charsPerRow = this.fontSet.width / characterWidth;
     }
 
     /**
@@ -106,11 +119,6 @@ Phaser.RetroFont = function (game, key, characterWidth, characterHeight, chars, 
     * @property {number} fixedWidth
     */
     this.fixedWidth = 0;
-
-    /**
-    * @property {Image} fontSet - A reference to the image stored in the Game.Cache that contains the font.
-    */
-    this.fontSet = game.cache.getImage(key);
 
     /**
     * @property {string} _text - The text of the font image.

--- a/src/gameobjects/Video.js
+++ b/src/gameobjects/Video.js
@@ -1135,7 +1135,7 @@ Phaser.Video.prototype = {
 };
 
 /**
-* @memberof Phaser.Video
+* @name Phaser.Video#currentTime
 * @property {number} currentTime - The current time of the video in seconds. If set the video will attempt to seek to that point in time.
 */
 Object.defineProperty(Phaser.Video.prototype, "currentTime", {
@@ -1155,7 +1155,7 @@ Object.defineProperty(Phaser.Video.prototype, "currentTime", {
 });
 
 /**
-* @memberof Phaser.Video
+* @name Phaser.Video#duration
 * @property {number} duration - The duration of the video in seconds.
 * @readOnly
 */
@@ -1170,7 +1170,7 @@ Object.defineProperty(Phaser.Video.prototype, "duration", {
 });
 
 /**
-* @memberof Phaser.Video
+* @name Phaser.Video#progress
 * @property {number} progress - The progress of this video. This is a value between 0 and 1, where 0 is the start and 1 is the end of the video.
 * @readOnly
 */

--- a/src/gameobjects/components/LoadTexture.js
+++ b/src/gameobjects/components/LoadTexture.js
@@ -34,6 +34,13 @@ Phaser.Component.LoadTexture.prototype = {
     * 
     * Calling this method causes a WebGL texture update, so use sparingly or in low-intensity portions of your game, or if you know the new texture is already on the GPU.
     *
+    * You can use the new const `Phaser.PENDING_ATLAS` as the texture key for any sprite. 
+    * Doing this then sets the key to be the `frame` argument (the frame is set to zero). 
+    * 
+    * This allows you to create sprites using `load.image` during development, and then change them 
+    * to use a Texture Atlas later in development by simply searching your code for 'PENDING_ATLAS' 
+    * and swapping it to be the key of the atlas data.
+    *
     * @method
     * @param {string|Phaser.RenderTexture|Phaser.BitmapData|Phaser.Video|PIXI.Texture} key - This is the image or texture used by the Sprite during rendering. It can be a string which is a reference to the Cache Image entry, or an instance of a RenderTexture, BitmapData, Video or PIXI.Texture.
     * @param {string|number} [frame] - If this Sprite is using part of a sprite sheet or texture atlas you can specify the exact frame to use by giving a string or numeric index.
@@ -41,7 +48,15 @@ Phaser.Component.LoadTexture.prototype = {
     */
     loadTexture: function (key, frame, stopAnimation) {
 
-        frame = frame || 0;
+        if (key === Phaser.PENDING_ATLAS)
+        {
+            key = frame;
+            frame = 0;
+        }
+        else
+        {
+            frame = frame || 0;
+        }
 
         if ((stopAnimation || stopAnimation === undefined) && this.animations)
         {

--- a/src/gameobjects/components/LoadTexture.js
+++ b/src/gameobjects/components/LoadTexture.js
@@ -93,6 +93,15 @@ Phaser.Component.LoadTexture.prototype = {
             this.key = img.key;
             this.setTexture(new PIXI.Texture(img.base));
 
+            if (key === '__default')
+            {
+                this.texture.baseTexture.skipRender = true;
+            }
+            else
+            {
+                this.texture.baseTexture.skipRender = false;
+            }
+
             setFrame = !this.animations.loadFrameData(img.frameData, frame);
         }
         

--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -170,6 +170,8 @@ PIXI.Sprite.prototype.setTexture = function(texture, destroyBase)
         this.texture.baseTexture.destroy();
     }
 
+    //  Over-ridden by loadTexture as needed
+    this.texture.baseTexture.skipRender = false;
     this.texture = texture;
     this.texture.valid = true;
 };

--- a/src/pixi/extras/TilingSprite.js
+++ b/src/pixi/extras/TilingSprite.js
@@ -344,6 +344,8 @@ PIXI.TilingSprite.prototype.generateTilingTexture = function(forcePowerOfTwo, re
     var texture = this.texture;
     var frame = texture.frame;
 
+    console.log('generateTilingTexture', texture, frame);
+
     var targetWidth = this._frame.sourceSizeW;
     var targetHeight = this._frame.sourceSizeH;
 

--- a/src/pixi/renderers/webgl/utils/WebGLSpriteBatch.js
+++ b/src/pixi/renderers/webgl/utils/WebGLSpriteBatch.js
@@ -539,7 +539,14 @@ PIXI.WebGLSpriteBatch.prototype.flush = function()
         blendSwap = currentBlendMode !== nextBlendMode;
         shaderSwap = currentShader !== nextShader; // should I use _UIDS???
 
-        if ((currentBaseTexture !== nextTexture && !nextTexture.skipRender) || blendSwap || shaderSwap)
+        var skip = nextTexture.skipRender;
+
+        if (skip && sprite.children.length > 0)
+        {
+            skip = false;
+        }
+
+        if ((currentBaseTexture !== nextTexture && !skip) || blendSwap || shaderSwap)
         {
             this.renderBatch(currentBaseTexture, batchSize, start);
 

--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -78,6 +78,7 @@ Phaser.TilemapParser = {
     * Parses a CSV file into valid map data.
     *
     * @method Phaser.TilemapParser.parseCSV
+    * @param {string} key - The name you want to give the map data.
     * @param {string} data - The CSV file data.
     * @param {number} [tileWidth=32] - The pixel width of a single map tile. If using CSV data you must specify this. Not required if using Tiled map data.
     * @param {number} [tileHeight=32] - The pixel height of a single map tile. If using CSV data you must specify this. Not required if using Tiled map data.

--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -446,10 +446,10 @@ Phaser.TilemapParser = {
             {
                 var newCollection = new Phaser.ImageCollection(set.name, set.firstgid, set.tilewidth, set.tileheight, set.margin, set.spacing, set.properties);
                 
-                for (var i in set.tiles)
+                for (var ti in set.tiles)
                 {
-                    var image = set.tiles[i].image;
-                    var gid = set.firstgid + parseInt(i, 10);
+                    var image = set.tiles[ti].image;
+                    var gid = set.firstgid + parseInt(ti, 10);
                     newCollection.addImage(gid, image);
                 }
 

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1382,7 +1382,7 @@ declare module Phaser {
         group(parent?: any, name?: string, addToStage?: boolean, enableBody?: boolean, physicsBodyType?: number): Phaser.Group;
         image(x: number, y: number, key?: any, frame?: any): Phaser.Image;
         renderTexture(width?: number, height?: number, key?: any, addToCache?: boolean): Phaser.RenderTexture;
-        retroFont(font: string, characterWidth: number, characterHeight: number, chars: string, charsPerRow: number, xSpacing?: number, ySpacing?: number, xOffset?: number, yOffset?: number): Phaser.RetroFont;
+        retroFont(font: string | Phaser.Image, characterWidth: number, characterHeight: number, chars: string, charsPerRow: number, xSpacing?: number, ySpacing?: number, xOffset?: number, yOffset?: number): Phaser.RetroFont;
         rope(x: number, y: number, key: any, frame?: any, points?: Phaser.Point[]): Phaser.Rope;
         sound(key: string, volume?: number, loop?: boolean, connect?: boolean): Phaser.Sound;
         sprite(x: number, y: number, key?: any, frame?: any): Phaser.Sprite;


### PR DESCRIPTION
Before, when making a new RetroFont, you had to pass in a key that went to the Game.Cache. Now it works with either a string or a Phaser.Image.