### PR TITLE
On Bitmapdata.copy if the source texture has trimming and scaling app…

### DIFF
--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -1403,9 +1403,8 @@ Phaser.BitmapData.prototype = {
         }
 
         //  Doesn't work fully with children, or nested scale + rotation transforms (see copyTransform)
-        ctx.translate(tx, ty);
-
         ctx.scale(this._scale.x, this._scale.y);
+        ctx.translate(tx, ty);
 
         ctx.rotate(this._rotate);
 


### PR DESCRIPTION
This PR changes:
- Nothing, it's a bug fix

On `Bitmapdata.copy` if the source texture has trimming and scaling applied to it, the trim values were previously not being scaled relative to the texture.

By reversing the order of these `scale` and `translate` calls, translations correctly account for scaling.
