### PR TITLE
Fix cache reference bug in web GL context restoration.

### DIFF
--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -1943,9 +1943,9 @@ Phaser.Cache.prototype = {
     */
     clearGLTextures: function () {
 
-        for (var key in this.cache.image)
+        for (var key in this._cache.image)
         {
-            this.cache.image[key].base._glTextures = [];
+            this._cache.image[key].base._glTextures = [];
         }
 
     },


### PR DESCRIPTION
Fixes error being reported in the console when the web GL context is restored in the game. 

![phaser-cleargltextures-bug-console](https://cloud.githubusercontent.com/assets/1807492/12137480/da8f516a-b448-11e5-840f-4f95ae9ea58a.png)

PR fixes cache reference typo.

