### PR TITLE
jsdoc fix: complete the Phaser.Line.intersectsRectangle @method tag

### DIFF
--- a/src/geom/Line.js
+++ b/src/geom/Line.js
@@ -638,7 +638,7 @@ Phaser.Line.intersects = function (a, b, asSegment, result) {
 *
 * The for the purposes of this function rectangles are considered 'solid'.
 *
-* @method intersectsRectangle
+* @method Phaser.Line.intersectsRectangle
 * @param {Phaser.Line} line - The line to check for intersection with.
 * @param {Phaser.Rectangle|object} rect - The rectangle, or rectangle-like object, to check for intersection with.
 * @return {boolean} True if the line intersects with the rectangle edges, or starts or ends within the rectangle.


### PR DESCRIPTION
This PR changes 

* Documentation

Describe the changes below:


Complete the @method tag of Phaser.Line.intersectsRectangle with the class prefix.