### PR TITLE
Use centerX, centerY in Phaser.Line#fromSprite

### DIFF
--- a/src/geom/Line.js
+++ b/src/geom/Line.js
@@ -67,7 +67,7 @@ Phaser.Line.prototype = {
     * @method Phaser.Line#fromSprite
     * @param {Phaser.Sprite} startSprite - The coordinates of this Sprite will be set to the Line.start point.
     * @param {Phaser.Sprite} endSprite - The coordinates of this Sprite will be set to the Line.start point.
-    * @param {boolean} [useCenter=false] - If true it will use startSprite.center.x, if false startSprite.x. Note that Sprites don't have a center property by default, so only enable if you've over-ridden your Sprite with a custom class.
+    * @param {boolean} [useCenter=false] - If true it will use startSprite.centerX, if false startSprite.x.
     * @return {Phaser.Line} This line object
     */
     fromSprite: function (startSprite, endSprite, useCenter) {
@@ -76,7 +76,7 @@ Phaser.Line.prototype = {
 
         if (useCenter)
         {
-            return this.setTo(startSprite.center.x, startSprite.center.y, endSprite.center.x, endSprite.center.y);
+            return this.setTo(startSprite.centerX, startSprite.centerY, endSprite.centerX, endSprite.centerY);
         }
 
         return this.setTo(startSprite.x, startSprite.y, endSprite.x, endSprite.y);


### PR DESCRIPTION
This PR changes

* The public-facing API

This is an incompatible change but since Sprites have never had a `center` property it seems appropriate.



