### PR TITLE
Fix issue #2234: Errors in getAudioURL() and getVideoURL() when using blob: or data: URIs

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -2455,8 +2455,8 @@ Phaser.Loader.prototype = {
 
             if (url.uri) // {uri: .., type: ..} pair
             {
-                url = url.uri;
                 videoType = url.type;
+                url = url.uri;
             }
             else
             {
@@ -2478,7 +2478,7 @@ Phaser.Loader.prototype = {
 
             if (this.game.device.canPlayVideo(videoType))
             {
-                return urls[i];
+                return url;
             }
         }
 
@@ -2510,8 +2510,8 @@ Phaser.Loader.prototype = {
 
             if (url.uri) // {uri: .., type: ..} pair
             {
-                url = url.uri;
                 audioType = url.type;
+                url = url.uri;
             }
             else
             {
@@ -2533,7 +2533,7 @@ Phaser.Loader.prototype = {
 
             if (this.game.device.canPlayAudio(audioType))
             {
-                return urls[i];
+                return url;
             }
         }
 


### PR DESCRIPTION
This PR contains the changes @jackfreak suggested for fixing getAudioURL() and getVideoURL() for blob: and data: URIs in issue #2234.