### PR TITLE
typescript/pixi.d.ts: Add `padding` to Graphics.generateTexture

### DIFF
--- a/typescript/pixi.d.ts
+++ b/typescript/pixi.d.ts
@@ -635,7 +635,7 @@ declare module PIXI {
         drawShape(shape: Ellipse): GraphicsData;
         drawShape(shape: Polygon): GraphicsData;
         endFill(): Graphics;
-        generateTexture(resolution?: number, scaleMode?: number): Texture;
+        generateTexture(resolution?: number, scaleMode?: number, padding?: number): Texture;
         lineStyle(lineWidth?: number, color?: number, alpha?: number): Graphics;
         lineTo(x: number, y: number): Graphics;
         moveTo(x: number, y: number): Graphics;


### PR DESCRIPTION
This PR changes (delete as applicable)

* TypeScript Defs

Describe the changes below:

This patch fix an error message below

```
node_modules/phaser/typescript/pixi.d.ts(605,18): error TS2415: Class 'Graphics' incorrectly extends base class 'DisplayObjectContainer'.
  Types of property 'generateTexture' are incompatible.
    Type '(resolution?: number, scaleMode?: number) => Texture' is not assignable to type '(resolution?: number, scaleMode?: number, renderer?: PixiRenderer) => RenderTexture'.
      Type 'Texture' is not assignable to type 'RenderTexture'.
        Property 'renderer' is missing in type 'Texture'.
```

It's happen because method `generateTexture` in class `PIXI.Graphics` has argument `padding` but TypeScript not.