### PR TITLE
Remove encoding metadata from Tiled json if data has already had its …

### DIFF
--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -13,7 +13,7 @@
 Phaser.TilemapParser = {
 
     /**
-     * When scanning the Tiled map data the TilemapParser can either insert a null value (true) or 
+     * When scanning the Tiled map data the TilemapParser can either insert a null value (true) or
      * a Phaser.Tile instance with an index of -1 (false, the default). Depending on your game type
      * depends how this should be configured. If you've a large sparsely populated map and the tile
      * data doesn't need to change then setting this value to `true` will help with memory consumption.
@@ -233,15 +233,15 @@ Phaser.TilemapParser = {
             }
 
             var curl = json.layers[i];
-            
+
             // Base64 decode data if necessary
-            // NOTE: uncompressed base64 only. 
+            // NOTE: uncompressed base64 only.
             if (!curl.compression && curl.encoding && curl.encoding === "base64") {
                 var binaryString =  window.atob(curl.data);
                 var len = binaryString.length;
                 var bytes = new Array( len );
                 // Interpret binaryString as an array of bytes representing
-                // little-endian encoded uint32 values. 
+                // little-endian encoded uint32 values.
                 for (var j = 0; j < len; j+=4) {
                     bytes[j/4] = (binaryString.charCodeAt(j) |
                                  binaryString.charCodeAt(j+1) << 8 |
@@ -249,6 +249,7 @@ Phaser.TilemapParser = {
                                  binaryString.charCodeAt(j+3) << 24) >>> 0;
                 }
                 curl.data = bytes;
+                delete curl.encoding;
             }
 
 
@@ -292,7 +293,7 @@ Phaser.TilemapParser = {
                 flipped = false;
                 gid = curl.data[t];
 
-                //  If true the current tile is flipped or rotated (Tiled TMX format) 
+                //  If true the current tile is flipped or rotated (Tiled TMX format)
                 if (gid > 0x20000000)
                 {
                     flippedVal = 0;
@@ -317,7 +318,7 @@ Phaser.TilemapParser = {
                         gid -= 0x20000000;
                         flippedVal += 1;
                     }
-                   
+
                     switch (flippedVal)
                     {
                         case 5:
@@ -446,7 +447,7 @@ Phaser.TilemapParser = {
             else
             {
                 var newCollection = new Phaser.ImageCollection(set.name, set.firstgid, set.tilewidth, set.tileheight, set.margin, set.spacing, set.properties);
-                
+
                 for (var ti in set.tiles)
                 {
                     var image = set.tiles[ti].image;


### PR DESCRIPTION
The parser updates the json passed into it to remove the base64 encoding.  I'm unsure if this is a good idea or not, but given that that's what it's already doing it should remove the encoding parameter so that a subsequent process doesn't try to decode the data again.  

If preferred I could rewrite it to use a local variable and leave the passed in layer data as it is, but of course this has more potential to conflict with existing code.  

The new line 252 is the only substantive change, everything else is from the whitespace removal due to the .editorconfig