### PR TITLE
Fix for DisplayObject/DisplayObjectContainer - getting dimensions or bounds do NOT retrieve proper values 

### DIFF
--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -326,10 +326,8 @@ PIXI.DisplayObject.prototype = {
         var p = this.parent;
 
         if (parent)
-
         {
             p = parent;
-
         }
         else if (!this.parent)
         {

--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -313,21 +313,21 @@ PIXI.DisplayObject.prototype = {
     * the new, updated, worldTransform property, along with the parent transform used.
     *
     * @method PIXI.DisplayObject#updateTransform
-    * @param {PIXI.DisplayObject} [parent] - Optional parent to calculate this DisplayObjects transform from.
-    * @return {PIXI.DisplayObject} - A reference to this DisplayObject.
+    * @param {PIXI.DisplayObject} [targetCoordinateSpace] Optional targetCoordinateSpace to calculate this DisplayObjects transform from.
+    * @return {PIXI.DisplayObject} A reference to this DisplayObject.
     */
-    updateTransform: function (parent) {
+    updateTransform: function (targetCoordinateSpace) {
 
-        if (!parent && !this.parent && !this.game)
+        if (!targetCoordinateSpace && !this.parent && !this.game)
         {
             return this;
         }
 
         var p = this.parent;
 
-        if (parent)
+        if (targetCoordinateSpace)
         {
-            p = parent;
+            p = targetCoordinateSpace;
         }
         else if (!this.parent)
         {

--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -226,7 +226,7 @@ PIXI.DisplayObject = function() {
     * @property {PIXI.Rectangle} _bounds - The cached bounds of this object.
     * @private
     */
-    this._bounds = new PIXI.Rectangle(0, 0, 1, 1);
+    this._bounds = new PIXI.Rectangle(0, 0, 0, 0);
 
     /**
     * @property {PIXI.Rectangle} _currentBounds - The most recently calculated bounds of this object.
@@ -313,21 +313,23 @@ PIXI.DisplayObject.prototype = {
     * the new, updated, worldTransform property, along with the parent transform used.
     *
     * @method PIXI.DisplayObject#updateTransform
-    * @param {PIXI.DisplayObject} [targetCoordinateSpace] Optional targetCoordinateSpace to calculate this DisplayObjects transform from.
-    * @return {PIXI.DisplayObject} A reference to this DisplayObject.
+    * @param {PIXI.DisplayObjectContainer} [parent] - Optional parent to calculate this DisplayObjects transform from.
+    * @return {PIXI.DisplayObject} - A reference to this DisplayObject.
     */
-    updateTransform: function (targetCoordinateSpace) {
+    updateTransform: function (parent) {
 
-        if (!targetCoordinateSpace && !this.parent && !this.game)
+        if (!parent && !this.parent && !this.game)
         {
             return this;
         }
 
         var p = this.parent;
 
-        if (targetCoordinateSpace)
+        if (parent)
+
         {
-            p = targetCoordinateSpace;
+            p = parent;
+
         }
         else if (!this.parent)
         {

--- a/src/pixi/display/DisplayObjectContainer.js
+++ b/src/pixi/display/DisplayObjectContainer.js
@@ -290,17 +290,16 @@ PIXI.DisplayObjectContainer.prototype.removeChildren = function(beginIndex, endI
  * Updates the transform on all children of this container for rendering
  *
  * @method updateTransform
- * @param {PIXI.DisplayObject} [targetCoordinateSpace] Optional targetCoordinateSpace to calculate this DisplayObjects transform from.
  * @private
  */
-PIXI.DisplayObjectContainer.prototype.updateTransform = function (targetCoordinateSpace)
+PIXI.DisplayObjectContainer.prototype.updateTransform = function ()
 {
     if (!this.visible)
     {
         return;
     }
 
-    this.displayObjectUpdateTransform(targetCoordinateSpace);
+    this.displayObjectUpdateTransform();
 
     if (this._cacheAsBitmap)
     {
@@ -317,45 +316,36 @@ PIXI.DisplayObjectContainer.prototype.updateTransform = function (targetCoordina
 PIXI.DisplayObjectContainer.prototype.displayObjectContainerUpdateTransform = PIXI.DisplayObjectContainer.prototype.updateTransform;
 
 /**
- * Retrieves the bounds of the displayObjectContainer as a rectangle. The bounds calculation takes all visible children into consideration.
+ * Retrieves the global bounds of the displayObjectContainer as a rectangle. The bounds calculation takes all visible children into consideration.
  *
  * @method getBounds
- * @param {PIXI.DisplayObject | PIXI.Matrix} [targetCoordinateSpace]
+ * @param {PIXI.DisplayObject|PIXI.Matrix} [targetCoordinateSpace] Returns a rectangle that defines the area of the display object relative to the coordinate system of the targetCoordinateSpace object.
  * @return {Rectangle} The rectangular bounding area
  */
 PIXI.DisplayObjectContainer.prototype.getBounds = function (targetCoordinateSpace)
 {
-    if (this.children.length === 0)
-    {
-        return PIXI.EmptyRectangle;
+    var isTargetCoordinateSpaceDisplayObject = targetCoordinateSpace && targetCoordinateSpace instanceof PIXI.DisplayObject;
+    var isTargetCoordinateSpaceThisOrParent = true;
+
+    if (!isTargetCoordinateSpaceDisplayObject) {
+        targetCoordinateSpace = this;
+    } else if (targetCoordinateSpace instanceof PIXI.DisplayObjectContainer) {
+        isTargetCoordinateSpaceThisOrParent = targetCoordinateSpace.contains(this);
+    } else {
+        isTargetCoordinateSpaceThisOrParent = false;
     }
 
-    var isTargetCoordinateSpaceDisplayObject = targetCoordinateSpace && targetCoordinateSpace instanceof PIXI.DisplayObject;
     var i;
 
-    if (isTargetCoordinateSpaceDisplayObject)
-    {
-        var matrixCache = this.worldTransform;
+    if (isTargetCoordinateSpaceDisplayObject) {
 
-        this.worldTransform = new PIXI.Matrix();
+        var matrixCache = targetCoordinateSpace.worldTransform;
 
-        for (i = 0; i < this.children.length; i++)
-        {
-            this.children[i].updateTransform();
-        }
-
-        var targetCoordinateSpaceMatrixCache = targetCoordinateSpace.worldTransform;
         targetCoordinateSpace.worldTransform = PIXI.identityMatrix;
-    }
 
-    if (!isTargetCoordinateSpaceDisplayObject || isTargetCoordinateSpaceDisplayObject && targetCoordinateSpace !== this)
-    {
-        this.updateTransform(targetCoordinateSpace);
-    }
-
-    if (isTargetCoordinateSpaceDisplayObject)
-    {
-        targetCoordinateSpace.worldTransform = targetCoordinateSpaceMatrixCache;
+        for (i = 0; i < targetCoordinateSpace.children.length; i++) {
+            targetCoordinateSpace.children[i].updateTransform();
+        }
     }
 
     var minX = Infinity;
@@ -370,19 +360,17 @@ PIXI.DisplayObjectContainer.prototype.getBounds = function (targetCoordinateSpac
 
     var childVisible = false;
 
-    for (i = 0; i < this.children.length; i++)
-    {
+    for (i = 0; i < this.children.length; i++) {
         var child = this.children[i];
-        
-        if (!child.visible)
-        {
+
+        if (!child.visible) {
             continue;
         }
 
         childVisible = true;
 
         childBounds = this.children[i].getBounds();
-     
+
         minX = minX < childBounds.x ? minX : childBounds.x;
         minY = minY < childBounds.y ? minY : childBounds.y;
 
@@ -393,27 +381,80 @@ PIXI.DisplayObjectContainer.prototype.getBounds = function (targetCoordinateSpac
         maxY = maxY > childMaxY ? maxY : childMaxY;
     }
 
-    if (isTargetCoordinateSpaceDisplayObject)
-    {
-        this.worldTransform = matrixCache;
-
-        for (i = 0; i < this.children.length; i++)
-        {
-            this.children[i].updateTransform();
-        }
-    }
-
-    if (!childVisible)
-    {
-        return PIXI.EmptyRectangle;
-    }
-
     var bounds = this._bounds;
+
+    if (!childVisible) {
+        bounds = new PIXI.Rectangle();
+
+        var w0 = bounds.x;
+        var w1 = bounds.width + bounds.x;
+
+        var h0 = bounds.y;
+        var h1 = bounds.height + bounds.y;
+
+        var worldTransform = this.worldTransform;
+
+        var a = worldTransform.a;
+        var b = worldTransform.b;
+        var c = worldTransform.c;
+        var d = worldTransform.d;
+        var tx = worldTransform.tx;
+        var ty = worldTransform.ty;
+
+        var x1 = a * w1 + c * h1 + tx;
+        var y1 = d * h1 + b * w1 + ty;
+
+        var x2 = a * w0 + c * h1 + tx;
+        var y2 = d * h1 + b * w0 + ty;
+
+        var x3 = a * w0 + c * h0 + tx;
+        var y3 = d * h0 + b * w0 + ty;
+
+        var x4 = a * w1 + c * h0 + tx;
+        var y4 = d * h0 + b * w1 + ty;
+
+        maxX = x1;
+        maxY = y1;
+
+        minX = x1;
+        minY = y1;
+
+        minX = x2 < minX ? x2 : minX;
+        minX = x3 < minX ? x3 : minX;
+        minX = x4 < minX ? x4 : minX;
+
+        minY = y2 < minY ? y2 : minY;
+        minY = y3 < minY ? y3 : minY;
+        minY = y4 < minY ? y4 : minY;
+
+        maxX = x2 > maxX ? x2 : maxX;
+        maxX = x3 > maxX ? x3 : maxX;
+        maxX = x4 > maxX ? x4 : maxX;
+
+        maxY = y2 > maxY ? y2 : maxY;
+        maxY = y3 > maxY ? y3 : maxY;
+        maxY = y4 > maxY ? y4 : maxY;
+    }
 
     bounds.x = minX;
     bounds.y = minY;
     bounds.width = maxX - minX;
     bounds.height = maxY - minY;
+
+    if (isTargetCoordinateSpaceDisplayObject) {
+        targetCoordinateSpace.worldTransform = matrixCache;
+
+        for (i = 0; i < targetCoordinateSpace.children.length; i++) {
+            targetCoordinateSpace.children[i].updateTransform();
+        }
+    }
+
+    if (!isTargetCoordinateSpaceThisOrParent) {
+        var targetCoordinateSpaceBounds = targetCoordinateSpace.getBounds();
+
+        bounds.x -= targetCoordinateSpaceBounds.x;
+        bounds.y -= targetCoordinateSpaceBounds.y;
+    }
 
     return bounds;
 };
@@ -428,6 +469,25 @@ PIXI.DisplayObjectContainer.prototype.getLocalBounds = function()
 {
     return this.getBounds(this.parent);
 };
+
+/**
+* Determines whether the specified display object is a child of the DisplayObjectContainer instance or the instance itself.
+*
+* @method contains
+* @param {DisplayObject} child
+* @returns {boolean}
+*/
+PIXI.DisplayObjectContainer.prototype.contains = function (child) {
+    if (!child)
+        return false;
+
+    if (child === this) {
+        return true;
+    }
+    else {
+        return this.contains(child.parent);
+    }
+}
 
 /**
  * Sets the containers Stage reference. This is the Stage that this object, and all of its children, is connected to.

--- a/src/pixi/display/DisplayObjectContainer.js
+++ b/src/pixi/display/DisplayObjectContainer.js
@@ -292,7 +292,7 @@ PIXI.DisplayObjectContainer.prototype.removeChildren = function(beginIndex, endI
  * @method updateTransform
  * @private
  */
-PIXI.DisplayObjectContainer.prototype.updateTransform = function ()
+PIXI.DisplayObjectContainer.prototype.updateTransform = function()
 {
     if (!this.visible)
     {
@@ -322,16 +322,21 @@ PIXI.DisplayObjectContainer.prototype.displayObjectContainerUpdateTransform = PI
  * @param {PIXI.DisplayObject|PIXI.Matrix} [targetCoordinateSpace] Returns a rectangle that defines the area of the display object relative to the coordinate system of the targetCoordinateSpace object.
  * @return {Rectangle} The rectangular bounding area
  */
-PIXI.DisplayObjectContainer.prototype.getBounds = function (targetCoordinateSpace)
+PIXI.DisplayObjectContainer.prototype.getBounds = function(targetCoordinateSpace)
 {
     var isTargetCoordinateSpaceDisplayObject = targetCoordinateSpace && targetCoordinateSpace instanceof PIXI.DisplayObject;
     var isTargetCoordinateSpaceThisOrParent = true;
 
-    if (!isTargetCoordinateSpaceDisplayObject) {
+    if (!isTargetCoordinateSpaceDisplayObject) 
+	{
         targetCoordinateSpace = this;
-    } else if (targetCoordinateSpace instanceof PIXI.DisplayObjectContainer) {
+    } 
+	else if (targetCoordinateSpace instanceof PIXI.DisplayObjectContainer) 
+	{
         isTargetCoordinateSpaceThisOrParent = targetCoordinateSpace.contains(this);
-    } else {
+    } 
+	else 
+	{
         isTargetCoordinateSpaceThisOrParent = false;
     }
 
@@ -343,7 +348,8 @@ PIXI.DisplayObjectContainer.prototype.getBounds = function (targetCoordinateSpac
 
         targetCoordinateSpace.worldTransform = PIXI.identityMatrix;
 
-        for (i = 0; i < targetCoordinateSpace.children.length; i++) {
+        for (i = 0; i < targetCoordinateSpace.children.length; i++) 
+		{
             targetCoordinateSpace.children[i].updateTransform();
         }
     }
@@ -383,7 +389,8 @@ PIXI.DisplayObjectContainer.prototype.getBounds = function (targetCoordinateSpac
 
     var bounds = this._bounds;
 
-    if (!childVisible) {
+    if (!childVisible) 
+	{
         bounds = new PIXI.Rectangle();
 
         var w0 = bounds.x;
@@ -441,15 +448,18 @@ PIXI.DisplayObjectContainer.prototype.getBounds = function (targetCoordinateSpac
     bounds.width = maxX - minX;
     bounds.height = maxY - minY;
 
-    if (isTargetCoordinateSpaceDisplayObject) {
+    if (isTargetCoordinateSpaceDisplayObject) 
+	{
         targetCoordinateSpace.worldTransform = matrixCache;
 
-        for (i = 0; i < targetCoordinateSpace.children.length; i++) {
+        for (i = 0; i < targetCoordinateSpace.children.length; i++) 
+		{
             targetCoordinateSpace.children[i].updateTransform();
         }
     }
 
-    if (!isTargetCoordinateSpaceThisOrParent) {
+    if (!isTargetCoordinateSpaceThisOrParent) 
+	{
         var targetCoordinateSpaceBounds = targetCoordinateSpace.getBounds();
 
         bounds.x -= targetCoordinateSpaceBounds.x;
@@ -481,10 +491,12 @@ PIXI.DisplayObjectContainer.prototype.contains = function (child) {
     if (!child)
         return false;
 
-    if (child === this) {
+    if (child === this) 
+	{
         return true;
     }
-    else {
+    else 
+	{
         return this.contains(child.parent);
     }
 }

--- a/typescript/pixi.comments.d.ts
+++ b/typescript/pixi.comments.d.ts
@@ -796,7 +796,7 @@ declare module PIXI {
         y: number;
 
         click(e: InteractionData): void;
-        displayObjectUpdateTransform(targetCoordinateSpace?: PIXI.DisplayObject): void;
+        displayObjectUpdateTransform(parent?: DisplayObjectContainer): void;
         generateTexture(resolution?: number, scaleMode?: number, renderer?: PixiRenderer | number): RenderTexture;
         mousedown(e: InteractionData): void;
         mouseout(e: InteractionData): void;
@@ -816,7 +816,7 @@ declare module PIXI {
         touchendoutside(e: InteractionData): void;
         touchstart(e: InteractionData): void;
         touchmove(e: InteractionData): void;
-        updateTransform(targetCoordinateSpace?: PIXI.DisplayObject): void;
+        updateTransform(parent?: DisplayObjectContainer): void;
 
     }
 
@@ -878,11 +878,11 @@ declare module PIXI {
         addChildAt(child: DisplayObject, index: number): DisplayObject;
 
         /**
-        * Retrieves the bounds of the displayObjectContainer as a rectangle. The bounds calculation takes all visible children into consideration.
-        * @param targetCoordinateSpace The targetCoordinateSpace to calculate the bounds from.
+        * Retrieves the global bounds of the displayObjectContainer as a rectangle. The bounds calculation takes all visible children into consideration.
+        * @param targetCoordinateSpace Returns a rectangle that defines the area of the display object relative to the coordinate system of the targetCoordinateSpace object.
         * @return The rectangular bounding area
         */
-        getBounds(targetCoordinateSpace?: PIXI.DisplayObject | Matrix): Rectangle;
+        getBounds(targetCoordinateSpace?: DisplayObject | Matrix): Rectangle;
 
         /**
         * Returns the child at the specified index
@@ -950,6 +950,13 @@ declare module PIXI {
         * @param child2 -
         */
         swapChildren(child: DisplayObject, child2: DisplayObject): void;
+
+        /**
+        * Determines whether the specified display object is a child of the DisplayObjectContainer instance or the instance itself.
+        * 
+        * @param child
+        */
+        contains(child: DisplayObject): boolean;
 
     }
 

--- a/typescript/pixi.comments.d.ts
+++ b/typescript/pixi.comments.d.ts
@@ -796,9 +796,7 @@ declare module PIXI {
         y: number;
 
         click(e: InteractionData): void;
-        displayObjectUpdateTransform(): void;
-        getBounds(matrix?: Matrix): Rectangle;
-        getLocalBounds(): Rectangle;
+        displayObjectUpdateTransform(targetCoordinateSpace?: PIXI.DisplayObject): void;
         generateTexture(resolution?: number, scaleMode?: number, renderer?: PixiRenderer | number): RenderTexture;
         mousedown(e: InteractionData): void;
         mouseout(e: InteractionData): void;
@@ -818,7 +816,7 @@ declare module PIXI {
         touchendoutside(e: InteractionData): void;
         touchstart(e: InteractionData): void;
         touchmove(e: InteractionData): void;
-        updateTransform(parent?: PIXI.DisplayObjectContainer): void;
+        updateTransform(targetCoordinateSpace?: PIXI.DisplayObject): void;
 
     }
 
@@ -881,9 +879,10 @@ declare module PIXI {
 
         /**
         * Retrieves the bounds of the displayObjectContainer as a rectangle. The bounds calculation takes all visible children into consideration.
+        * @param targetCoordinateSpace The targetCoordinateSpace to calculate the bounds from.
         * @return The rectangular bounding area
         */
-        getBounds(): Rectangle;
+        getBounds(targetCoordinateSpace?: PIXI.DisplayObject | Matrix): Rectangle;
 
         /**
         * Returns the child at the specified index

--- a/typescript/pixi.d.ts
+++ b/typescript/pixi.d.ts
@@ -484,7 +484,7 @@ declare module PIXI {
         y: number;
 
         click(e: InteractionData): void;
-        displayObjectUpdateTransform(targetCoordinateSpace?: PIXI.DisplayObject): void
+        displayObjectUpdateTransform(parent?: DisplayObjectContainer): void;
         generateTexture(resolution?: number, scaleMode?: number, renderer?: PixiRenderer | number): RenderTexture;
         mousedown(e: InteractionData): void;
         mouseout(e: InteractionData): void;
@@ -504,7 +504,7 @@ declare module PIXI {
         touchendoutside(e: InteractionData): void;
         touchstart(e: InteractionData): void;
         touchmove(e: InteractionData): void;
-        updateTransform(parent?: PIXI.DisplayObjectContainer): void;
+        updateTransform(parent?: DisplayObjectContainer): void;
 
     }
 
@@ -519,7 +519,7 @@ declare module PIXI {
 
         addChild(child: DisplayObject): DisplayObject;
         addChildAt(child: DisplayObject, index: number): DisplayObject;
-        getBounds(targetCoordinateSpace?: PIXI.DisplayObject | Matrix): Rectangle;
+        getBounds(targetCoordinateSpace?: DisplayObject | Matrix): Rectangle;
         getChildAt(index: number): DisplayObject;
         getChildIndex(child: DisplayObject): number;
         getLocalBounds(): Rectangle;
@@ -529,6 +529,7 @@ declare module PIXI {
         removeStageReference(): void;
         setChildIndex(child: DisplayObject, index: number): void;
         swapChildren(child: DisplayObject, child2: DisplayObject): void;
+        contains(child: DisplayObject): boolean;
 
     }
 

--- a/typescript/pixi.d.ts
+++ b/typescript/pixi.d.ts
@@ -484,9 +484,7 @@ declare module PIXI {
         y: number;
 
         click(e: InteractionData): void;
-        displayObjectUpdateTransform(): void;
-        getBounds(matrix?: Matrix): Rectangle;
-        getLocalBounds(): Rectangle;
+        displayObjectUpdateTransform(targetCoordinateSpace?: PIXI.DisplayObject): void
         generateTexture(resolution?: number, scaleMode?: number, renderer?: PixiRenderer | number): RenderTexture;
         mousedown(e: InteractionData): void;
         mouseout(e: InteractionData): void;
@@ -521,7 +519,7 @@ declare module PIXI {
 
         addChild(child: DisplayObject): DisplayObject;
         addChildAt(child: DisplayObject, index: number): DisplayObject;
-        getBounds(): Rectangle;
+        getBounds(targetCoordinateSpace?: PIXI.DisplayObject | Matrix): Rectangle;
         getChildAt(index: number): DisplayObject;
         getChildIndex(child: DisplayObject): number;
         getLocalBounds(): Rectangle;


### PR DESCRIPTION
The PR changes include:
* TypeScript Defs
* Nothing, it's a bug fix

I noticed that getting dimensions or bounds changed in Phaser 2.6.1 and it was bugged - returned dimensions were doubled in the direction of the scaling for example, but the nice thing was that this time the dimensions included the rotation of the object - which I think should be the default behavior. It also bugged getLocalBounds which started returning global getBounds();
When I checked the previous version of phaser 2.5.0 - total different story. getLocalBounds returns the object without any transformations to it. Getting width and height works ok, but rotation wasn't calculated to the dimensions at all.
In all cases only getBounds returned proper dimensions, which is obviously not enough and this is also a very important issue to be resolved as soon as possible since it's a major core component feature used all the time.
That's why I decided to spare the time and hopefully find a good fix for all of this mess and I think I finally got there and tried to make the changes as much as possible with your Code of Conduct. This is actually the first time I am requesting a pull so I hope it will do some good. I did compare my results with how Flash handles dimensions - they match, so I do hope I didn't miss something and believe you guys would make sure everything works ok.
To help you with reviewing and possibly (and hopefully) accepting this pull request I've made available online 3 demos of the issues and with demo of the fix of course - check the console log:
1. http://www.nedyalkov.net/filip/demos/phaser/IncorrectDisplayObjectDimensionsDemo_v2.5.0/
2. http://www.nedyalkov.net/filip/demos/phaser/IncorrectDisplayObjectDimensionsDemo_v2.6.1/
3. http://www.nedyalkov.net/filip/demos/phaser/IncorrectDisplayObjectDimensionsDemoFixed_v2.6.1/

Here is a zip file of the demo projects (build with VS2015):
http://www.nedyalkov.net/filip/demos/phaser/IncorrectDisplayObjectDimensionsDemos.zip

I really hope to see this FIX in the next version - would help me and a lot of people I guess to get the job done properly!

Thank you!