### PR TITLE
Made Phaser.Text create a new object for this.style

### DIFF
--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -50,7 +50,7 @@ Phaser.Text = function (game, x, y, text, style) {
         text = text.toString();
     }
 
-    style = style || {};
+    style = Phaser.Utils.extend({}, style);
 
     /**
     * @property {number} type - The const type of this object.


### PR DESCRIPTION
... instead of using the same reference for style options object.
This helps when user is using options hierarchies for instantiating game objects.