### PR TITLE
Fixes 1707 - BaseTexture defaults to resolution of 1

### DIFF
--- a/v2-community/src/gameobjects/BitmapData.js
+++ b/v2-community/src/gameobjects/BitmapData.js
@@ -121,7 +121,7 @@ Phaser.BitmapData = function (game, key, width, height, skipPool) {
     * @property {PIXI.BaseTexture} baseTexture - The PIXI.BaseTexture.
     * @default
     */
-    this.baseTexture = new PIXI.BaseTexture(this.canvas);
+    this.baseTexture = new PIXI.BaseTexture(this.canvas, null, this.game.resolution);
 
     /**
     * @property {PIXI.Texture} texture - The PIXI.Texture.

--- a/v2-community/src/gameobjects/Video.js
+++ b/v2-community/src/gameobjects/Video.js
@@ -254,12 +254,12 @@ Phaser.Video = function (game, key, url) {
     */
     if (this.video && !url)
     {
-        this.baseTexture = new PIXI.BaseTexture(this.video);
+        this.baseTexture = new PIXI.BaseTexture(this.video, null, this.game.resolution);
         this.baseTexture.forceLoaded(this.width, this.height);
     }
     else
     {
-        this.baseTexture = new PIXI.BaseTexture(Phaser.Cache.DEFAULT.baseTexture.source);
+        this.baseTexture = new PIXI.BaseTexture(Phaser.Cache.DEFAULT.baseTexture.source, null, this.game.resolution);
         this.baseTexture.forceLoaded(this.width, this.height);
     }
 

--- a/v2-community/src/loader/Cache.js
+++ b/v2-community/src/loader/Cache.js
@@ -252,7 +252,7 @@ Phaser.Cache.prototype = {
             key: key,
             url: url,
             data: data,
-            base: new PIXI.BaseTexture(data),
+            base: new PIXI.BaseTexture(data, null, this.game.resolution),
             frame: new Phaser.Frame(0, 0, 0, data.width, data.height, key),
             frameData: new Phaser.FrameData(),
             fileFormat: extension
@@ -305,7 +305,7 @@ Phaser.Cache.prototype = {
             key: key,
             url: url,
             data: data,
-            base: new PIXI.BaseTexture(data),
+            base: new PIXI.BaseTexture(data, null, this.game.resolution),
             frame: new Phaser.Frame(0, 0, 0, data.width, data.height, key),
             frameData: new Phaser.FrameData()
         };
@@ -518,7 +518,7 @@ Phaser.Cache.prototype = {
             url: url,
             data: data,
             font: null,
-            base: new PIXI.BaseTexture(data)
+            base: new PIXI.BaseTexture(data, null, this.game.resolution)
         };
 
         if (xSpacing === undefined) { xSpacing = 0; }
@@ -700,7 +700,7 @@ Phaser.Cache.prototype = {
             frameHeight: frameHeight,
             margin: margin,
             spacing: spacing,
-            base: new PIXI.BaseTexture(data),
+            base: new PIXI.BaseTexture(data, null, this.game.resolution),
             frameData: Phaser.AnimationParser.spriteSheet(this.game, data, frameWidth, frameHeight, frameMax, margin, spacing, skipFrames)
         };
 
@@ -726,7 +726,7 @@ Phaser.Cache.prototype = {
             key: key,
             url: url,
             data: data,
-            base: new PIXI.BaseTexture(data)
+            base: new PIXI.BaseTexture(data, null, this.game.resolution)
         };
 
         if (format === Phaser.Loader.TEXTURE_ATLAS_XML_STARLING)

--- a/v2-community/src/pixi/textures/BaseTexture.js
+++ b/v2-community/src/pixi/textures/BaseTexture.js
@@ -10,8 +10,9 @@
  * @constructor
  * @param source {String|Canvas} the source object (image or canvas)
  * @param scaleMode {Number} See {{#crossLink "PIXI/scaleModes:property"}}PIXI.scaleModes{{/crossLink}} for possible values
+ * @param [resolution] {Number} the resolution of the texture (for HiDPI displays)
  */
-PIXI.BaseTexture = function(source, scaleMode)
+PIXI.BaseTexture = function(source, scaleMode, resolution)
 {
     /**
      * The Resolution of the texture. 
@@ -19,7 +20,7 @@ PIXI.BaseTexture = function(source, scaleMode)
      * @property resolution
      * @type Number
      */
-    this.resolution = 1;
+    this.resolution = resolution || 1;
     
     /**
      * [read-only] The width of the base texture set when the image has loaded
@@ -235,9 +236,10 @@ PIXI.BaseTexture.prototype.unloadFromGPU = function()
  * @method fromCanvas
  * @param canvas {Canvas} The canvas element source of the texture
  * @param scaleMode {Number} See {{#crossLink "PIXI/scaleModes:property"}}PIXI.scaleModes{{/crossLink}} for possible values
+ * @param [resolution] {Number} the resolution of the texture (for HiDPI displays)
  * @return {BaseTexture}
  */
-PIXI.BaseTexture.fromCanvas = function(canvas, scaleMode)
+PIXI.BaseTexture.fromCanvas = function(canvas, scaleMode, resolution)
 {
     if (canvas.width === 0)
     {
@@ -249,5 +251,7 @@ PIXI.BaseTexture.fromCanvas = function(canvas, scaleMode)
         canvas.height = 1;
     }
 
-    return new PIXI.BaseTexture(canvas, scaleMode);
+    resolution = resolution || 1;
+
+    return new PIXI.BaseTexture(canvas, scaleMode, resolution);
 };

--- a/v2-community/src/tilemap/TilemapLayer.js
+++ b/v2-community/src/tilemap/TilemapLayer.js
@@ -65,7 +65,7 @@ Phaser.TilemapLayer = function (game, tilemap, index, width, height) {
     */
     this.context = this.canvas.getContext('2d');
 
-    this.setTexture(new PIXI.Texture(new PIXI.BaseTexture(this.canvas)));
+    this.setTexture(new PIXI.Texture(new PIXI.BaseTexture(this.canvas, null, this.game.resolution)));
 
     /**
     * The const type of this object.


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Recreating after move to CE.
Original issue raised: https://github.com/photonstorm/phaser/issues/1707
Original PR was https://github.com/photonstorm/phaser/pull/2704

This adds a third optional param to PIXI.BaseTexture allowing textures to be scaled according to `devicePixelRatio`