### PR TITLE
Fixes an issue with changing the width/height of a mask. (WEBGL)

### DIFF
--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -295,11 +295,19 @@ Object.defineProperty(PIXI.DisplayObject.prototype, 'mask', {
 
     set: function(value) {
 
-        if (this._mask) this._mask.isMask = false;
+        if (this._mask)
+        {
+            this._mask.isMask = false;
+        }
 
         this._mask = value;
 
-        if (this._mask) this._mask.isMask = true;
+        if (this._mask)
+        {
+            this._mask.isMask = true;
+            // mask needs to be dirty on the first iteration
+            this._mask.dirty = true;
+        }
     }
 
 });

--- a/src/pixi/primitives/Graphics.js
+++ b/src/pixi/primitives/Graphics.js
@@ -828,13 +828,13 @@ PIXI.Graphics.prototype.getBounds = function(matrix)
 {
     if (!this._currentBounds)
     {
-        //  Return an empty object if the item is a mask!
         if (!this.renderable)
         {
             return PIXI.EmptyRectangle;
         }
 
-        if (this.dirty)
+        // If it's a mask dont make it dirty since it crash in maskManager.pushMask()
+        if (!this.isMask && this.dirty)
         {
             this.updateLocalBounds();
             this.webGLDirty = true;


### PR DESCRIPTION
###### Jsfiddle for context:  https://jsfiddle.net/wdghvgkh/4/

If you change the width or height of a graphics mask after its already been assigned to another displayObject PIXI will crash with the following error:  `Uncaught TypeError: Cannot read property 'data' of undefined`. in `PIXI.WebGLMaskManager.prototype.pushMask()`. 

.. Many breakpoints later  - it's apperent that this is caused by the mask mistakenly(?) beeing set to ``not dirty`` by  `PIXI.Graphics.prototype.getBounds()`.

The PR should also solve this issue: https://github.com/photonstorm/phaser/issues/2213
