### PR TITLE
Don't extend Phaser.Utils when doing deep copy in Phaser.Cache.getJSON.

### DIFF
--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -454,10 +454,10 @@ Phaser.Cache.prototype = {
             font: null,
             base: new PIXI.BaseTexture(data)
         };
-        
+
         if (xSpacing === undefined) { xSpacing = 0; }
         if (ySpacing === undefined) { ySpacing = 0; }
-        
+
         if (atlasType === 'json')
         {
             obj.font = Phaser.LoaderParser.jsonBitmapFont(atlasData, obj.base, xSpacing, ySpacing);
@@ -1312,7 +1312,7 @@ Phaser.Cache.prototype = {
         {
             if (clone)
             {
-                return Phaser.Utils.extend(true, data);
+                return Phaser.Utils.extend(true, {}, data);
             }
             else
             {


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Fixes #2524. Tested with build locally and code from this fiddle: https://jsfiddle.net/1ypcnre5/ Fixed that guy's issue, don't know if anything else was expecting/relying on this behavior.