### PR TITLE
Patch for destructive getLocalBounds in PIXI.DisplayObjectContainer

### DIFF
--- a/src/pixi/display/DisplayObjectContainer.js
+++ b/src/pixi/display/DisplayObjectContainer.js
@@ -384,6 +384,11 @@ PIXI.DisplayObjectContainer.prototype.getLocalBounds = function()
     var bounds = this.getBounds();
 
     this.worldTransform = matrixCache;
+	
+    for(var i=0,j=this.children.length; i<j; i++)
+    {
+        this.children[i].updateTransform();
+    }	
 
     return bounds;
 };


### PR DESCRIPTION
PIXI has an open upstream bug regarding getLocalBounds. See https://github.com/pixijs/pixi.js/issues/1698.

getLocalBounds destroys the worldTransforms on children until the next stage.updateTransform() call in Phaser.Game. This can make a number of things break including mouse input if width,height, or getLocalBounds methods are called inside of an update or preUpdate method.

Because Phaser uses a modified version of PIXI, I'm proposing to directly patch the issue here.