### PR TITLE
Fixed Animation.setFrame() for sprite index argument

### DIFF
--- a/src/animation/Animation.js
+++ b/src/animation/Animation.js
@@ -306,7 +306,7 @@ Phaser.Animation.prototype = {
             {
                 for (var i = 0; i < this._frames.length; i++)
                 {
-                    if (this._frames[i] === frameIndex)
+                    if (this._frames[i] === frameId)
                     {
                         frameIndex = i;
                     }


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:
To my understanding the function `Animation.setFrame(frameId, useLocalFrameIndex)` did not work correctly if `frameId` was a sprite index (i.e. `typeof frameId === "number")`  and `useLocalFrameIndex === false`. This should fix it.
