### PR TITLE
Remove assignment to obsolete tileColor property

### DIFF
--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -859,8 +859,6 @@ Phaser.TilemapLayer.prototype.renderRegion = function (scrollX, scrollY, left, t
     // xmax/ymax - remaining cells to render on column/row
     var tx, ty, x, y, xmax, ymax;
 
-    context.fillStyle = this.tileColor;
-
     for (y = normStartY, ymax = bottom - top, ty = baseY;
         ymax >= 0;
         y++, ymax--, ty += th)


### PR DESCRIPTION
This PR removes the assignment of context.fillStyle to the obsolete tileColor property that was removed in 2.4.0. This property is undefined, and generates warnings in the FF console as a result.