### PR TITLE
Fix missing interpolation context for array-based tweens

### DIFF
--- a/src/tween/TweenData.js
+++ b/src/tween/TweenData.js
@@ -403,7 +403,7 @@ Phaser.TweenData.prototype = {
         {
             return this.repeat();
         }
-        
+
         return Phaser.TweenData.RUNNING;
 
     },
@@ -458,7 +458,7 @@ Phaser.TweenData.prototype = {
 
                 if (Array.isArray(end))
                 {
-                    blob[property] = this.interpolationFunction(end, this.value);
+                    blob[property] = this.interpolationFunction.call(this.interpolationContext, end, this.value);
                 }
                 else
                 {


### PR DESCRIPTION
This PR changes
- Nothing, it's a bug fix

Calling `generateData()` would fail with an error.
