### PR TITLE
updateText after setStyle

### DIFF
--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -342,6 +342,11 @@ Phaser.Text.prototype.setStyle = function (style) {
 
     this.style = style;
     this.dirty = true;
+    
+    if (text !== '')
+    {
+        this.updateText();
+    }
 
     return this;
 

--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -343,7 +343,7 @@ Phaser.Text.prototype.setStyle = function (style) {
     this.style = style;
     this.dirty = true;
     
-    if (text !== '')
+    if (this._text !== '')
     {
         this.updateText();
     }


### PR DESCRIPTION
This PR changes

* Nothing, it's a bug fix

Describe the changes below:

Not tested, however I think it would solve the following;

```javascript
var text = this.game.add.text(0, 0, "my text is here");
console.log(text.width); // w1
text.setStyle("Arial 100px");
console.log(text.width); // w2
```

In the above, `w1 == w2` where in fact it should be `w1 < w2`.  Looking at the docs, `updateText()` is considered private.  If it wasn't private, a work around (for typescript) could be to include the `updateText()` in the typescript defs and call it manually after `text.setStyle`.

In fact, in typescript, I am currently using `(<any>text).updateText()` to manually call this.
