### PR TITLE
Update FrameData.js

### DIFF
--- a/src/animation/FrameData.js
+++ b/src/animation/FrameData.js
@@ -230,7 +230,7 @@ Phaser.FrameData.prototype = {
             for (var i = 0; i < frames.length; i++)
             {
                 //  Does the frames array contain names or indexes?
-                if (useNumericIndex)
+                if (useNumericIndex && this._frames[frames[i]])
                 {
                     output.push(this._frames[frames[i]].index);
                 }


### PR DESCRIPTION
"Uncaught TypeError: Cannot read property 'index' of undefined"

The above error occurred, after updating https://github.com/englercj/phaser-tiled to be compatible with Phaser version 2.4.4. The above change fixed this issue!