### PR TITLE
Ability to capture all keyboard input and route it to a callback ( Feature Suggestion ) 

### DIFF
--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -211,6 +211,9 @@ Phaser.Keyboard.prototype = {
             return;
         }
 
+        //Avoid setting multiple listeners
+        this.stop();
+
         window.addEventListener('keydown', this._processKeyEvent.bind(this), false);
         window.addEventListener('keyup', this._processKeyEvent.bind(this), false);
         window.addEventListener('keypress', this._processKeyEvent.bind(this), false);

--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -222,8 +222,9 @@ Phaser.Keyboard.prototype = {
 
     /**
     * Keyboard input dispatcher. All key events goes through this function
-    * @param  {[type]} event [description]
-    * @return {[type]}       [description]
+    * @method Phaser.Keyboard#processKeyEvent
+    * @param {KeyboardEvent} event
+    * @protected
     */
     _processKeyEvent: function(event) {
         
@@ -289,19 +290,21 @@ Phaser.Keyboard.prototype = {
     },
 
     /**
-     * Clears the current input redirect callback if any.
-     * @return {[type]} [description]
-     */
+    * Clears the current keyboard capture callback added by setCapture()
+    * @method Phaser.Keyboard#clearCapture
+    */
     clearCapture: function () {
         this.captureKeyboardCallback = null;
     },
 
     /**
-     * Redirects all key events to the given callback function.
-     * Useful when you need to ignore all other input callbacks, i.e when wanting to do text input.
-     * To remove the redirect use clearRedirect()
-     * @param {Function} callback
-     */
+    * Redirects all key events to the given callback function.
+    * Useful when you need to ignore all other input callbacks, i.e when wanting to do text input.
+    * To remove the capture use clearCapture()
+    * 
+    * @method Phaser.Keyboard#setCapture
+    * @param {function} callback
+    */
     setCapture: function (callback) {
 
         if(typeof callback === 'function')

--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -232,14 +232,14 @@ Phaser.Keyboard.prototype = {
         this.event = event;
 
         // If a input redirect callback exists run that istead.
-        if(this.captureKeyboardCallback)
+        if (this.captureKeyboardCallback)
         {
             this.captureKeyboardCallback.call(this.callbackContext,event);
             return;
         }
 
         // Route the event to the correct handler
-        switch(event.type) {
+        switch (event.type) {
             case "keydown":
                 this._processKeyDown(event);
                 break;
@@ -278,7 +278,7 @@ Phaser.Keyboard.prototype = {
 
         this.stop();
 
-        this.clearCaptures();
+        this.clearKeyCaptures();
 
         this._keys.length = 0;
         this._i = 0;
@@ -350,9 +350,9 @@ Phaser.Keyboard.prototype = {
     /**
     * Clear all set key captures.
     *
-    * @method Phaser.Keyboard#clearCaptures
+    * @method Phaser.Keyboard#clearKeyCaptures
     */
-    clearCaptures: function () {
+    clearKeyCaptures: function () {
 
         this._capture = {};
 

--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -232,7 +232,7 @@ Phaser.Keyboard.prototype = {
         this.event = event;
 
         // If a input redirect callback exists run that istead.
-        if(this.captureKeyboardCallback) 
+        if(this.captureKeyboardCallback)
         {
             this.captureKeyboardCallback.call(this.callbackContext,event);
             return;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2139,9 +2139,6 @@ declare module Phaser {
         destroy(): void;
         downDuration(keycode: number, duration?: number): boolean;
         isDown(keycode: number): boolean;
-        processKeyDown(event: KeyboardEvent): void;
-        processKeyPress(event: KeyboardEvent): void;
-        processKeyUp(event: KeyboardEvent): void;
         removeKey(keycode: number): void;
         reset(hard?: boolean): void;
         start(): void;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2128,11 +2128,14 @@ declare module Phaser {
         pressEvent: any;
 
         addCallbacks(context: any, onDown?: Function, onUp?: Function, onPress?: Function): void;
+        setCapture(callback: Function): void;
+        clearCapture(): void;
         addKey(keycode: number): Phaser.Key;
         addKeys(keys: any): any;
         addKeyCapture(keycode: any): void;
+        removeKeyCapture(keycode: number): void;
         createCursorKeys(): Phaser.CursorKeys;
-        clearCaptures(): void;
+        clearKeyCaptures(): void;
         destroy(): void;
         downDuration(keycode: number, duration?: number): boolean;
         isDown(keycode: number): boolean;
@@ -2140,7 +2143,6 @@ declare module Phaser {
         processKeyPress(event: KeyboardEvent): void;
         processKeyUp(event: KeyboardEvent): void;
         removeKey(keycode: number): void;
-        removeKeyCapture(keycode: number): void;
         reset(hard?: boolean): void;
         start(): void;
         stop(): void;


### PR DESCRIPTION
This adds the ability to temporarily route all keyboard input to a callback in a minimally invasive way. ( Usually called keyboard focus in other API's ) Useful when you need to ignore other input callbacks for a while, like if you are doing text input.

Did some minor refactoring on the keyboard class in the process.

**Example usage:**

```
var inputFieldText = '';

game.input.keyboard.setCapture((e) => {
    if (e.type === 'keypress') {
        inputFieldText += String.fromCharCode(e.keyCode);
        console.log(inputFieldText);
    }   
});

//.. Somewhere else ( when you want to remove the capture, and resume with the normal callbacks )
game.input.keyboard.clearCapture();

```
