### PR TITLE
Fixed path in manifests graphics.json. EarCut is now included.

### DIFF
--- a/v2-community/tasks/manifests/graphics.json
+++ b/v2-community/tasks/manifests/graphics.json
@@ -1,5 +1,5 @@
 [
-    "src/phaser/utils/EarCut.js",
+    "src/utils/EarCut.js",
     "src/pixi/renderers/webgl/utils/WebGLGraphics.js",
     "src/pixi/renderers/canvas/CanvasGraphics.js",
     "src/gameobjects/GraphicsData.js",


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:
Fixed error in path for EarCut.
Fixes this:
#https://github.com/photonstorm/phaser/issues/2876
