### PR TITLE
bugfix, in Class Graphics, the method generateTexture should return t…

### DIFF
--- a/typescript/pixi.d.ts
+++ b/typescript/pixi.d.ts
@@ -637,7 +637,7 @@ declare module PIXI {
         drawShape(shape: Ellipse): GraphicsData;
         drawShape(shape: Polygon): GraphicsData;
         endFill(): Graphics;
-        generateTexture(resolution?: number, scaleMode?: number, padding?: number): Texture;
+        generateTexture(resolution?: number, scaleMode?: number, padding?: number): RenderTexture;
         lineStyle(lineWidth?: number, color?: number, alpha?: number): Graphics;
         lineTo(x: number, y: number): Graphics;
         moveTo(x: number, y: number): Graphics;


### PR DESCRIPTION
**Important:** Pull Requests should _only_ be issued against the `dev` branch. PRs against the master branch will always be closed.

This PR changes (delete as applicable)

* Documentation
* TypeScript Defs
* The public-facing API
* Nothing, it's a bug fix

Describe the changes below:


…ype RenderTexture, but not current Texture. When use typescript to compile, there is a Error:  Type 'Texture' is not assignable to type 'RenderTexture'.