### PR TITLE
Added property 'smoothBounds' to Phaser.Camera (issue #2774)

### DIFF
--- a/src/core/Camera.js
+++ b/src/core/Camera.js
@@ -54,6 +54,12 @@ Phaser.Camera = function (game, id, x, y, width, height) {
     this.bounds = new Phaser.Rectangle(x, y, width, height);
 
     /**
+    * @property {boolean} smoothBounds - If a Camera has smoothBounds set to `true`, it will interpolate to the new target position when the camera bounds are updated, rather then jumping there immediately.  Interpolation rates are calculated using the values stored in Camera.lerp.
+    * @default
+    */
+    this.smoothBounds = false;
+
+    /**
     * @property {Phaser.Rectangle} deadzone - Moving inside this Rectangle will not cause the camera to move.
     */
     this.deadzone = null;
@@ -679,7 +685,16 @@ Phaser.Camera.prototype = {
         if (vx <= this.bounds.x * this.scale.x)
         {
             this.atLimit.x = true;
-            this.view.x = this.bounds.x * this.scale.x;
+
+            // if smoothBounds enabled, interpolate to new view position (at rate this.lerp.x) instead of jumping.
+            if (this.smoothBounds)
+            {
+                this.view.x = this.game.math.linear(this.view.x, this.bounds.x * this.scale.x, this.lerp.x);
+            }
+            else
+            {
+                this.view.x = this.bounds.x * this.scale.x;
+            }
 
             if (!this._shake.shakeBounds)
             {
@@ -691,7 +706,15 @@ Phaser.Camera.prototype = {
         if (vw >= this.bounds.right * this.scale.x)
         {
             this.atLimit.x = true;
-            this.view.x = (this.bounds.right * this.scale.x) - this.width;
+
+            if (this.smoothBounds)
+            {
+                this.view.x = this.game.math.linear(this.view.x, (this.bounds.right * this.scale.x) - this.width, this.lerp.x);
+            }
+            else
+            {
+                this.view.x = (this.bounds.right * this.scale.x) - this.width;
+            }
 
             if (!this._shake.shakeBounds)
             {
@@ -703,7 +726,15 @@ Phaser.Camera.prototype = {
         if (vy <= this.bounds.top * this.scale.y)
         {
             this.atLimit.y = true;
-            this.view.y = this.bounds.top * this.scale.y;
+
+            if (this.smoothBounds)
+            {
+                this.view.y = this.game.math.linear(this.view.y, this.bounds.top * this.scale.y, this.lerp.y);
+            }
+            else
+            {
+                this.view.y = this.bounds.top * this.scale.y;
+            }
 
             if (!this._shake.shakeBounds)
             {
@@ -715,7 +746,15 @@ Phaser.Camera.prototype = {
         if (vh >= this.bounds.bottom * this.scale.y)
         {
             this.atLimit.y = true;
-            this.view.y = (this.bounds.bottom * this.scale.y) - this.height;
+
+            if (this.smoothBounds)
+            {
+                this.view.y = this.game.math.linear(this.view.y, (this.bounds.bottom * this.scale.y) - this.height, this.lerp.y);
+            }
+            else
+            {
+                this.view.y = (this.bounds.bottom * this.scale.y) - this.height;
+            }
 
             if (!this._shake.shakeBounds)
             {

--- a/src/core/Camera.js
+++ b/src/core/Camera.js
@@ -141,6 +141,12 @@ Phaser.Camera = function (game, id, x, y, width, height) {
     this.fx = null;
 
     /**
+    * @property {Phaser.Point} _smoothBoundsTarget - internal point used for camera interpolation from outside of bounds.
+    * @private
+    */
+    this._smoothBoundsTarget = new Phaser.Point();
+
+    /**
     * @property {Phaser.Point} _targetPosition - Internal point used to calculate target position.
     * @private
     */
@@ -514,6 +520,10 @@ Phaser.Camera.prototype = {
         if (this.bounds)
         {
             this.checkBounds();
+            if (this.smoothBounds) {
+                this.view.x = this.game.math.linear(this.view.x, this._smoothBoundsTarget.x, this.lerp.x);
+                this.view.y = this.game.math.linear(this.view.y, this._smoothBoundsTarget.y, this.lerp.y);
+            }
         }
 
         if (this.roundPx)
@@ -686,10 +696,10 @@ Phaser.Camera.prototype = {
         {
             this.atLimit.x = true;
 
-            // if smoothBounds enabled, interpolate to new view position (at rate this.lerp.x) instead of jumping.
+            // if smoothBounds enabled, set interpolation target instead of jumping.
             if (this.smoothBounds)
             {
-                this.view.x = this.game.math.linear(this.view.x, this.bounds.x * this.scale.x, this.lerp.x);
+                this._smoothBoundsTarget.x = this.bounds.x * this.scale.x;
             }
             else
             {
@@ -709,7 +719,7 @@ Phaser.Camera.prototype = {
 
             if (this.smoothBounds)
             {
-                this.view.x = this.game.math.linear(this.view.x, (this.bounds.right * this.scale.x) - this.width, this.lerp.x);
+                this._smoothBoundsTarget.x = (this.bounds.right * this.scale.x) - this.width;
             }
             else
             {
@@ -729,7 +739,7 @@ Phaser.Camera.prototype = {
 
             if (this.smoothBounds)
             {
-                this.view.y = this.game.math.linear(this.view.y, this.bounds.top * this.scale.y, this.lerp.y);
+                this._smoothBoundsTarget.y = this.bounds.top * this.scale.y;
             }
             else
             {
@@ -749,7 +759,7 @@ Phaser.Camera.prototype = {
 
             if (this.smoothBounds)
             {
-                this.view.y = this.game.math.linear(this.view.y, (this.bounds.bottom * this.scale.y) - this.height, this.lerp.y);
+                this._smoothBoundsTarget.y = (this.bounds.bottom * this.scale.y) - this.height;
             }
             else
             {


### PR DESCRIPTION
This PR changes:
- Documentation
- The public-facing API

Describe the changes below:

`Camera.checkBounds` "snaps" to the Camera's bounds if the Camera is found outside them.  This is a problem for smooth cam movement if the Camera's bounds are changed in-game. 

As a remedy, I added the `Camera.smoothBounds` property, and a check within `Camera.checkBounds` against this property.  If `Camera.smoothBounds` is true, then the Camera will interpolate rather than snapping when it's found outside the bounds.  (This interpolation happens at a rate of `Camera.lerp`.)

See [this issue](https://github.com/photonstorm/phaser/issues/2774) for information.
