### PR TITLE
Allow direct import of Phaser.Image for RetroFont

### DIFF
--- a/src/gameobjects/RetroFont.js
+++ b/src/gameobjects/RetroFont.js
@@ -12,7 +12,7 @@
 * @extends Phaser.RenderTexture
 * @constructor
 * @param {Phaser.Game} game - Current game instance.
-* @param {string} key - The font set graphic set as stored in the Game.Cache.
+* @param {string | Phaser.Image} key - The font set graphic set's key as stored in the Game.Cache, or an image to use for the graphic set.
 * @param {number} characterWidth - The width of each character in the font set.
 * @param {number} characterHeight - The height of each character in the font set.
 * @param {string} chars - The characters used in the font set, in display order. You can use the TEXT_SET consts for common font set arrangements.
@@ -24,14 +24,27 @@
 */
 Phaser.RetroFont = function (game, key, characterWidth, characterHeight, chars, charsPerRow, xSpacing, ySpacing, xOffset, yOffset) {
 
-    if (!game.cache.checkImageKey(key))
+     /**
+    * @property {Image} fontSet - A reference to the image stored in the Game.Cache that contains the font.
+    */
+    this.fontSet = null;
+
+    if(typeof key === Phaser.Image)
+    {
+        this.fontSet = key;
+    }
+    else if (!game.cache.checkImageKey(key))
     {
         return false;
+    }
+    else
+    {
+        this.fontSet = game.cache.getImage(key);
     }
 
     if (charsPerRow === undefined || charsPerRow === null)
     {
-        charsPerRow = game.cache.getImage(key).width / characterWidth;
+        charsPerRow = this.fontSet.width / characterWidth;
     }
 
     /**
@@ -106,11 +119,6 @@ Phaser.RetroFont = function (game, key, characterWidth, characterHeight, chars, 
     * @property {number} fixedWidth
     */
     this.fixedWidth = 0;
-
-    /**
-    * @property {Image} fontSet - A reference to the image stored in the Game.Cache that contains the font.
-    */
-    this.fontSet = game.cache.getImage(key);
 
     /**
     * @property {string} _text - The text of the font image.

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1415,7 +1415,7 @@ declare module Phaser {
         physicsGroup(physicsBodyType: number, parent?: any, name?: string, addToStage?: boolean): Phaser.Group;
         plugin(plugin: Phaser.Plugin, ...parameter: any[]): Phaser.Plugin;
         renderTexture(width?: number, height?: number, key?: string, addToCache?: boolean): Phaser.RenderTexture;
-        retroFont(font: string, characterWidth: number, characterHeight: number, chars: string, charsPerRow: number, xSpacing?: number, ySpacing?: number, xOffset?: number, yOffset?: number): Phaser.RetroFont;
+        retroFont(font: string | Phaser.Image, characterWidth: number, characterHeight: number, chars: string, charsPerRow: number, xSpacing?: number, ySpacing?: number, xOffset?: number, yOffset?: number): Phaser.RetroFont;
         rope(x: number, y: number, key: any, frame?: any, points?: Phaser.Point[]): Phaser.Rope;
         sound(key: string, volume?: number, loop?: boolean, connect?: boolean): Phaser.Sound;
         sprite(x: number, y: number, key?: any, frame?: any, group?: Phaser.Group): Phaser.Sprite;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1382,7 +1382,7 @@ declare module Phaser {
         group(parent?: any, name?: string, addToStage?: boolean, enableBody?: boolean, physicsBodyType?: number): Phaser.Group;
         image(x: number, y: number, key?: any, frame?: any): Phaser.Image;
         renderTexture(width?: number, height?: number, key?: any, addToCache?: boolean): Phaser.RenderTexture;
-        retroFont(font: string, characterWidth: number, characterHeight: number, chars: string, charsPerRow: number, xSpacing?: number, ySpacing?: number, xOffset?: number, yOffset?: number): Phaser.RetroFont;
+        retroFont(font: string | Phaser.Image, characterWidth: number, characterHeight: number, chars: string, charsPerRow: number, xSpacing?: number, ySpacing?: number, xOffset?: number, yOffset?: number): Phaser.RetroFont;
         rope(x: number, y: number, key: any, frame?: any, points?: Phaser.Point[]): Phaser.Rope;
         sound(key: string, volume?: number, loop?: boolean, connect?: boolean): Phaser.Sound;
         sprite(x: number, y: number, key?: any, frame?: any): Phaser.Sprite;


### PR DESCRIPTION
Before, when making a new RetroFont, you had to pass in a key that went to the Game.Cache. Now it works with either a string or a Phaser.Image.

Now with 20% more the right branch!