### PR TITLE
Fix for world.centerX and world.centerY with negative bounds origin.

### DIFF
--- a/src/core/World.js
+++ b/src/core/World.js
@@ -299,7 +299,7 @@ Object.defineProperty(Phaser.World.prototype, "height", {
 Object.defineProperty(Phaser.World.prototype, "centerX", {
 
     get: function () {
-        return this.bounds.halfWidth;
+        return this.bounds.halfWidth + this.bounds.x;
     }
 
 });
@@ -312,7 +312,7 @@ Object.defineProperty(Phaser.World.prototype, "centerX", {
 Object.defineProperty(Phaser.World.prototype, "centerY", {
 
     get: function () {
-        return this.bounds.halfHeight;
+        return this.bounds.halfHeight + this.bounds.y;
     }
 
 });


### PR DESCRIPTION
Phaser.World.centerX and Phaser.World.centerY only worked if the bounds had an origin of 0,0.  This change takes into account the actual origin.