### PR TITLE
Fixed ScaleManager EXACT_FIT not working

### DIFF
--- a/src/core/ScaleManager.js
+++ b/src/core/ScaleManager.js
@@ -725,7 +725,7 @@ Phaser.ScaleManager.prototype = {
 
         this._booted = true;
 
-        if (this._pendingScaleMode)
+        if (this._pendingScaleMode !== null)
         {
             this.scaleMode = this._pendingScaleMode;
             this._pendingScaleMode = null;
@@ -742,7 +742,7 @@ Phaser.ScaleManager.prototype = {
     */
     parseConfig: function (config) {
 
-        if (config['scaleMode'])
+        if (config['scaleMode'] !== undefined)
         {
             if (this._booted)
             {
@@ -754,7 +754,7 @@ Phaser.ScaleManager.prototype = {
             }
         }
 
-        if (config['fullScreenScaleMode'])
+        if (config['fullScreenScaleMode'] !== undefined)
         {
             this.fullScreenScaleMode = config['fullScreenScaleMode'];
         }


### PR DESCRIPTION
```
var game = new Phaser.Game({
    width:100,
    height:100,
    parent:'gameContainer',
    scaleMode:Phaser.ScaleManager.EXACT_FIT
});
```
this code not working bescause Phaser.ScaleManager.EXACT_FIT is zero.  

```
if (config['scaleMode'] !== undefined)//config['scaleMode'] default value is undefined

if (this._pendingScaleMode !== null) //this._pendingScaleMode default value is null
```
I fixed it by this code. 😄