### PR TITLE
Some browsers use cancelAnimationFrame with prefix like this msCancel…

### DIFF
--- a/src/utils/RequestAnimationFrame.js
+++ b/src/utils/RequestAnimationFrame.js
@@ -42,7 +42,7 @@ Phaser.RequestAnimationFrame = function(game, forceSetTimeOut) {
     for (var x = 0; x < vendors.length && !window.requestAnimationFrame; x++)
     {
         window.requestAnimationFrame = window[vendors[x] + 'RequestAnimationFrame'];
-        window.cancelAnimationFrame = window[vendors[x] + 'CancelAnimationFrame'];
+        window.cancelAnimationFrame = window[vendors[x] + 'CancelAnimationFrame'] || window[vendors[x] + 'CancelRequestAnimationFrame'];
     }
 
     /**


### PR DESCRIPTION
This PR changes
- Nothing, it's a bug fix

Describe the changes below:

Some prefixes use cancelRequestAnimationFrame instead of cancelAnimationFrame. IE11 is one of those browsers.
