### PR TITLE
Added missing property (particleAnchor) to emitter typescript definitions

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2682,6 +2682,7 @@ declare module Phaser {
                 minRotation: number;
                 name: string;
                 on: boolean;
+                particleAnchor: Phaser.Point;
                 particleBringToTop: boolean;
                 particleSendToBack: boolean;
                 particleClass: any;


### PR DESCRIPTION
This PR changes

* TypeScript Defs

Describe the changes below:
Added the missing property particleAnchor to Particles.Arcade.Emitter class
