### PR TITLE
AudioBufferSourceNode - same issue as on play:

### DIFF
--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -770,7 +770,7 @@ Phaser.Sound.prototype = {
         {
             if (this.usingWebAudio)
             {
-                var p = this.position + (this.pausedPosition / 1000);
+                var p = Math.max(0, this.position + (this.pausedPosition / 1000));
 
                 this._sound = this.context.createBufferSource();
                 this._sound.buffer = this._buffer;


### PR DESCRIPTION
I was able to reproduce this rare occurrence. It gets triggered by me in some cases when leaving focus and then resuming the sound. Same as we have had it for the play function, see => https://github.com/photonstorm/phaser/issues/2351

Cheers