### PR TITLE
Allow debug.line to be used without error TS2346

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -5391,7 +5391,7 @@ declare module Phaser {
             inputInfo(x: number, y: number, color?: string): void;
             lineInfo(line: Phaser.Line, x: number, y: number, color?: string): void;
             key(key: Phaser.Key, x?: number, y?: number, color?: string): void;
-            line(): void;
+            line(...args: string[]): void;
             preUpdate(): void;
             pixel(x: number, y: number, color?: string, size?: number): void;
             pointer(pointer: Phaser.Pointer, hideIfUp?: boolean, downColor?: string, upColor?: string, color?: string): void;


### PR DESCRIPTION
When calling debug.line('Any string'); the TypeScript compiler give error TS2346 because there are no parameters in the method definition. This creates a dummy parameter which allows the same functionality without the compiler error.