### PR TITLE
removeTextureAtlas now deletes the correct cache object.

### DIFF
--- a/v2-community/src/loader/Cache.js
+++ b/v2-community/src/loader/Cache.js
@@ -1987,7 +1987,7 @@ Phaser.Cache.prototype = {
     */
     removeTextureAtlas: function (key) {
 
-        delete this._cache.atlas[key];
+        delete this._cache.image[key];
 
     },
 


### PR DESCRIPTION
Changes:
* Nothing, it's a bug fix

PR for Issue #2893. removeTextureAtlas removes now from the image cache.

