### PR TITLE
Fixed widthInPixels/heightInPixels for JSON tilemaps and TilemapLayerGL display width/height

### DIFF
--- a/src/tilemap/TilemapLayerGL.js
+++ b/src/tilemap/TilemapLayerGL.js
@@ -337,8 +337,8 @@ Phaser.TilemapLayerGL.prototype.destroy = function() {
 Phaser.TilemapLayerGL.prototype.resize = function (width, height) {
 
     //  These setters will automatically update any linked children
-    this.displayWidth = width;
-    this.displayHeight = height;
+    this.width = width;
+    this.height = height;
 
     this.dirty = true;
 
@@ -512,16 +512,12 @@ Phaser.TilemapLayerGL.prototype.renderRegion = function (scrollX, scrollY, left,
 * @private
 */
 Phaser.TilemapLayerGL.prototype.renderFull = function () {
-    
+
     var scrollX = this._mc.scrollX;
     var scrollY = this._mc.scrollY;
 
-    // var renderW = this.game._width;
-    // var renderH = this.game._height;
-
-    //  displayWidth surely?
-    var renderW = this.game._width;
-    var renderH = this.game._height;
+    var renderW = this._displayWidth;
+    var renderH = this._displayHeight;
 
     var tw = this._mc.tileWidth;
     var th = this._mc.tileHeight;

--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -201,8 +201,8 @@ Phaser.TilemapParser = {
             format: Phaser.Tilemap.TILED_JSON,
             version: json.version,
             properties: json.properties,
-            widthInPixels: json.width * json.tileWidth,
-            heightInPixels: json.height * json.tileHeight
+            widthInPixels: json.width * json.tilewidth,
+            heightInPixels: json.height * json.tileheight
         };
 
         //  Tile Layers


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

---

Fixed a few of bugs that my current project brought to light.

- `widthInPixels` and `heightInPixels` were being read incorrectly from JSON data (capitalisation of properties)
- `TilemapLayerGL#resize` was setting the wrong property
- `TilemapLayerGL#renderFull` was using `this.game._width`/`height` instead of its own display width/height

