### PR TITLE
Group.getClosestTo() comparator wrong direction

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -2238,7 +2238,7 @@ Phaser.Group.prototype.getClosestTo = function (object, callback, callbackContex
         {
             tempDistance = Math.abs(Phaser.Point.distance(object, child));
 
-            if (tempDistance > distance && (!callback || callback.call(callbackContext, child, tempDistance)))
+            if (tempDistance < distance && (!callback || callback.call(callbackContext, child, tempDistance)))
             {
                 distance = tempDistance;
                 result = child;


### PR DESCRIPTION
This PR changes Nothing, it's a bug fix

Recent update flipped the comparator operator to 'greater than' making the getClosestTo() behave like getFurthestFrom(). This PR changes it back to 'less than.'