### PR TITLE
Fixed a bug of tilemap.hasTile 

### DIFF
--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -1219,9 +1219,10 @@ Phaser.Tilemap.prototype = {
     hasTile: function (x, y, layer) {
 
         layer = this.getLayer(layer);
-
+        if (this.layers[layer].data[y] === undefined || this.layers[layer].data[y][x] === undefined) {
+            return false;
+        }
         return (this.layers[layer].data[y][x].index > -1);
-
     },
 
     /**


### PR DESCRIPTION
map.hasTile() bug.
"Uncaught TypeError: Cannot read property '1' of undefined"

false if there is not a tile at the given location. but has error.

```JavaScript
example:

game.physics.startSystem(Phaser.Physics.ARCADE);
map = game.add.tilemap('XXXX');
map.addTilesetImage('YYY', 'ZZZ');

console.log(map.width);              // output: 40
console.log(map.height);             // output: 40

// true
console.log(map.hasTile(0,0));       // output: true
console.log(map.hasTile(1,39));      // output: true
console.log(map.hasTile(39,0));      // output: true
// Error!!
console.log(map.hasTile(1, 40));     // output: Uncaught TypeError: Cannot read property '1' of undefined
```

- https://github.com/photonstorm/phaser/commit/2d4d1a050d6b7cbe3e1dc20bdc1a81a5d981c789