### PR TITLE
Check for sprite destruction after onInputDown event.

### DIFF
--- a/src/input/InputHandler.js
+++ b/src/input/InputHandler.js
@@ -957,6 +957,11 @@ Phaser.InputHandler.prototype = {
             if (this.sprite && this.sprite.events)
             {
                 this.sprite.events.onInputDown$dispatch(this.sprite, pointer);
+                //  The onInputDown event might have destroyed this sprite.
+                if (this.sprite === null)
+                {
+                    return;
+                }
             }
 
             //  It's possible the onInputDown event created a new Sprite that is on-top of this one, so we ought to force a Pointer update


### PR DESCRIPTION
This sprite might have been destroyed during the onInputDown event. Check for this before continuing.

I ran into this issue after using the onInputDown event to destroy a sprite that had drag enabled.
startDrag does not check to see if the sprite has been destroyed. I feel like this is the best location to do the check because it will also prevent potentially calling bringToTop on a null object. (Line 978 in the new commit)