### PR TITLE
Exclude 'resources' from bower installations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "**/.*",
     "node_modules",
     "bower_components",
+    "resources",
     "test",
     "tests"
   ],


### PR DESCRIPTION
This PR changes

* Files added by `bower install`

`bower install` should omit '/resources' like `npm install` does.


