### PR TITLE
Modifed Group.getClosestTo() and Group.getFurthestFrom() to add optional filter callback

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -2213,8 +2213,12 @@ Phaser.Group.prototype.getBottom = function () {
 *
 * 'close' is determined by the distance from the objects `x` and `y` properties compared to the childs `x` and `y` properties.
 *
+* If callback returns true, the object is considered for distance. If callback is null, then any child will satisfy the criteria. 
+*
 * @method Phaser.Group#getClosestTo
 * @param {any} object - The object used to determine the distance. This can be a Sprite, Group, Image or any object with public x and y properties.
+* @param {function} [callback=null] - The function that each child will be evaluated against. Each child of the group will be passed to it as its first parameter, with the distance as the second.
+* @param {object} [callbackContext] - The context in which the function should be called (usually 'this').
 * @return {any} The child closest to given object, or null if no child was found.
 */
 Phaser.Group.prototype.getClosestTo = function (object, callback, callbackContext) {

--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -2207,7 +2207,7 @@ Phaser.Group.prototype.getBottom = function () {
 };
 
 /**
-* Get the closest child to given Object.
+* Get the closest child to given Object, with optional callback to filter children.
 *
 * This can be a Sprite, Group, Image or any object with public x and y properties.
 *
@@ -2217,12 +2217,17 @@ Phaser.Group.prototype.getBottom = function () {
 * @param {any} object - The object used to determine the distance. This can be a Sprite, Group, Image or any object with public x and y properties.
 * @return {any} The child closest to given object, or null if no child was found.
 */
-Phaser.Group.prototype.getClosestTo = function (object) {
+Phaser.Group.prototype.getClosestTo = function (object, callback, callbackContext) {
 
     var distance = Number.MAX_VALUE;
     var tempDistance = 0;
     var result = null;
 
+    if (!callback)
+    {
+        callback = function() {return true;};
+    }
+
     for (var i = 0; i < this.children.length; i++)
     {
         var child = this.children[i];
@@ -2231,7 +2236,7 @@ Phaser.Group.prototype.getClosestTo = function (object) {
         {
             tempDistance = Math.abs(Phaser.Point.distance(object, child));
 
-            if (tempDistance < distance)
+            if (tempDistance < distance && callback.call(callbackContext, child, tempDistance))
             {
                 distance = tempDistance;
                 result = child;
@@ -2244,112 +2249,29 @@ Phaser.Group.prototype.getClosestTo = function (object) {
 };
 
 /**
-* Get the closest child to given Object that satisfies the filter criteria.
-*
-* This can be a Sprite, Group, Image or any object with public x and y properties.
-*
-* 'close' is determined by the distance from the objects `x` and `y` properties compared to the childs `x` and `y` properties.
-*
-* If filter returns true, the object is considered for closeness. If filter is null, then any child will satisfy the criteria. 
-* 
-* @method Phaser.Group#getClosestToFilter
-* @param {any} object - The object used to determine the distance. This can be a Sprite, Group, Image or any object with public x and y properties.
-* @param {function} filter - The function that each child will be evaluated against. Each child of the group will be passed to it as its first parameter, with the distance as the second.
-* @return {any} The child closest to given object that satisfies the filter criteria, or null if no child was found.
-*/
-Phaser.Group.prototype.getClosestToFilter = function (object, filter) {
-
-    var distance = Number.MAX_VALUE;
-    var tempDistance = 0;
-    var result = null;
-
-    var _filter = filter;
-    if (_filter === null || _filter === undefined)
-    {
-        _filter = function() {return true;};
-    }
-    
-    for (var i = 0; i < this.children.length; i++)
-    {
-        var child = this.children[i];
-
-        if (child.exists)
-        {
-            tempDistance = Math.abs(Phaser.Point.distance(object, child));
-
-            if (tempDistance < distance && _filter(child, tempDistance))
-            {
-                distance = tempDistance;
-                result = child;
-            }
-        }
-    }
-
-    return result;
-
-};
-
-/**
-* Get the child furthest away from the given Object.
+* Get the child furthest away from the given Object, with optional callback to filter children.
 *
 * This can be a Sprite, Group, Image or any object with public x and y properties.
 *
 * 'furthest away' is determined by the distance from the objects `x` and `y` properties compared to the childs `x` and `y` properties.
 *
+* If callback returns true, the object is considered for distance. If callback is null, then any child will satisfy the criteria. 
+*
 * @method Phaser.Group#getFurthestFrom
 * @param {any} object - The object used to determine the distance. This can be a Sprite, Group, Image or any object with public x and y properties.
+* @param {function} [callback=null] - The function that each child will be evaluated against. Each child of the group will be passed to it as its first parameter, with the distance as the second.
+* @param {object} [callbackContext] - The context in which the function should be called (usually 'this').
 * @return {any} The child furthest from the given object, or null if no child was found.
 */
-Phaser.Group.prototype.getFurthestFrom = function (object) {
+Phaser.Group.prototype.getFurthestFrom = function (object, callback, callbackContext) {
 
     var distance = 0;
     var tempDistance = 0;
     var result = null;
 
-    for (var i = 0; i < this.children.length; i++)
+    if (!callback)
     {
-        var child = this.children[i];
-
-        if (child.exists)
-        {
-            tempDistance = Math.abs(Phaser.Point.distance(object, child));
-
-            if (tempDistance > distance)
-            {
-                distance = tempDistance;
-                result = child;
-            }
-        }
-    }
-
-    return result;
-
-};
-
-/**
-* Get the child furthest away from the given Object that satisfies the filter criteria.
-*
-* This can be a Sprite, Group, Image or any object with public x and y properties.
-*
-* 'furthest away' is determined by the distance from the objects `x` and `y` properties compared to the childs `x` and `y` properties.
-*
-* If filter returns true, the object is considered for closeness. If filter is null, then any child will satisfy the criteria. 
-* 
-* @method Phaser.Group#getFurthestFrom
-* @param {any} object - The object used to determine the distance. This can be a Sprite, Group, Image or any object with public x and y properties.
-* @param {function} filter - The function that each child will be evaluated against. Each child of the group will be passed to it as its first parameter, with the distance as the second.
-* @return {any} The child furthest from the given object, or null if no child was found.
-*/
-Phaser.Group.prototype.getFurthestFromFilter = function (object, filter) {
-
-    var distance = 0;
-    var tempDistance = 0;
-    var result = null;
-
-    var _filter = filter;
-    if (_filter === null || _filter === undefined)
-    {
-        _filter = function() {return true;};
+        callback = function() {return true;};
     }
 
     for (var i = 0; i < this.children.length; i++)
@@ -2360,7 +2282,7 @@ Phaser.Group.prototype.getFurthestFromFilter = function (object, filter) {
         {
             tempDistance = Math.abs(Phaser.Point.distance(object, child));
 
-            if (tempDistance > distance && _filter(child, tempDistance))
+            if (tempDistance > distance && callback.call(callbackContext, child, tempDistance))
             {
                 distance = tempDistance;
                 result = child;

--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -2244,6 +2244,52 @@ Phaser.Group.prototype.getClosestTo = function (object) {
 };
 
 /**
+* Get the closest child to given Object that satisfies the filter criteria.
+*
+* This can be a Sprite, Group, Image or any object with public x and y properties.
+*
+* 'close' is determined by the distance from the objects `x` and `y` properties compared to the childs `x` and `y` properties.
+*
+* If filter returns true, the object is considered for closeness. If filter is null, then any child will satisfy the criteria. 
+* 
+* @method Phaser.Group#getClosestToFilter
+* @param {any} object - The object used to determine the distance. This can be a Sprite, Group, Image or any object with public x and y properties.
+* @param {function} filter - The function that each child will be evaluated against. Each child of the group will be passed to it as its first parameter, with the distance as the second.
+* @return {any} The child closest to given object that satisfies the filter criteria, or null if no child was found.
+*/
+Phaser.Group.prototype.getClosestToFilter = function (object, filter) {
+
+    var distance = Number.MAX_VALUE;
+    var tempDistance = 0;
+    var result = null;
+
+    var _filter = filter;
+    if (_filter === null || _filter === undefined)
+    {
+        _filter = function() {return true;};
+    }
+    
+    for (var i = 0; i < this.children.length; i++)
+    {
+        var child = this.children[i];
+
+        if (child.exists)
+        {
+            tempDistance = Math.abs(Phaser.Point.distance(object, child));
+
+            if (tempDistance < distance && _filter(child, tempDistance))
+            {
+                distance = tempDistance;
+                result = child;
+            }
+        }
+    }
+
+    return result;
+
+};
+
+/**
 * Get the child furthest away from the given Object.
 *
 * This can be a Sprite, Group, Image or any object with public x and y properties.
@@ -2269,6 +2315,52 @@ Phaser.Group.prototype.getFurthestFrom = function (object) {
             tempDistance = Math.abs(Phaser.Point.distance(object, child));
 
             if (tempDistance > distance)
+            {
+                distance = tempDistance;
+                result = child;
+            }
+        }
+    }
+
+    return result;
+
+};
+
+/**
+* Get the child furthest away from the given Object that satisfies the filter criteria.
+*
+* This can be a Sprite, Group, Image or any object with public x and y properties.
+*
+* 'furthest away' is determined by the distance from the objects `x` and `y` properties compared to the childs `x` and `y` properties.
+*
+* If filter returns true, the object is considered for closeness. If filter is null, then any child will satisfy the criteria. 
+* 
+* @method Phaser.Group#getFurthestFrom
+* @param {any} object - The object used to determine the distance. This can be a Sprite, Group, Image or any object with public x and y properties.
+* @param {function} filter - The function that each child will be evaluated against. Each child of the group will be passed to it as its first parameter, with the distance as the second.
+* @return {any} The child furthest from the given object, or null if no child was found.
+*/
+Phaser.Group.prototype.getFurthestFromFilter = function (object, filter) {
+
+    var distance = 0;
+    var tempDistance = 0;
+    var result = null;
+
+    var _filter = filter;
+    if (_filter === null || _filter === undefined)
+    {
+        _filter = function() {return true;};
+    }
+
+    for (var i = 0; i < this.children.length; i++)
+    {
+        var child = this.children[i];
+
+        if (child.exists)
+        {
+            tempDistance = Math.abs(Phaser.Point.distance(object, child));
+
+            if (tempDistance > distance && _filter(child, tempDistance))
             {
                 distance = tempDistance;
                 result = child;

--- a/src/gameobjects/components/Health.js
+++ b/src/gameobjects/components/Health.js
@@ -20,8 +20,6 @@ Phaser.Component.Health.prototype = {
     * 
     * It can be used in combination with the `damage` method or modified directly.
     * 
-    * If health is taken below or is equal to zero then the `kill` method is called.    
-    *    
     * @property {number} health
     * @default
     */

--- a/src/gameobjects/components/Health.js
+++ b/src/gameobjects/components/Health.js
@@ -20,6 +20,8 @@ Phaser.Component.Health.prototype = {
     * 
     * It can be used in combination with the `damage` method or modified directly.
     * 
+    * If health is taken below or is equal to zero then the `kill` method is called.    
+    *    
     * @property {number} health
     * @default
     */


### PR DESCRIPTION
This PR changes the public-facing API.

A pair of new functions for the Group class, getClosestToFilter() and getFurthestFromFilter(), allowing a filter function to be passed and only members of the group who satisfy the filter will be considered for distance to the target object.



