### PR TITLE
Fix path for phaser in the requirejs project template

### DIFF
--- a/resources/Project Templates/RequireJS/src/main.js
+++ b/resources/Project Templates/RequireJS/src/main.js
@@ -5,7 +5,8 @@
         baseUrl: "src/",
         
         paths: {
-            //  Edit the below path to point to where-ever you have placed the phaser.min.js file
+            // phaser.min.js library location, by default this is the location where bower will place it.
+            // Feel free to edit the below path to point to wherever you have placed this file.
             phaser: 'libs/phaser/build/phaser.min'
         },
 

--- a/resources/Project Templates/RequireJS/src/main.js
+++ b/resources/Project Templates/RequireJS/src/main.js
@@ -6,7 +6,7 @@
         
         paths: {
             //  Edit the below path to point to where-ever you have placed the phaser.min.js file
-            phaser: 'libs/phaser/phaser.min'
+            phaser: 'libs/phaser/build/phaser.min'
         },
 
         shim: {


### PR DESCRIPTION
This PR changes (delete as applicable)
- Nothing, it's a bug fix

Describe the changes below:

Fix the requirejs project template for phaser. Looks like the path changed from "libs/phaser" to "libs/phaser/build/"

I am new to phaser, but just wanted to fix this for others as well!
