### PR TITLE
Fix Phaser.Rectangle.aabb()

### DIFF
--- a/src/geom/Rectangle.js
+++ b/src/geom/Rectangle.js
@@ -975,10 +975,10 @@ Phaser.Rectangle.aabb = function(points, out) {
         out = new Phaser.Rectangle();
     }
 
-    var xMax = Number.MIN_VALUE,
-        xMin = Number.MAX_VALUE,
-        yMax = Number.MIN_VALUE,
-        yMin = Number.MAX_VALUE;
+    var xMax = Number.NEGATIVE_INFINITY,
+        xMin = Number.POSITIVE_INFINITY,
+        yMax = Number.NEGATIVE_INFINITY,
+        yMin = Number.POSITIVE_INFINITY;
 
     points.forEach(function(point) {
         if (point.x > xMax) {


### PR DESCRIPTION
**Important:** Pull Requests should _only_ be issued against the `dev` branch. PRs against the master branch will always be closed.

This PR changes (delete as applicable)
* Nothing, it's a bug fix

Describe the changes below:

Number.MIN_VALUE does not give the most negative number, rather it gives you the smallest number above 0 that JS is capable of representing.  As a result, this aabb function failed with negative points.