### PR TITLE
Alter BitmapText to use toString on text parameter in constructor

### DIFF
--- a/src/gameobjects/BitmapText.js
+++ b/src/gameobjects/BitmapText.js
@@ -113,7 +113,7 @@ Phaser.BitmapText = function (game, x, y, font, text, size, align) {
     * @property {string} _text - Internal cache var.
     * @private
     */
-    this._text = text;
+    this._text = text.toString() || '';
 
     /**
     * @property {string} _data - Internal cache var.


### PR DESCRIPTION
The BitmapText property accessor for the text property uses toString on the value passed in, meaning Numbers can be passed in as the text value with no problem. However, passing a Number into the constructor results in the following exception as it isn't implicitly converted to a string in a similar manner.

```
phaser.js:71890 TypeError: text.substr is not a function
    at Phaser.BitmapText.updateText (http://localhost/phaser/build/phaser.js:56283:21)
    at new Phaser.BitmapText (http://localhost/phaser/build/phaser.js:56034:10)
    at Phaser.GameObjectFactory.bitmapText (http://localhost/phaser/build/phaser.js:46318:26)
    at Object.Boot.create (http://localhost/phaser/:46:34)
    at Phaser.StateManager.loadComplete (http://localhost/phaser/build/phaser.js:29240:35)
    at Phaser.Loader.finishedLoading (http://localhost/phaser/build/phaser.js:71446:25)
    at Phaser.Loader.processLoadQueue (http://localhost/phaser/build/phaser.js:71403:18)
    at Phaser.Loader.asyncComplete (http://localhost/phaser/build/phaser.js:71476:14)
    at Phaser.Loader.xmlLoadComplete (http://localhost/phaser/build/phaser.js:72413:14)
    at .<anonymous> (http://localhost/phaser/build/phaser.js:72236:34)
```

This simply mimics the logic in the property accessor by running toString on the text value and using an empty string if null to allow Numbers to be passed into the constructor.