### PR TITLE
Update DisplayObjectContainer.js

### DIFF
--- a/src/pixi/display/DisplayObjectContainer.js
+++ b/src/pixi/display/DisplayObjectContainer.js
@@ -223,10 +223,10 @@ PIXI.DisplayObjectContainer.prototype.removeChildren = function (beginIndex, end
     if (endIndex === undefined) { endIndex = this.children.length; }
 
     var range = endIndex - beginIndex;
-
+    
     if (range > 0 && range <= endIndex)
     {
-        var removed = this.children.splice(begin, range);
+        var removed = this.children.splice(beginIndex, range);
 
         for (var i = 0; i < removed.length; i++)
         {


### PR DESCRIPTION
**Important:** Pull Requests should _only_ be issued against the `dev` branch. PRs against the master branch will always be closed.

This PR changes 

* Nothing, it's a bug fix

Describe the changes below:
incorrect variable name 'begin' is used in PIXI.DisplayObjectContainer.prototype..removeChildren. The correct name is 'beginIndex'

