### PR TITLE
Correct Tween#frameBased docs:

### DIFF
--- a/src/time/Time.js
+++ b/src/time/Time.js
@@ -18,14 +18,14 @@
 *
 *   Unlike wall-clock time, *game time stops when Phaser is paused*.
 *
-*   Game time is used for {@link Phaser.Timer timer events}.
+*   Game time is used for {@link Phaser.Timer timer events} and {@link Phaser.Tween tweens} when `Tween.frameBased` is false.
 *
 * - ***Physics time*** represents the amount of time given to physics calculations.
 *
 *   *When {@link #slowMotion} is in effect physics time runs slower than game time.*
 *   Like game time, physics time stops when Phaser is paused.
 *
-*   Physics time is used for physics calculations and {@link Phaser.Tween tweens}.
+*   Physics time is used for physics calculations and {@link Phaser.Tween tweens} when `Tween.frameBased` is true.
 *
 * - {@link https://en.wikipedia.org/wiki/Wall-clock_time ***Wall-clock time***} represents the duration between two events in real life time.
 *

--- a/src/tween/Tween.js
+++ b/src/tween/Tween.js
@@ -136,13 +136,12 @@ Phaser.Tween = function (target, game, manager) {
     this.isPaused = false;
 
     /**
-    * Is this Tween frame or time based? A frame based tween will use the physics elapsed timer when updating. This means
-    * it will retain the same consistent frame rate, regardless of the speed of the device. The duration value given should
-    * be given in frames.
+    * Is this Tween frame or time based? A frame based tween will use the physics elapsed timer when updating.
+    * This means it will retain the same consistent frame rate, regardless of the speed of the device.
     *
-    * If the Tween uses a time based update (which is the default) then the duration is given in milliseconds.
-    * In this situation a 2000ms tween will last exactly 2 seconds, regardless of the device and how many visual updates the tween
-    * has actually been through. For very short tweens you may wish to experiment with a frame based update instead.
+    * If the Tween uses a time based update (which is the default) a 2000ms tween will last exactly 2 seconds,
+    * regardless of the device and how many visual updates the tween has actually been through.
+    * For very short tweens you may wish to experiment with a frame based update instead.
     *
     * The default value is whatever you've set in TweenManager.frameBased.
     *
@@ -195,7 +194,7 @@ Phaser.Tween.prototype = {
     *
     * @method Phaser.Tween#to
     * @param {object} properties - An object containing the properties you want to tween, such as `Sprite.x` or `Sound.volume`. Given as a JavaScript object.
-    * @param {number} [duration=1000] - Duration of this tween in ms. Or if `Tween.frameBased` is true this represents the number of frames that should elapse.
+    * @param {number} [duration=1000] - Duration of this tween in ms.
     * @param {function|string} [ease=null] - Easing function. If not set it will default to Phaser.Easing.Default, which is Phaser.Easing.Linear.None by default but can be over-ridden.
     * @param {boolean} [autoStart=false] - Set to `true` to allow this tween to start automatically. Otherwise call Tween.start().
     * @param {number} [delay=0] - Delay before this tween will start in milliseconds. Defaults to 0, no delay.
@@ -242,7 +241,7 @@ Phaser.Tween.prototype = {
     *
     * @method Phaser.Tween#from
     * @param {object} properties - An object containing the properties you want to tween., such as `Sprite.x` or `Sound.volume`. Given as a JavaScript object.
-    * @param {number} [duration=1000] - Duration of this tween in ms. Or if `Tween.frameBased` is true this represents the number of frames that should elapse.
+    * @param {number} [duration=1000] - Duration of this tween in ms.
     * @param {function|string} [ease=null] - Easing function. If not set it will default to Phaser.Easing.Default, which is Phaser.Easing.Linear.None by default but can be over-ridden.
     * @param {boolean} [autoStart=false] - Set to `true` to allow this tween to start automatically. Otherwise call Tween.start().
     * @param {number} [delay=0] - Delay before this tween will start in milliseconds. Defaults to 0, no delay.

--- a/src/tween/TweenManager.js
+++ b/src/tween/TweenManager.js
@@ -25,13 +25,12 @@ Phaser.TweenManager = function (game) {
     this.game = game;
 
     /**
-    * Are all newly created Tweens frame or time based? A frame based tween will use the physics elapsed timer when updating. This means
-    * it will retain the same consistent frame rate, regardless of the speed of the device. The duration value given should
-    * be given in frames.
+    * Are all newly created Tweens frame or time based? A frame based tween will use the physics elapsed timer when updating.
+    * This means it will retain the same consistent frame rate, regardless of the speed of the device.
     * 
-    * If the Tween uses a time based update (which is the default) then the duration is given in milliseconds.
-    * In this situation a 2000ms tween will last exactly 2 seconds, regardless of the device and how many visual updates the tween
-    * has actually been through. For very short tweens you may wish to experiment with a frame based update instead.
+    * If the Tween uses a time based update (which is the default) then a 2000ms tween will last exactly 2 seconds,
+    * regardless of the device and how many visual updates the tween has actually been through.
+    * For very short tweens you may wish to experiment with a frame based update instead.
     * @property {boolean} frameBased
     * @default
     */


### PR DESCRIPTION
This PR changes
- Documentation

Duration of frame-based tweens is in ms, not frames.

Tweens run in game time by default.

Thanks [Cola_Colin](http://www.html5gamedevs.com/topic/25156-confused-about-timing-systems-in-phaser/).
