### PR TITLE
Typings entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "typescript": "1.4.1",
     "yuidocjs": "^0.3.50"
   },
+  "typings": "./typescript/typings.json",
   "typescript": {
     "definitions": [
       "typescript/p2.d.ts",


### PR DESCRIPTION
This PR changes:
- package.json entry for typings.

See #2595. Honestly, I haven't been able to install typings using the shorter notation I would have expected, maybe because of being in a branch.

