### PR TITLE
Gamepad problems in Google Chrome

### DIFF
--- a/src/input/Gamepad.js
+++ b/src/input/Gamepad.js
@@ -252,6 +252,11 @@ Phaser.Gamepad.prototype = {
     */
     _pollGamepads: function () {
 
+        if (!this._active)
+        {
+            return;
+        }
+
         if (navigator['getGamepads'])
         {
             var rawGamepads = navigator.getGamepads();
@@ -289,6 +294,11 @@ Phaser.Gamepad.prototype = {
                 {
                     break;
                 }
+            }
+
+            for (var g = 0; g < this._gamepads.length; g++)
+            {
+                this._gamepads[g]._rawPad = this._rawPads[g];
             }
 
             if (gamepadsChanged)


### PR DESCRIPTION
This PR changes

* Nothing, it's a bug fix

Describe the changes below:

When using the Gamepad API in Google Chrome, the onConnect callback for a gampad was not always being called. This would prevent setup of buttons, etc. This behavior is evident even on the [Phaser Gamepad Input example](http://phaser.io/examples/v2/input/gamepad-buttons). I tracked this down to a race condition where `Gamepad._pollGamepads` was finding gamepads before the game code could add the callback - resulting in the callback sometimes being added too late to ever fire. In my case, I had a lot of code executing before attempting the gamepad setup which pretty much guaranteed that mine was NEVER being called. The code in the Phaser example was working more often than it failed, but would still fail sometimes. To correct this, I added a check to the `Gamepad._pollGamepads` function which will immediately return if _active is false. This means that until `game.input.gamepad.start()` is explicitly called, no attempt will be made to setup the gamepads discovered in the browser. To ensure that the gamepad's onConnect event handler will always be called, one must only add the callback to the SinglePad object before calling `game.input.gamepad.start()`. For example,

    var controller = game.input.gamepad.pad1;
    controller.addCallbacks(this, {
        onConnect: someFunction 
    });
    game.input.gamepad.start();

The other problem was that the game seemed to lose the gamepad after the focus is lost to the browser window or tab. Again, this was evident not only in my game but also in the [Phaser example](http://phaser.io/examples/v2/input/gamepad-buttons). In this case I tracked the issue to the `SinglePad_rawPad` object pointing to a defunct raw gamepad object. The `timestamp` field on this object would not update despite new input, leading me to conclude that this object was no longer correct as far as the browser was concerned. Checking `game.input.gamepad._gamepads[0]._rawPad === navigator.getGamepads()[0]` proved to be `false` in these cases. The code in `Gamepad._pollGamepads` seemed to account for this by resetting the `_rawPads` array on every update, but these changes were not being flowed down to the SinglePad objects. To correct this, I added the following code to `_pollGamepads`:

    for (var g = 0; g < this._gamepads.length; g++)
    {
        this._gamepads[g]._rawPad = this._rawPads[g];
    }

which ensures that the `_rawPad` object on each SinglePad will always be a valid raw object.

Because both changes were in code specific to Google Chrome, I found no adverse effects when using Firefox after making these changes.