### PR TITLE
Fix tinting issue when loading textures

### DIFF
--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -174,6 +174,7 @@ PIXI.Sprite.prototype.setTexture = function(texture, destroyBase)
     this.texture.baseTexture.skipRender = false;
     this.texture = texture;
     this.texture.valid = true;
+    this.cachedTint = -1;
 };
 
 /**


### PR DESCRIPTION
Previously when a sprite was tinted and a new texture was loaded then the tint did not apply to the texture and the old tinted texture was used. This change fixes the issue by resetting the cached tint upon texture loading.

Here is an example that failed:
```js
var mysprite = game.add.sprite(1, 2, 'texturea');
mysprite.tint = 0xff00ff;
```

Later:
```js
mysprite.loadTexture('textureb');
```
Now the tint was not applied to the new texture and the old tinted texture was used for rendering.
