### PR TITLE
1. Non-hierarchical propagation for Phaser.Pointer

### DIFF
--- a/src/gameobjects/components/Events.js
+++ b/src/gameobjects/components/Events.js
@@ -6,7 +6,7 @@
 
 /**
 * The Events component is a collection of events fired by the parent Game Object.
-* 
+*
 * Phaser uses what are known as 'Signals' for all event handling. All of the events in
 * this class are signals you can subscribe to, much in the same way you'd "listen" for
 * an event.
@@ -17,7 +17,7 @@
 * `sprite.events.onAddedToGroup.add(yourFunction, this);`
 *
 * Where `yourFunction` is the function you want called when this event occurs.
-* 
+*
 * For more details about how signals work please see the Phaser.Signal class.
 *
 * The Input-related events will only be dispatched if the Sprite has had `inputEnabled` set to `true`
@@ -59,6 +59,7 @@ Phaser.Events.prototype = {
         if (this._onOutOfBounds)       { this._onOutOfBounds.dispose(); }
 
         if (this._onInputOver)         { this._onInputOver.dispose(); }
+        if (this._onInputUpdate)       { this._onInputUpdate.dispose(); }
         if (this._onInputOut)          { this._onInputOut.dispose(); }
         if (this._onInputDown)         { this._onInputDown.dispose(); }
         if (this._onInputUp)           { this._onInputUp.dispose(); }
@@ -146,7 +147,7 @@ Phaser.Events.prototype = {
     onEnterBounds: null,
 
     /**
-    * This signal is dispatched if the Game Object has `inputEnabled` set to `true`, 
+    * This signal is dispatched if the Game Object has `inputEnabled` set to `true`,
     * and receives an over event from a Phaser.Pointer.
     * It is sent two arguments:
     * {any} The Game Object that received the event.
@@ -156,7 +157,13 @@ Phaser.Events.prototype = {
     onInputOver: null,
 
     /**
-    * This signal is dispatched if the Game Object has `inputEnabled` set to `true`, 
+    * @property {Phaser.Signal} onInputUpdate - This signal is dispatched if the parent is inputEnabled and a pointer is moved within it.
+    */
+    onInputUpdate: null,
+
+    /**
+    * @property {Phaser.Signal} onInputOut - This signal is dispatched if the parent is inputEnabled and receives an out event from a Pointer.
+    * This signal is dispatched if the Game Object has `inputEnabled` set to `true`,
     * and receives an out event from a Phaser.Pointer, which was previously over it.
     * It is sent two arguments:
     * {any} The Game Object that received the event.
@@ -166,7 +173,7 @@ Phaser.Events.prototype = {
     onInputOut: null,
 
     /**
-    * This signal is dispatched if the Game Object has `inputEnabled` set to `true`, 
+    * This signal is dispatched if the Game Object has `inputEnabled` set to `true`,
     * and receives a down event from a Phaser.Pointer. This effectively means the Pointer has been
     * pressed down (but not yet released) on the Game Object.
     * It is sent two arguments:
@@ -177,7 +184,7 @@ Phaser.Events.prototype = {
     onInputDown: null,
 
     /**
-    * This signal is dispatched if the Game Object has `inputEnabled` set to `true`, 
+    * This signal is dispatched if the Game Object has `inputEnabled` set to `true`,
     * and receives an up event from a Phaser.Pointer. This effectively means the Pointer had been
     * pressed down, and was then released on the Game Object.
     * It is sent three arguments:
@@ -227,7 +234,7 @@ Phaser.Events.prototype = {
     onDragStop: null,
 
     /**
-    * This signal is dispatched if the Game Object has the AnimationManager component, 
+    * This signal is dispatched if the Game Object has the AnimationManager component,
     * and an Animation has been played.
     * You can also listen to `Animation.onStart` rather than via the Game Objects events.
     * It is sent two arguments:
@@ -238,7 +245,7 @@ Phaser.Events.prototype = {
     onAnimationStart: null,
 
     /**
-    * This signal is dispatched if the Game Object has the AnimationManager component, 
+    * This signal is dispatched if the Game Object has the AnimationManager component,
     * and an Animation has been stopped (via `animation.stop()` and the `dispatchComplete` argument has been set.
     * You can also listen to `Animation.onComplete` rather than via the Game Objects events.
     * It is sent two arguments:
@@ -249,7 +256,7 @@ Phaser.Events.prototype = {
     onAnimationComplete: null,
 
     /**
-    * This signal is dispatched if the Game Object has the AnimationManager component, 
+    * This signal is dispatched if the Game Object has the AnimationManager component,
     * and an Animation has looped playback.
     * You can also listen to `Animation.onLoop` rather than via the Game Objects events.
     * It is sent two arguments:

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -215,66 +215,66 @@ Phaser.Input = function (game) {
 
     /**
     * The most recently active Pointer object.
-    * 
+    *
     * When you've limited max pointers to 1 this will accurately be either the first finger touched or mouse.
-    * 
+    *
     * @property {Phaser.Pointer} activePointer
     */
     this.activePointer = null;
 
     /**
     * The mouse has its own unique Phaser.Pointer object which you can use if making a desktop specific game.
-    * 
+    *
     * @property {Pointer} mousePointer
     */
     this.mousePointer = null;
 
     /**
     * The Mouse Input manager.
-    * 
-    * You should not usually access this manager directly, but instead use Input.mousePointer or Input.activePointer 
+    *
+    * You should not usually access this manager directly, but instead use Input.mousePointer or Input.activePointer
     * which normalizes all the input values for you, regardless of browser.
-    * 
+    *
     * @property {Phaser.Mouse} mouse
     */
     this.mouse = null;
 
     /**
     * The Keyboard Input manager.
-    * 
+    *
     * @property {Phaser.Keyboard} keyboard
     */
     this.keyboard = null;
 
     /**
     * The Touch Input manager.
-    * 
-    * You should not usually access this manager directly, but instead use Input.activePointer 
+    *
+    * You should not usually access this manager directly, but instead use Input.activePointer
     * which normalizes all the input values for you, regardless of browser.
-    * 
+    *
     * @property {Phaser.Touch} touch
     */
     this.touch = null;
 
     /**
     * The MSPointer Input manager.
-    * 
-    * You should not usually access this manager directly, but instead use Input.activePointer 
+    *
+    * You should not usually access this manager directly, but instead use Input.activePointer
     * which normalizes all the input values for you, regardless of browser.
-    * 
+    *
     * @property {Phaser.MSPointer} mspointer
     */
     this.mspointer = null;
 
     /**
     * The Gamepad Input manager.
-    * 
+    *
     * @property {Phaser.Gamepad} gamepad
     */
     this.gamepad = null;
 
     /**
-    * If the Input Manager has been reset locked then all calls made to InputManager.reset, 
+    * If the Input Manager has been reset locked then all calls made to InputManager.reset,
     * such as from a State change, are ignored.
     * @property {boolean} resetLocked
     * @default
@@ -480,14 +480,9 @@ Phaser.Input.prototype = {
     * for input and overlap with the Pointer. If you need fine-grained control over which of the items is
     * selected then you can use this callback to do so.
     *
-    * The callback will be sent 3 parameters:
-    * 
-    * 1) A reference to the Phaser.Pointer object that is processing the Items.
-    * 2) An array containing all potential interactive candidates. This is an array of `InputHandler` objects, not Sprites.
-    * 3) The current 'favorite' candidate, based on its priorityID and position in the display list.
+    * A reference to the Phaser.Pointer, from which you can retrieve the current target object and all
+    * interactive candidates, will be sent to the callback
     *
-    * Your callback MUST return one of the candidates sent to it.
-    * 
     * @method Phaser.Input#setInteractiveCandidateHandler
     * @param {function} callback - The callback that will be called each time `Pointer.processInteractiveObjects` is called. Set to `null` to disable.
     * @param {object} context - The context in which the callback will be called.
@@ -503,17 +498,17 @@ Phaser.Input.prototype = {
     * Adds a callback that is fired every time the activePointer receives a DOM move event such as a mousemove or touchmove.
     *
     * The callback will be sent 4 parameters:
-    * 
+    *
     * A reference to the Phaser.Pointer object that moved,
     * The x position of the pointer,
     * The y position,
     * A boolean indicating if the movement was the result of a 'click' event (such as a mouse click or touch down).
-    * 
+    *
     * It will be called every time the activePointer moves, which in a multi-touch game can be a lot of times, so this is best
     * to only use if you've limited input to a single pointer (i.e. mouse or touch).
-    * 
+    *
     * The callback is added to the Phaser.Input.moveCallbacks array and should be removed with Phaser.Input.deleteMoveCallback.
-    * 
+    *
     * @method Phaser.Input#addMoveCallback
     * @param {function} callback - The callback that will be called each time the activePointer receives a DOM move event.
     * @param {object} context - The context in which the callback will be called.
@@ -526,7 +521,7 @@ Phaser.Input.prototype = {
 
     /**
     * Removes the callback from the Phaser.Input.moveCallbacks array.
-    * 
+    *
     * @method Phaser.Input#deleteMoveCallback
     * @param {function} callback - The callback to be removed.
     * @param {object} context - The context in which the callback exists.
@@ -574,7 +569,7 @@ Phaser.Input.prototype = {
 
     /**
     * Updates the Input Manager. Called by the core Game loop.
-    * 
+    *
     * @method Phaser.Input#update
     * @protected
     */

