### PR TITLE
Fix typo in componentToHex

### DIFF
--- a/src/physics/p2/BodyDebug.js
+++ b/src/physics/p2/BodyDebug.js
@@ -458,7 +458,7 @@ Phaser.Utils.extend(Phaser.Physics.P2.BodyDebug.prototype, {
         var hex;
         hex = c.toString(16);
 
-        if (hex.len === 2)
+        if (hex.length === 2)
         {
             return hex;
         }


### PR DESCRIPTION
Its always bothered me that the debug bodies were consistently red even though the method that generates their color is called `randomPastelHex`. I finally realized why, and it was pretty funny.

This should probably be removed completely and use the Phaser.Color utilities though.

Note: due to the calculation for generating the color, they are mostly whitish after this change.