### PR TITLE
Set isPlaying to true if no marker (.play is not called again)

### DIFF
--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -451,6 +451,7 @@ Phaser.Sound.prototype = {
                         {
                             this.currentTime = 0;
                             this.startTime = this.game.time.time;
+                            this.isPlaying = true; // play not called again in this case
                         }
                         else
                         {


### PR DESCRIPTION
**Important:** Pull Requests should _only_ be issued against the `dev` branch. PRs against the master branch will always be closed.

This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Sound.isPlaying was set to false when doing an audio loop, but never set back to true if it's a sound not using a marker.



