### PR TITLE
Check if hidden is available first

### DIFF
--- a/src/core/Stage.js
+++ b/src/core/Stage.js
@@ -226,7 +226,11 @@ Phaser.Stage.prototype.updateTransform = function () {
 */
 Phaser.Stage.prototype.checkVisibility = function () {
 
-    if (document.webkitHidden !== undefined)
+    if (document.hidden !== undefined)
+    {
+        this._hiddenVar = 'visibilitychange';
+    }
+    else if (document.webkitHidden !== undefined)
     {
         this._hiddenVar = 'webkitvisibilitychange';
     }
@@ -237,10 +241,6 @@ Phaser.Stage.prototype.checkVisibility = function () {
     else if (document.msHidden !== undefined)
     {
         this._hiddenVar = 'msvisibilitychange';
-    }
-    else if (document.hidden !== undefined)
-    {
-        this._hiddenVar = 'visibilitychange';
     }
     else
     {


### PR DESCRIPTION
This PR changes
* Nothing, it's a bug fix

Check if 'document.hidden' is available first, and if it is then never even check for the prefix version. That will stop the warning (like "mozHidden and mozVisibilityState are deprecated") in newer versions of browsers and retain backward compatibility.

