### PR TITLE
Ensure a parent container is a Group before removing from its hash.

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -289,7 +289,7 @@ Phaser.Group.prototype.add = function (child, silent) {
 
     if (child.parent !== this)
     {
-        if (child.body && child.parent)
+        if (child.body && child.parent && child.parent.hash)
         {
             child.parent.removeFromHash(child);
         }


### PR DESCRIPTION
Hi. I found an issue when (ab)using sprites as containers.

Basically, placing sprites inside another one gives the impression of depth. I've been trying this concept for a while, making a 'platformer' where the player uses an escalator to go to another floor inside a building, the steps make the base layer, the handrail is above and the player character is placed "between" these.

The problem happens when adding the sprite to another group, effectively removing it from inside the sprite, raising the exception. Adding a check to confirm the container has an `#hash` avoids the issue.