--- a/src/input/InputHandler.js
+++ b/src/input/InputHandler.js
@@ -897,7 +897,7 @@ Phaser.InputHandler.prototype = {
             {
                 this._pointerData[pointer.id].x = pointer.x - this.sprite.x;
                 this._pointerData[pointer.id].y = pointer.y - this.sprite.y;
-                /* return */ this.sprite.events.onInputUpdate.dispatch(this.sprite, pointer);
+                this.sprite.events.onInputUpdate.dispatch(this.sprite, pointer);
                 return true;
             }
             else

--- a/src/input/InputHandler.js
+++ b/src/input/InputHandler.js
@@ -283,7 +283,7 @@ Phaser.InputHandler.prototype = {
 
     /**
     * Starts the Input Handler running. This is called automatically when you enable input on a Sprite, or can be called directly if you need to set a specific priority.
-    * 
+    *
     * @method Phaser.InputHandler#start
     * @param {number} [priority=0] - Higher priority sprites take click priority over low-priority sprites when they are stacked on-top of each other.
     * @param {boolean} [useHandCursor=false] - If true the Sprite will show the hand cursor on mouse-over (doesn't apply to mobile browsers)
@@ -864,7 +864,7 @@ Phaser.InputHandler.prototype = {
         if (this.sprite === null || this.sprite.parent === undefined)
         {
             //  Abort. We've been destroyed.
-            return;
+            return false;
         }
 
         if (!this.enabled || !this.sprite.visible || !this.sprite.parent.visible)
@@ -897,6 +897,7 @@ Phaser.InputHandler.prototype = {
             {
                 this._pointerData[pointer.id].x = pointer.x - this.sprite.x;
                 this._pointerData[pointer.id].y = pointer.y - this.sprite.y;
+                /* return */ this.sprite.events.onInputUpdate.dispatch(this.sprite, pointer);
                 return true;
             }
             else
@@ -1178,7 +1179,7 @@ Phaser.InputHandler.prototype = {
 
     /**
     * Called as a Pointer actively drags this Game Object.
-    * 
+    *
     * @method Phaser.InputHandler#updateDrag
     * @private
     * @param {Phaser.Pointer} pointer - The Pointer causing the drag update.

--- a/src/input/InputHandler.js
+++ b/src/input/InputHandler.js
@@ -459,14 +459,10 @@ Phaser.InputHandler.prototype = {
     *
     * @method Phaser.InputHandler#validForInput
     * @protected
-    * @param {number} highestID - The highest ID currently processed by the Pointer.
-    * @param {number} highestRenderID - The highest Render Order ID currently processed by the Pointer.
-    * @param {boolean} [includePixelPerfect=true] - If this object has `pixelPerfectClick` or `pixelPerfectOver` set should it be considered as valid?
     * @return {boolean} True if the object this InputHandler is bound to should be considered as valid for input detection.
     */
-    validForInput: function (highestID, highestRenderID, includePixelPerfect) {
+    validForInput: function () {
 
-        if (includePixelPerfect === undefined) { includePixelPerfect = true; }
 
         if (!this.enabled ||
             this.sprite.scale.x === 0 ||
@@ -477,18 +473,7 @@ Phaser.InputHandler.prototype = {
             return false;
         }
 
-        //   If we're trying to specifically IGNORE pixel perfect objects, then set includePixelPerfect to false and skip it
-        if (!includePixelPerfect && (this.pixelPerfectClick || this.pixelPerfectOver))
-        {
-            return false;
-        }
-
-        if (this.priorityID > highestID || (this.priorityID === highestID && this.sprite.renderOrderID > highestRenderID))
-        {
-            return true;
-        }
-
-        return false;
+        return true;
 
     },
 
@@ -868,7 +853,7 @@ Phaser.InputHandler.prototype = {
     /**
     * Internal Update method. This is called automatically and handles the Pointer
     * and drag update loops.
-    * 
+    *
     * @method Phaser.InputHandler#update
     * @protected
     * @param {Phaser.Pointer} pointer
@@ -917,6 +902,7 @@ Phaser.InputHandler.prototype = {
             else
             {
                 this._pointerOutHandler(pointer);
+                pointer.propagateThrough();
                 return false;
             }
         }
@@ -924,7 +910,7 @@ Phaser.InputHandler.prototype = {
 
     /**
     * Internal method handling the pointer over event.
-    * 
+    *
     * @method Phaser.InputHandler#_pointerOverHandler
     * @private
     * @param {Phaser.Pointer} pointer - The pointer that triggered the event
@@ -935,6 +921,12 @@ Phaser.InputHandler.prototype = {
         if (this.sprite === null)
         {
             //  Abort. We've been destroyed.
+            return;
+        }
+
+        if(this.pixelPerfectOver && !this.checkPixel(null, null, pointer))
+        {
+            pointer.propagateThrough();
             return;
         }
 
@@ -971,7 +963,7 @@ Phaser.InputHandler.prototype = {
 
     /**
     * Internal method handling the pointer out event.
-    * 
+    *
     * @method Phaser.InputHandler#_pointerOutHandler
     * @private
     * @param {Phaser.Pointer} pointer - The pointer that triggered the event.
@@ -1011,7 +1003,7 @@ Phaser.InputHandler.prototype = {
 
     /**
     * Internal method handling the touched / clicked event.
-    * 
+    *
     * @method Phaser.InputHandler#_touchedHandler
     * @private
     * @param {Phaser.Pointer} pointer - The pointer that triggered the event.
@@ -1024,14 +1016,16 @@ Phaser.InputHandler.prototype = {
             return;
         }
 
+        if(this.pixelPerfectClick && !this.checkPixel(null, null, pointer))
+        {
+            pointer.propagateThrough();
+            return;
+        }
+
         var data = this._pointerData[pointer.id];
 
         if (!data.isDown && data.isOver)
         {
-            if (this.pixelPerfectClick && !this.checkPixel(null, null, pointer))
-            {
-                return;
-            }
 
             data.isDown = true;
             data.isUp = false;
@@ -1094,7 +1088,7 @@ Phaser.InputHandler.prototype = {
 
     /**
     * Internal method handling the drag threshold timer.
-    * 
+    *
     * @method Phaser.InputHandler#dragTimeElapsed
     * @private
     * @param {Phaser.Pointer} pointer
@@ -1159,7 +1153,7 @@ Phaser.InputHandler.prototype = {
                     isOver = this.checkPointerOver(pointer);
                 }
             }
-            
+
             data.isOver = isOver;
 
             if (!isOver && this.useHandCursor)
@@ -1384,11 +1378,11 @@ Phaser.InputHandler.prototype = {
     * Allow this Sprite to be dragged by any valid pointer.
     *
     * When the drag begins the Sprite.events.onDragStart event will be dispatched.
-    * 
+    *
     * When the drag completes by way of the user letting go of the pointer that was dragging the sprite, the Sprite.events.onDragStop event is dispatched.
     *
     * You can control the thresholds over when a drag starts via the properties:
-    * 
+    *
     * `Pointer.dragDistanceThreshold` the distance, in pixels, that the pointer has to move
     * before the drag will start.
     *
@@ -1399,7 +1393,7 @@ Phaser.InputHandler.prototype = {
     *
     * For the duration of the drag the Sprite.events.onDragUpdate event is dispatched. This event is only dispatched when the pointer actually
     * changes position and moves. The event sends 5 parameters: `sprite`, `pointer`, `dragX`, `dragY` and `snapPoint`.
-    * 
+    *
     * @method Phaser.InputHandler#enableDrag
     * @param {boolean} [lockCenter=false] - If false the Sprite will drag from where you click it minus the dragOffset. If true it will center itself to the tip of the mouse pointer.
     * @param {boolean} [bringToTop=false] - If true the Sprite will be bought to the top of the rendering list in its current Group.

--- a/src/input/Pointer.js
+++ b/src/input/Pointer.js
@@ -310,7 +310,7 @@ Phaser.Pointer = function (game, id, pointerMode) {
     this.interactiveCandidates = [];
 
     /**
-    * @property {boolean} _propagateThrough - Internal variable indicating weather the pointer should propagate through the current target object.
+    * @property {boolean} _propagateThrough - Internal variable indicating whether the pointer should propagate through the current target object.
     * @private
     */
     this._propagateThrough = false;

--- a/src/input/Pointer.js
+++ b/src/input/Pointer.js
@@ -71,10 +71,10 @@ Phaser.Pointer = function (game, id, pointerMode) {
 
     /**
     * If this Pointer is a Mouse or Pen / Stylus then you can access its left button directly through this property.
-    * 
+    *
     * The DeviceButton has its own properties such as `isDown`, `duration` and methods like `justReleased` for more fine-grained
     * button control.
-    * 
+    *
     * @property {Phaser.DeviceButton} leftButton
     * @default
     */
@@ -82,12 +82,12 @@ Phaser.Pointer = function (game, id, pointerMode) {
 
     /**
     * If this Pointer is a Mouse or Pen / Stylus then you can access its middle button directly through this property.
-    * 
+    *
     * The DeviceButton has its own properties such as `isDown`, `duration` and methods like `justReleased` for more fine-grained
     * button control.
     *
     * Please see the DeviceButton docs for details on browser button limitations.
-    * 
+    *
     * @property {Phaser.DeviceButton} middleButton
     * @default
     */
@@ -95,12 +95,12 @@ Phaser.Pointer = function (game, id, pointerMode) {
 
     /**
     * If this Pointer is a Mouse or Pen / Stylus then you can access its right button directly through this property.
-    * 
+    *
     * The DeviceButton has its own properties such as `isDown`, `duration` and methods like `justReleased` for more fine-grained
     * button control.
     *
     * Please see the DeviceButton docs for details on browser button limitations.
-    * 
+    *
     * @property {Phaser.DeviceButton} rightButton
     * @default
     */
@@ -108,12 +108,12 @@ Phaser.Pointer = function (game, id, pointerMode) {
 
     /**
     * If this Pointer is a Mouse or Pen / Stylus then you can access its X1 (back) button directly through this property.
-    * 
+    *
     * The DeviceButton has its own properties such as `isDown`, `duration` and methods like `justReleased` for more fine-grained
     * button control.
     *
     * Please see the DeviceButton docs for details on browser button limitations.
-    * 
+    *
     * @property {Phaser.DeviceButton} backButton
     * @default
     */
@@ -121,12 +121,12 @@ Phaser.Pointer = function (game, id, pointerMode) {
 
     /**
     * If this Pointer is a Mouse or Pen / Stylus then you can access its X2 (forward) button directly through this property.
-    * 
+    *
     * The DeviceButton has its own properties such as `isDown`, `duration` and methods like `justReleased` for more fine-grained
     * button control.
     *
     * Please see the DeviceButton docs for details on browser button limitations.
-    * 
+    *
     * @property {Phaser.DeviceButton} forwardButton
     * @default
     */
@@ -134,12 +134,12 @@ Phaser.Pointer = function (game, id, pointerMode) {
 
     /**
     * If this Pointer is a Pen / Stylus then you can access its eraser button directly through this property.
-    * 
+    *
     * The DeviceButton has its own properties such as `isDown`, `duration` and methods like `justReleased` for more fine-grained
     * button control.
     *
     * Please see the DeviceButton docs for details on browser button limitations.
-    * 
+    *
     * @property {Phaser.DeviceButton} eraserButton
     * @default
     */
@@ -299,15 +299,21 @@ Phaser.Pointer = function (game, id, pointerMode) {
     this.targetObject = null;
 
     /**
-    * This array is erased and re-populated every time this Pointer is updated. It contains references to all
-    * of the Game Objects that were considered as being valid for processing by this Pointer, this frame. To be
-    * valid they must have suitable a `priorityID`, be Input enabled, visible and actually have the Pointer over
-    * them. You can check the contents of this array in events such as `onInputDown`, but beware it is reset
-    * every frame.
+    * This array is re-assigned every time this Pointer is updated. It contains references to all of the
+    * Game Objects that were considered as being valid for processing by this Pointer, this frame, sorted
+    * by priority and render order. To be considered valid they must be Input enabled, visible and actually have
+    * the Pointer over them. You can check the contents of this array in events such as `onInputDown`, but
+    * beware it is reset every frame.
     * @property {array} interactiveCandidates
     * @default
     */
     this.interactiveCandidates = [];
+
+    /**
+    * @property {boolean} _propagateThrough - Internal variable indicating weather the pointer should propagate through the current target object.
+    * @private
+    */
+    this._propagateThrough = false;
 
     /**
     * @property {boolean} active - An active pointer is one that is currently pressed down on the display. A Mouse is always active.
@@ -330,7 +336,7 @@ Phaser.Pointer = function (game, id, pointerMode) {
     * @property {Phaser.Point} positionDown - A Phaser.Point object containing the x/y values of the pointer when it was last in a down state on the display.
     */
     this.positionDown = new Phaser.Point();
-    
+
     /**
     * @property {Phaser.Point} positionUp - A Phaser.Point object containing the x/y values of the pointer when it was last released.
     */
@@ -415,7 +421,7 @@ Phaser.Pointer.prototype = {
 
     /**
     * Resets the states of all the button booleans.
-    * 
+    *
     * @method Phaser.Pointer#resetButtons
     * @protected
     */
@@ -438,7 +444,7 @@ Phaser.Pointer.prototype = {
 
     /**
     * Called by updateButtons.
-    * 
+    *
     * @method Phaser.Pointer#processButtonsDown
     * @private
     * @param {integer} buttons - The DOM event.buttons property.
@@ -457,7 +463,7 @@ Phaser.Pointer.prototype = {
         {
             this.rightButton.start(event);
         }
-                
+
         if (Phaser.Pointer.MIDDLE_BUTTON & buttons)
         {
             this.middleButton.start(event);
@@ -482,7 +488,7 @@ Phaser.Pointer.prototype = {
 
     /**
     * Called by updateButtons.
-    * 
+    *
     * @method Phaser.Pointer#processButtonsUp
     * @private
     * @param {integer} buttons - The DOM event.buttons property.
@@ -501,7 +507,7 @@ Phaser.Pointer.prototype = {
         {
             this.rightButton.stop(event);
         }
-                
+
         if (button === Phaser.Mouse.MIDDLE_BUTTON)
         {
             this.middleButton.stop(event);
@@ -527,7 +533,7 @@ Phaser.Pointer.prototype = {
     /**
     * Called when the event.buttons property changes from zero.
     * Contains a button bitmask.
-    * 
+    *
     * @method Phaser.Pointer#updateButtons
     * @protected
     * @param {MouseEvent} event - The DOM event.
@@ -582,6 +588,29 @@ Phaser.Pointer.prototype = {
             this.isDown = true;
         }
 
+    },
+
+    /**
+    * Call this in an input event handler to make the event propagate to other valid objects "underneath".
+    *
+    * @method Phaser.Pointer#propagateThrough
+    * @default
+    */
+    propagateThrough: function() {
+        this._propagateThrough = true;
+    },
+
+    /**
+    * Check if pointer should propagate through the current target object and reset the indicator.
+    *
+    * @method Phaser.Pointer#triggerPropagation
+    * @private
+    * @return {boolean} True if pointer should propagate, false otherwise.
+    */
+    triggerPropagation: function() {
+        var shouldPropagate = this._propagateThrough;
+        this._propagateThrough = false;
+        return shouldPropagate;
     },
 
     /**
@@ -645,9 +674,16 @@ Phaser.Pointer.prototype = {
 
         this.totalTouches++;
 
-        if (this.targetObject !== null)
+        var propagated = true; // no-object propagates input
+        for (var i = this.interactiveCandidates.length; i --> 0;)
         {
+            this.targetObject = this.interactiveCandidates[i];
             this.targetObject._touchedHandler(this);
+            propagated = this.triggerPropagation();
+            if(!propagated)
+            {
+                break;
+            }
         }
 
         return this;
@@ -708,7 +744,7 @@ Phaser.Pointer.prototype = {
 
     /**
     * Called when the Pointer is moved.
-    * 
+    *
     * @method Phaser.Pointer#move
     * @param {MouseEvent|PointerEvent|TouchEvent} event - The event passed up from the input handler.
     * @param {boolean} [fromClick=false] - Was this called from the click event?
@@ -786,15 +822,29 @@ Phaser.Pointer.prototype = {
             input.moveCallbacks[i].callback.call(input.moveCallbacks[i].context, this, this.x, this.y, fromClick);
         }
 
-        //  Easy out if we're dragging something and it still exists
-        if (this.targetObject !== null && this.targetObject.isDragged === true)
+        var dragged = false; // no-object can not be dragged
+        var propagated = true; // no-object propagates input
+        for (var i = this.interactiveCandidates.length; i --> 0;)
         {
-            if (this.targetObject.update(this) === false)
+            this.targetObject = this.interactiveCandidates[i];
+            if(this.targetObject.isDragged === true)
             {
-                this.targetObject = null;
+                dragged = true;
+                if(this.targetObject.update(this) === false)
+                {
+                    this.interactiveCandidates.splice(i,1);
+                    this.targetObject = null;
+                }
+            }
+            propagated = this.triggerPropagation();
+            if(!propagated)
+            {
+                break;
             }
         }
-        else if (input.interactiveItems.total > 0)
+
+        if (!(dragged && !propagated) && // if an object was dragged and did not propagate the input, then we can skip processing other objects
+                input.interactiveItems.total > 0)
         {
             this.processInteractiveObjects(fromClick);
         }
@@ -805,7 +855,7 @@ Phaser.Pointer.prototype = {
 
     /**
     * Process all interactive objects to find out which ones were updated in the recent Pointer move.
-    * 
+    *
     * @method Phaser.Pointer#processInteractiveObjects
     * @protected
     * @param {boolean} [fromClick=false] - Was this called from the click event?
@@ -813,71 +863,76 @@ Phaser.Pointer.prototype = {
     */
     processInteractiveObjects: function (fromClick) {
 
-        //  Work out which object is on the top
-        var highestRenderOrderID = 0;
-        var highestInputPriorityID = -1;
-        var candidateTarget = null;
+        var detectedObjects = [];
 
-        //  First pass gets all objects that the pointer is over that DON'T use pixelPerfect checks and get the highest ID
-        //  We know they'll be valid for input detection but not which is the top just yet
-
+        // just fast hit-test all interactive items and collect valid ones
         var currentNode = this.game.input.interactiveItems.first;
-
-        this.interactiveCandidates = [];
-
         while (currentNode)
         {
-            //  Reset checked status
-            currentNode.checked = false;
-
-            if (currentNode.validForInput(highestInputPriorityID, highestRenderOrderID, false))
+            if(currentNode.validForInput())
             {
-                //  Flag it as checked so we don't re-scan it on the next phase
-                currentNode.checked = true;
-
                 if ((fromClick && currentNode.checkPointerDown(this, true)) ||
                     (!fromClick && currentNode.checkPointerOver(this, true)))
                 {
-                    highestRenderOrderID = currentNode.sprite.renderOrderID;
-                    highestInputPriorityID = currentNode.priorityID;
-                    candidateTarget = currentNode;
-                    this.interactiveCandidates.push(currentNode);
+                    detectedObjects.push(currentNode);
                 }
             }
-
             currentNode = this.game.input.interactiveItems.next;
         }
 
-        //  Then in the second sweep we process ONLY the pixel perfect ones that are checked and who have a higher ID
-        //  because if their ID is lower anyway then we can just automatically discount them
-        //  (A node that was previously checked did not request a pixel-perfect check.)
+        // sort them by priority and render order
+        detectedObjects.sort( function(one, other) {
+            var priority = one.priorityID - other.priorityID;
+            var renderOrder = one.sprite.renderOrderID - other.sprite.renderOrderID;
+            return priority ? priority : renderOrder;
+        });
 
-        currentNode = this.game.input.interactiveItems.first;
-
-        while (currentNode)
+        // call _pointerOut on objects that are no longer valid, and mark the ones that stayed valid
+        for (var i = this.interactiveCandidates.length; i --> 0;)
         {
-            if (!currentNode.checked &&
-                currentNode.validForInput(highestInputPriorityID, highestRenderOrderID, true))
+            var object = this.interactiveCandidates[i];
+            var index = detectedObjects.indexOf(object);
+            if(index === -1)
             {
-                if ((fromClick && currentNode.checkPointerDown(this, false)) ||
-                    (!fromClick && currentNode.checkPointerOver(this, false)))
+                object._pointerOutHandler(this);
+                object.checked = false;
+            }
+            else
+            {
+                object.checked = true;
+            }
+        }
+
+        this.targetObject = null;
+
+        // for currently valid objects if they were valid previously update, otherwise _pointerOverHandler
+        for (var i = detectedObjects.length; i --> 0;)
+        {
+            this.targetObject = detectedObjects[i];
+            if(this.targetObject.checked)
+            {
+                this.targetObject.checked = false;
+                if(this.targetObject.update(this) === false)
                 {
-                    highestRenderOrderID = currentNode.sprite.renderOrderID;
-                    highestInputPriorityID = currentNode.priorityID;
-                    candidateTarget = currentNode;
-                    this.interactiveCandidates.push(currentNode);
+                    detectedObjects.splice(i,1);
                 }
             }
-
-            currentNode = this.game.input.interactiveItems.next;
+            else
+            {
+                this.targetObject._pointerOverHandler(this);
+            }
+            if(!this.triggerPropagation()) // stop if did not propagate
+            {
+                break;
+            }
         }
+
+        this.interactiveCandidates = detectedObjects;
 
         if (this.game.input.customCandidateHandler)
         {
-            candidateTarget = this.game.input.customCandidateHandler.call(this.game.input.customCandidateHandlerContext, this, this.interactiveCandidates, candidateTarget);
+            this.game.input.customCandidateHandler.call(this.game.input.customCandidateHandlerContext, this);
         }
-
-        this.swapTarget(candidateTarget, false);
 
         return (this.targetObject !== null);
 
@@ -885,7 +940,7 @@ Phaser.Pointer.prototype = {
 
     /**
     * This will change the `Pointer.targetObject` object to be the one provided.
-    * 
+    *
     * This allows you to have fine-grained control over which object the Pointer is targeting.
     *
     * Note that even if you set a new Target here, it is still able to be replaced by any other valid
@@ -1017,9 +1072,9 @@ Phaser.Pointer.prototype = {
         this.withinGame = this.game.scale.bounds.contains(event.pageX, event.pageY);
         this.pointerId = null;
         this.identifier = null;
-        
+
         this.positionUp.setTo(this.x, this.y);
-        
+
         if (this.isMouse === false)
         {
             input.currentPointers--;
@@ -1033,6 +1088,7 @@ Phaser.Pointer.prototype = {
         }
 
         this.targetObject = null;
+        this.interactiveCandidates.length = 0;
 
         return this;
 
@@ -1165,12 +1221,14 @@ Phaser.Pointer.prototype = {
 
         this.resetButtons();
 
-        if (this.targetObject)
+        for (var i = this.interactiveCandidates.length; i --> 0;)
         {
+            this.targetObject = this.interactiveCandidates[i];
             this.targetObject._releasedHandler(this);
         }
 
         this.targetObject = null;
+        this.interactiveCandidates.length = 0;
 
     },
 
@@ -1193,7 +1251,7 @@ Phaser.Pointer.prototype.constructor = Phaser.Pointer;
 * How long the Pointer has been depressed on the touchscreen or *any* of the mouse buttons have been held down.
 * If not currently down it returns -1.
 * If you need to test a specific mouse or pen button then access the buttons directly, i.e. `Pointer.rightButton.duration`.
-* 
+*
 * @name Phaser.Pointer#duration
 * @property {number} duration
 * @readonly


### PR DESCRIPTION
This PR changes
- Documentation (in the code)
- TypeScript Defs (not sure...)
- The public-facing API

Describe the changes below:

Well, there's a lot. Had to change the way interactiveCanditates are selected, since can not skip any just because their priority or render id are lower, have to hit test all of them, then sort(could actually insert sorted). 
Now, whenever previously an input event would trigger on target, it is triggered on all interactive candidates in order, as long as the previous one propagated input. Input can be propagated in a handler by calling the appropriate method on the Pointer object. By default input is never propagated so only the first candidate receives the input.
Also had to move the pixel perfect checks into handlers, so that they are performed only when necessary.
Regarding the API there are only additions, and some changes to the recent interactive candidates callback.
I do not know how this affects pixel perfect input or dragging, and I have no idea what click trampolines are, but i tired to make sure that everything works as before if no input is propagated.
