### PR TITLE
Typescript - RandomDataGenerator.sow should accept any[]

### DIFF
--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -20434,7 +20434,7 @@ declare module Phaser {
         * 
         * @param seeds An array of values to use as the seed, or a generator state (from {#state}).
         */
-        constructor(seeds: number[]);
+        constructor(seeds: any[]);
 
 
         /**
@@ -20510,7 +20510,7 @@ declare module Phaser {
         * 
         * @param seeds The array of seeds: the `toString()` of each value is used.
         */
-        sow(seeds: number[]): void;
+        sow(seeds: any[]): void;
 
         /**
         * Returns a random timestamp between min and max, or between the beginning of 2000 and the end of 2020 if min and max aren't specified.

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -3793,7 +3793,6 @@ declare module Phaser {
 
         constructor(seeds: any[]|string);
 
-
         angle(): number;
         between(min: number, max: number): number;
         frac(): number;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -3791,7 +3791,7 @@ declare module Phaser {
 
     class RandomDataGenerator {
 
-        constructor(seeds: number[]);
+        constructor(seeds: any[]);
 
         angle(): number;
         between(min: number, max: number): number;
@@ -3802,7 +3802,7 @@ declare module Phaser {
         pick<T>(ary: T[]): T;
         real(): number;
         realInRange(min: number, max: number): number;
-        sow(seeds: number[]): void;
+        sow(seeds: any[]): void;
         timestamp(min: number, max: number): number;
         uuid(): number;
         weightedPick<T>(ary: T[]): T;


### PR DESCRIPTION
Currently set to number[], but any[] is allowed.