### PR TITLE
Fixes #1707 Game resolution is passed into PIXI.BaseTexture

### DIFF
--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -121,7 +121,7 @@ Phaser.BitmapData = function (game, key, width, height, skipPool) {
     * @property {PIXI.BaseTexture} baseTexture - The PIXI.BaseTexture.
     * @default
     */
-    this.baseTexture = new PIXI.BaseTexture(this.canvas);
+    this.baseTexture = new PIXI.BaseTexture(this.canvas, null, this.game.resolution);
 
     /**
     * @property {PIXI.Texture} texture - The PIXI.Texture.

--- a/src/gameobjects/Video.js
+++ b/src/gameobjects/Video.js
@@ -247,12 +247,12 @@ Phaser.Video = function (game, key, url) {
     */
     if (this.video && !url)
     {
-        this.baseTexture = new PIXI.BaseTexture(this.video);
+        this.baseTexture = new PIXI.BaseTexture(this.video, null, this.game.resolution);
         this.baseTexture.forceLoaded(this.width, this.height);
     }
     else
     {
-        this.baseTexture = new PIXI.BaseTexture(Phaser.Cache.DEFAULT.baseTexture.source);
+        this.baseTexture = new PIXI.BaseTexture(Phaser.Cache.DEFAULT.baseTexture.source, null, this.game.resolution);
         this.baseTexture.forceLoaded(this.width, this.height);
     }
 

--- a/src/loader/Cache.js
+++ b/src/loader/Cache.js
@@ -264,7 +264,7 @@ Phaser.Cache.prototype = {
             key: key,
             url: url,
             data: data,
-            base: new PIXI.BaseTexture(data),
+            base: new PIXI.BaseTexture(data, null, this.game.resolution),
             frame: new Phaser.Frame(0, 0, 0, data.width, data.height, key),
             frameData: new Phaser.FrameData()
         };
@@ -477,7 +477,7 @@ Phaser.Cache.prototype = {
             url: url,
             data: data,
             font: null,
-            base: new PIXI.BaseTexture(data)
+            base: new PIXI.BaseTexture(data, null, this.game.resolution)
         };
 
         if (xSpacing === undefined) { xSpacing = 0; }
@@ -603,7 +603,7 @@ Phaser.Cache.prototype = {
             frameHeight: frameHeight,
             margin: margin,
             spacing: spacing,
-            base: new PIXI.BaseTexture(data),
+            base: new PIXI.BaseTexture(data, null, this.game.resolution),
             frameData: Phaser.AnimationParser.spriteSheet(this.game, data, frameWidth, frameHeight, frameMax, margin, spacing)
         };
 
@@ -629,7 +629,7 @@ Phaser.Cache.prototype = {
             key: key,
             url: url,
             data: data,
-            base: new PIXI.BaseTexture(data)
+            base: new PIXI.BaseTexture(data, null, this.game.resolution)
         };
 
         if (format === Phaser.Loader.TEXTURE_ATLAS_XML_STARLING)

--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -9,9 +9,10 @@
  * @uses EventTarget
  * @constructor
  * @param source {String|Canvas} the source object (image or canvas)
- * @param scaleMode {Number} See {{#crossLink "PIXI/scaleModes:property"}}PIXI.scaleModes{{/crossLink}} for possible values
+ * @param [scaleMode] {Number} See {{#crossLink "PIXI/scaleModes:property"}}PIXI.scaleModes{{/crossLink}} for possible values
+ * @param [resolution] {Number} the resolution of the texture for devices with different pixel ratios
  */
-PIXI.BaseTexture = function(source, scaleMode)
+PIXI.BaseTexture = function(source, scaleMode, resolution)
 {
     /**
      * The Resolution of the texture. 
@@ -19,7 +20,7 @@ PIXI.BaseTexture = function(source, scaleMode)
      * @property resolution
      * @type Number
      */
-    this.resolution = 1;
+    this.resolution = resolution || 1;
     
     /**
      * [read-only] The width of the base texture set when the image has loaded

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -74,7 +74,7 @@ Phaser.TilemapLayer = function (game, tilemap, index, width, height) {
     */
     this.context = this.canvas.getContext('2d');
 
-    this.setTexture(new PIXI.Texture(new PIXI.BaseTexture(this.canvas)));
+    this.setTexture(new PIXI.Texture(new PIXI.BaseTexture(this.canvas, null, this.game.resolution)));
 
     /**
     * The const type of this object.

--- a/src/tilemap/TilemapLayerGL.js
+++ b/src/tilemap/TilemapLayerGL.js
@@ -246,7 +246,7 @@ Phaser.TilemapLayerGL = function (game, tilemap, index, width, height, tileset) 
     */
     this._scrollY = 0;
 
-    var baseTexture = new PIXI.BaseTexture(tileset.image);
+    var baseTexture = new PIXI.BaseTexture(tileset.image, null, this.game.resolution);
 
     PIXI.Tilemap.call(this, new PIXI.Texture(baseTexture), width, height, this.map.width, this.map.height, this._mc.tileset.tileWidth, this._mc.tileset.tileHeight, this.layer);
 


### PR DESCRIPTION
This PR changes
- Nothing, it's a bug fix

This adds support for `resolution` as 3rd argument for `PIXI.BaseTexture`, see https://pixijs.github.io/docs/PIXI.BaseTexture.html

Anywhere that previously instantiated a `PIXI.BaseTexture` now attempts to pass through the `game.resolution` property. The property is optional and is backwards compatible.

Also a minor JSDoc fix, `scaleMode` is also an optional param for `PIXI.BaseTexture`.
