### PR TITLE
Add state property to State class in TypeScript definitions

### DIFF
--- a/src/core/State.js
+++ b/src/core/State.js
@@ -74,7 +74,7 @@ Phaser.State = function () {
     this.stage = null;
 
     /**
-    * @property {Phaser.StateManager} stage - A reference to the State Manager, which controls state changes.
+    * @property {Phaser.StateManager} state - A reference to the State Manager, which controls state changes.
     */
     this.state = null;
 

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -4774,6 +4774,7 @@ declare module Phaser {
         scale: Phaser.ScaleManager;
         sound: Phaser.SoundManager;
         stage: Phaser.Stage;
+        state: Phaser.StateManager;
         time: Phaser.Time;
         tweens: Phaser.TweenManager;
         world: Phaser.World;


### PR DESCRIPTION
This PR changes:
- Documentation
- TypeScript Defs

Specific changes:
- Add state property to State class in TypeScript definitions
- Fix tiny typo in StateManager documentation (stage -> state)

Issue: #2807
