### PR TITLE
BitmapData.generatetexture fix for Safari

### DIFF
--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -525,17 +525,14 @@ Phaser.BitmapData.prototype = {
     * @param {string} key - The key which will be used to store the image in the Cache.
     * @return {PIXI.Texture} The newly generated texture.
     */
-    generateTexture: function (key) {
+    generateTexture: function(key) {
+        var copyCanvas = PIXI.CanvasPool.create(this, this.ctx.width, this.ctx.height);
+        var copyContext = newCanvas.getContext('2d', { alpha: true });
+        var imageData = this.ctx.getImageData(0, 0, width, height);
+        copyContext.putImageData(imageData, 0, 0);
 
-        var image = new Image();
-
-        image.src = this.canvas.toDataURL("image/png");
-
-        var obj = this.game.cache.addImage(key, '', image);
-
-        return new PIXI.Texture(obj.base);
-
-    },
+        return PIXI.Texture.fromCanvas(copyCanvas);
+    }
 
     /**
     * Resizes the BitmapData. This changes the size of the underlying canvas and refreshes the buffer.

--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -526,13 +526,16 @@ Phaser.BitmapData.prototype = {
     * @return {PIXI.Texture} The newly generated texture.
     */
     generateTexture: function(key) {
-        var copyCanvas = PIXI.CanvasPool.create(this, this.ctx.width, this.ctx.height);
-        var copyContext = newCanvas.getContext('2d', { alpha: true });
-        var imageData = this.ctx.getImageData(0, 0, width, height);
+        var copyCanvas = PIXI.CanvasPool.create(this, this.width, this.height);
+
+        var copyContext = copyCanvas.getContext('2d', { alpha: true });
+
+        var imageData = this.ctx.getImageData(0, 0, this.width, this.height);
+
         copyContext.putImageData(imageData, 0, 0);
 
         return PIXI.Texture.fromCanvas(copyCanvas);
-    }
+    },
 
     /**
     * Resizes the BitmapData. This changes the size of the underlying canvas and refreshes the buffer.


### PR DESCRIPTION
**Important:** Pull Requests should _only_ be issued against the `dev` branch. PRs against the master branch will always be closed.

This PR changes (delete as applicable)
- Nothing, it's a bug fix

Describe the changes below:

This fixes a bug with BitmapData.generateTexture seen in Safari on both desktop and mobile.
http://www.html5gamedevs.com/topic/20258-bitmapdatageneratetexture-doesnt-work-first-time-in-safari/
