### PR TITLE
Feature suggestion: Ability to assign keyboard focus to a callback.

### DIFF
--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -53,6 +53,8 @@ Phaser.Keyboard = function (game) {
     */
     this.onPressCallback = null;
 
+    this.keyboardFocusCallback = null;
+
     /**
     * @property {function} onUpCallback - This callback is invoked every time a key is released.
     */
@@ -135,6 +137,26 @@ Phaser.Keyboard.prototype = {
             this.onPressCallback = onPress;
         }
 
+    },
+
+    /**
+     * If you want to have temporary control of all keyboard input.
+     * Useful for text input etc. Make sure to release the focus when no longer needed.
+     */
+    setFocus: function(callback) {
+
+        if (callback != undefined) 
+        {
+            this.keyboardFocusCallback = callback;
+        }
+    },
+
+    /**
+     * Removes the keyboard focus callback. Any input will now be processed normally.
+     */
+    clearFocus: function() {
+
+        this.keyboardFocusCallback = null;
     },
 
     /**
@@ -267,7 +289,6 @@ Phaser.Keyboard.prototype = {
         this._onKeyDown = null;
         this._onKeyUp = null;
         this._onKeyPress = null;
-
     },
 
     /**
@@ -344,6 +365,11 @@ Phaser.Keyboard.prototype = {
     */
     update: function () {
 
+        if(this.keyboardFocusCallback)
+        {
+            return;
+        }
+
         this._i = this._keys.length;
 
         while (this._i--)
@@ -378,6 +404,12 @@ Phaser.Keyboard.prototype = {
             event.preventDefault();
         }
 
+        if (this.keyboardFocusCallback) 
+        {
+            this.keyboardFocusCallback(event);
+            return;
+        }
+
         if (!this._keys[event.keyCode])
         {
             this._keys[event.keyCode] = new Phaser.Key(this.game, event.keyCode);
@@ -410,6 +442,12 @@ Phaser.Keyboard.prototype = {
             return;
         }
 
+        if (this.keyboardFocusCallback) 
+        {
+            this.keyboardFocusCallback(event);
+            return;
+        }
+
         if (this.onPressCallback)
         {
             this.onPressCallback.call(this.callbackContext, String.fromCharCode(event.charCode), event);
@@ -436,6 +474,12 @@ Phaser.Keyboard.prototype = {
         if (this._capture[event.keyCode])
         {
             event.preventDefault();
+        }
+
+        if (this.keyboardFocusCallback)
+        {
+            this.keyboardFocusCallback(event);
+            return;
         }
 
         if (!this._keys[event.keyCode])

--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -145,7 +145,7 @@ Phaser.Keyboard.prototype = {
      */
     setFocus: function(callback) {
 
-        if (callback != undefined) 
+        if (callback !== undefined)
         {
             this.keyboardFocusCallback = callback;
         }
@@ -404,7 +404,7 @@ Phaser.Keyboard.prototype = {
             event.preventDefault();
         }
 
-        if (this.keyboardFocusCallback) 
+        if (this.keyboardFocusCallback)
         {
             this.keyboardFocusCallback(event);
             return;
@@ -442,7 +442,7 @@ Phaser.Keyboard.prototype = {
             return;
         }
 
-        if (this.keyboardFocusCallback) 
+        if (this.keyboardFocusCallback)
         {
             this.keyboardFocusCallback(event);
             return;


### PR DESCRIPTION
This adds the ability to temporary gain keyboard focus, can be useful when you need to ignore other input callbacks, like if you are doing text input.

###### Example:

```
var inputFieldText = '';

game.input.keyboard.setFocus((e) => {
    if (e.type === 'keypress') {
        inputFieldText += String.fromCharCode(e.keyCode);
        console.log(inputFieldText);
    }   
});

//.. Somewhere else
game.input.keyboard.clearFocus();

```