### PR TITLE
Change return type of Phaser.Group#next to `any`

### DIFF
--- a/v2-community/typescript/phaser.d.ts
+++ b/v2-community/typescript/phaser.d.ts
@@ -1812,7 +1812,7 @@ declare module Phaser {
         moveDown(child: any): any;
         moveUp(child: any): any;
         multiplyAll(property: string, amount: number, checkAlive: boolean, checkVisible: boolean): void;
-        next(): void;
+        next(): any;
         postUpdate(): void;
         preUpdate(): void;
         previous(): void;


### PR DESCRIPTION
This PR changes:

* TypeScript Defs

The defined return type of Phaser.Group#next was previously `void`, which is inaccurate and causes unintended compiler errors.

See https://github.com/photonstorm/phaser/blob/master/v2-community/src/core/Group.js#L839.