### PR TITLE
Phaser.Math.between fixes & added Phaser.Math.random

### DIFF
--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -27,10 +27,10 @@ Phaser.Math = {
     * Returns a random float in the range `[min, max)`. If these parameters are not in order than they will be put in order.
     * Default is 0 for `min` and 1 for `max`.
     *
-    * @method Phaser.Math#between
+    * @method Phaser.Math#random
     * @param {number} min - The minimum value. Must be a Number.
     * @param {number} max - The maximum value. Must be a Number.
-    * @return {number} A floating point number between the range min to max.
+    * @return {number} A floating point number between min (inclusive) and max (exclusive).
     */
     random: function (min, max) {
         if (min === undefined) { min = 0; }
@@ -52,7 +52,7 @@ Phaser.Math = {
     * @method Phaser.Math#between
     * @param {number} min - The minimum value. Must be a Number.
     * @param {number} max - The maximum value. Must be a Number.
-    * @return {number} A floating point number between the range min to max.
+    * @return {number} An integer between min (inclusive) and max (inclusive).
     */
     between: function (min, max) {
         if (min === undefined) { min = 0; }

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -24,17 +24,49 @@ Phaser.Math = {
     PI2: Math.PI * 2,
 
     /**
-    * Returns a number between the `min` and `max` values.
+    * Returns a random float in the range `[min, max)`. If these parameters are not in order than they will be put in order.
+    * Default is 0 for `min` and 1 for `max`.
     *
     * @method Phaser.Math#between
-    * @param {number} min - The minimum value. Must be positive, and less than 'max'.
-    * @param {number} max - The maximum value. Must be position, and greater than 'min'.
-    * @return {number} A value between the range min to max.
+    * @param {number} min - The minimum value. Must be a Number.
+    * @param {number} max - The maximum value. Must be a Number.
+    * @return {number} A floating point number between the range min to max.
+    */
+    random: function (min, max) {
+        if (min === undefined) { min = 0; }
+        if (max === undefined) { max = 1; }
+
+        if ( min < max ) {
+            var temp = min;
+            min = max;
+            max = temp;
+        }
+
+        return Math.random() * (max - min) + min;
+    },
+
+    /**
+    * Returns a random integer in the range `[min, max]`. If these parameters are not in order than they will be put in order.
+    * Default is 0 for `min` and 1 for `max`.
+    *
+    * @method Phaser.Math#between
+    * @param {number} min - The minimum value. Must be a Number.
+    * @param {number} max - The maximum value. Must be a Number.
+    * @return {number} A floating point number between the range min to max.
     */
     between: function (min, max) {
+        if (min === undefined) { min = 0; }
+        if (max === undefined) { max = 1; }
 
-        return Math.floor(Math.random() * (max - min + 1) + min);
+        if ( min < max ) {
+            var temp = min;
+            min = max;
+            max = temp;
+        }
 
+        min = Math.ceil(min);
+        max = Math.floor(max);
+        return Math.floor(Math.random() * (max - min + 1)) + min;
     },
 
     /**

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2564,6 +2564,7 @@ declare module Phaser {
         static angleBetweenPointsY(point1: Phaser.Point, point2: Phaser.Point): number;
         static average(...numbers: number[]): number;
         static bernstein(n: number, i: number): number;
+        static random(min: number, max: number): number;
         static between(min: number, max: number): number;
         static bezierInterpolation(v: number[], k: number): number;
         static catmullRom(p0: number, p1: number, p2: number, p3: number, t: number): number;


### PR DESCRIPTION
This PR changes (delete as applicable)

* Documentation
* TypeScript Defs
* The public-facing API

Fixed docs for Phaser.Math.between(min,max), made it a bit more robust, added a random(min,max) function that acts the same as between(), but returns a floating point.

Ref https://github.com/photonstorm/phaser/issues/2758

