### PR TITLE
Revert PIXI.DisplayObjectContainer.getBounds call to updateTransform

### DIFF
--- a/src/pixi/display/DisplayObjectContainer.js
+++ b/src/pixi/display/DisplayObjectContainer.js
@@ -328,8 +328,6 @@ PIXI.DisplayObjectContainer.prototype.getBounds = function()
         return PIXI.EmptyRectangle;
     }
 
-    this.updateTransform();
-
     var minX = Infinity;
     var minY = Infinity;
 


### PR DESCRIPTION
This PR changes
* Nothing, it's a bug fix

Describe the changes below:

This reverts commit 410237881eb8c7bdc21753dd56e1b97885306737.

Calling updateTransform inside of DisplayObjectContainer.getBounds() has the following two 
detrimental side effects:
* getLocalBounds() actually returns world bounds.
* PIXI.identityMatrix becomes corrupted because worldTransform is updated destructively in updateTransform().

There is probably a way to rewrite getLocalBounds() to work without reverting this, but I don't see an obvious route.
