### PR TITLE
jsdoc fix: replace #onTop for #onCeiling

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1035,7 +1035,7 @@ Phaser.Loader.prototype = {
     *
     * The URL can be relative or absolute. If the URL is relative the `Loader.baseURL` and `Loader.path` values will be prepended to it.
     *
-    * @method Phaser.Loader#audiosprite
+    * @method Phaser.Loader#audioSprite
     * @param {string} key - Unique asset key of the audio file.
     * @param {Array|string} urls - An array containing the URLs of the audio files, i.e.: [ 'audiosprite.mp3', 'audiosprite.ogg', 'audiosprite.m4a' ] or a single string containing just one URL.
     * @param {string} [jsonURL=null] - The URL of the audiosprite configuration JSON object. If you wish to pass the data directly set this parameter to null.

--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1219,7 +1219,7 @@ Phaser.Physics.Arcade.Body.prototype = {
     /**
     * Returns true if the top of this Body is in contact with either the world bounds or a tile.
     *
-    * @method Phaser.Physics.Arcade.Body#onTop
+    * @method Phaser.Physics.Arcade.Body#onCeiling
     * @return {boolean} True if in contact with either the world bounds or a tile.
     */
     onCeiling: function(){


### PR DESCRIPTION
This PR changes

* Documentation

Describe the changes below:


Modified the jsdoc of Phaser.Arcade.Body.onCeiling, by replacing the #onTop reference for #onCeiling.
Modified the jsdoc of Phaser.Loader.audioSprite, by replacing the #autiosprite reference for #audioSprite.