### PR TITLE
Pass the keyboard event to getKeyCode. Fixes #2549.

### DIFF
--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -363,7 +363,7 @@ Phaser.Keyboard.prototype = {
     /**
     * Normalises the keyCode value from the browser and returns it.
     *
-    * This is based on browser support. It first checks for `event.key`, then `event.keyIdentifier` 
+    * This is based on browser support. It first checks for `event.key`, then `event.keyIdentifier`
     * and finally `event.keyCode`
     *
     * @method Phaser.Keyboard#getKeyCode
@@ -407,7 +407,7 @@ Phaser.Keyboard.prototype = {
             return;
         }
 
-        var key = this.getKeyCode();
+        var key = this.getKeyCode(event);
 
         //   The event is being captured but another hotkey may need it
         if (this._capture[key])
@@ -470,7 +470,7 @@ Phaser.Keyboard.prototype = {
             return;
         }
 
-        var key = this.getKeyCode();
+        var key = this.getKeyCode(event);
 
         if (this._capture[key])
         {
@@ -518,7 +518,7 @@ Phaser.Keyboard.prototype = {
     /**
     * Returns `true` if the Key was pressed down within the `duration` value given, or `false` if it either isn't down,
     * or was pressed down longer ago than then given duration.
-    * 
+    *
     * @method Phaser.Keyboard#downDuration
     * @param {integer} keycode - The {@link Phaser.KeyCode keycode} of the key to check: i.e. Phaser.KeyCode.UP or Phaser.KeyCode.SPACEBAR.
     * @param {number} [duration=50] - The duration within which the key is considered as being just pressed. Given in ms.
@@ -540,7 +540,7 @@ Phaser.Keyboard.prototype = {
     /**
     * Returns `true` if the Key was pressed down within the `duration` value given, or `false` if it either isn't down,
     * or was pressed down longer ago than then given duration.
-    * 
+    *
     * @method Phaser.Keyboard#upDuration
     * @param {Phaser.KeyCode|integer} keycode - The keycode of the key to check, i.e. Phaser.KeyCode.UP or Phaser.KeyCode.SPACEBAR.
     * @param {number} [duration=50] - The duration within which the key is considered as being just released. Given in ms.


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Weren't passing the `event` object to `getKeyCode` in `processKeyDown` and `processKeyUp`.
