### PR TITLE
Added removeAll to TweenManager's stub so call from stageManager does…

### DIFF
--- a/src/stubs/TweenManager.js
+++ b/src/stubs/TweenManager.js
@@ -12,5 +12,6 @@
 Phaser.TweenManager = function () {};
 
 Phaser.TweenManager.prototype.update = function () {};
+Phaser.TweenManager.prototype.removeAll = function () {};
 
 Phaser.TweenManager.prototype.constructor = Phaser.TweenManager;


### PR DESCRIPTION
This is a fix to this issue: https://github.com/photonstorm/phaser/issues/2283

I tried to custom build phaser with the following settings:

    grunt custom --exclude tweens,flexgrid,arcade,ninja,p2,particles,creature,video

And phaser would report an error on this line in `StateManager.js`:

    this.game.tweens.removeAll();

This PR adds this method to the stub to avoid the undefined reference error.