### PR TITLE
Distinguish between Arrays and Objects when cloning in Cache.getJSON.

### DIFF
--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -1312,7 +1312,8 @@ Phaser.Cache.prototype = {
         {
             if (clone)
             {
-                return Phaser.Utils.extend(true, {}, data);
+                var base = Array.isArray(data) ? [] : {};
+                return Phaser.Utils.extend(true, base, data);
             }
             else
             {


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Phaser.Utils.extend should be passed an Array if what we're cloning is an array, and should be passed an object otherwise. This clears up the test case mentioned here: http://www.html5gamedevs.com/topic/22910-getjson-clone/

Fixes #2551.