### PR TITLE
Negative lineSpacing shouldn't crop text

### DIFF
--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -439,7 +439,8 @@ Phaser.Text.prototype.updateText = function () {
     //  Adjust for line spacing
     if (lineSpacing !== 0)
     {
-        height += lineSpacing * lines.length;
+        var diff = lineSpacing > 0 ? lineSpacing * lines.length : lineSpacing * (lines.length - 1);
+        height += diff;
     }
 
     this.canvas.height = height * this._res;


### PR DESCRIPTION
2.4.6 introduced a change to the way line height is calculated. This caused negative lineSpacing to have cropped text. I added a conditional to handle negative line spacing while still honoring the new calculation for positive lineSpacing. I reported the issue as https://github.com/photonstorm/phaser/issues/2374.

Example of bug:
![43783efe-e16b-11e5-9d59-afa492a26488](https://cloud.githubusercontent.com/assets/325937/13579461/b256a394-e46b-11e5-86da-7cee613fef7f.png)

Example code: 
[cropped-text.zip](https://github.com/photonstorm/phaser/files/161894/cropped-text.zip)
