### PR TITLE
Fixing tileMap collision when tileMapLayer is set to a position other than 0,0

### DIFF
--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -374,14 +374,14 @@ Phaser.TilemapLayer.prototype.resizeWorld = function () {
 */
 Phaser.TilemapLayer.prototype._fixX = function (x) {
 
-    if (x < 0)
-    {
-        x = 0;
-    }
-
-    if (this.scrollFactorX === 1)
+    if (this.scrollFactorX === 1 || (this.scrollFactorX === 0 && this.position.x === 0))
     {
         return x;
+    }
+    
+    //This executes if the scrollFactorX is 0 and the x position of the tilemap is off from standard.
+    if(this.scrollFactorX === 0 && this.position.x !== 0) {
+        return x - this.position.x;
     }
 
     return this._scrollX + (x - (this._scrollX / this.scrollFactorX));
@@ -417,16 +417,17 @@ Phaser.TilemapLayer.prototype._unfixX = function (x) {
 */
 Phaser.TilemapLayer.prototype._fixY = function (y) {
 
-    if (y < 0)
-    {
-        y = 0;
-    }
-
-    if (this.scrollFactorY === 1)
+    if (this.scrollFactorY === 1 || (this.scrollFactorY === 0 && this.position.y === 0))
     {
         return y;
     }
-
+    
+    //This executes if the scrollFactorY is 0 and the y position of the tilemap is off from standard.
+    if(this.scrollFactorY === 0 && this.position.y !== 0) 
+    {
+        return y - this.position.y
+    }
+    
     return this._scrollY + (y - (this._scrollY / this.scrollFactorY));
 
 };


### PR DESCRIPTION
**Important:** Pull Requests should _only_ be issued against the `dev` branch. PRs against the master branch will always be closed.

This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Because the tileMapLayer position is not accounted for in the tileMap collision check, collision fails as it expects the tileMapLayer to have a default position of 0,0 with regards to fixedToCamera being set to false.

The benefit of this fix is apparent when creating near infinite (well until you get an arithmetic overflow in regards to position calculations...) tileMap worlds by stitching multiple tileMapLayer's together, and in order to achieve that you would need to set the position of that tileMapLayer to something other than 0,0.