### PR TITLE
Allow animation speed greater than 0

### DIFF
--- a/src/animation/Animation.js
+++ b/src/animation/Animation.js
@@ -768,19 +768,19 @@ Object.defineProperty(Phaser.Animation.prototype, 'frame', {
 
 /**
 * @name Phaser.Animation#speed
-* @property {number} speed - Gets or sets the current speed of the animation in frames per second. Changing this in a playing animation will take effect from the next frame. Minimum value is 1.
+* @property {number} speed - Gets or sets the current speed of the animation in frames per second. Changing this in a playing animation will take effect from the next frame. Value must be greater than 0.
 */
 Object.defineProperty(Phaser.Animation.prototype, 'speed', {
 
     get: function () {
 
-        return Math.round(1000 / this.delay);
+        return 1000 / this.delay;
 
     },
 
     set: function (value) {
 
-        if (value >= 1)
+        if (value > 0)
         {
             this.delay = 1000 / value;
         }


### PR DESCRIPTION
This PR changes
* Documentation (jsdoc)
* Nothing, it's a bug fix

`Animation.speed=` sets delay to 1000 / value if value is greater than or equal to 1. However, setting delay directly allows for animation delays greater than 1000. Therefore, changing `Animation.speed=` to allow for speed greater than 0.