### PR TITLE
Added feature: set character limit with suffix

### DIFF
--- a/v2-community/src/gameobjects/Text.js
+++ b/v2-community/src/gameobjects/Text.js
@@ -139,6 +139,18 @@ Phaser.Text = function (game, x, y, text, style) {
      */
     this.splitRegExp = /(?:\r\n|\r|\n)/;
 
+
+    /** The maximum number of characters that can be set.
+    * @property {number} characterLimitSize
+    */
+    this.characterLimitSize = -1;
+
+    /** The suffix that is applied to truncated text that is longer than the
+    * characterLimitSize.
+    * @property {string} characterLimitSuffix
+    */
+    this.characterLimitSuffix = '';
+
     /**
      * @property {number} _res - Internal canvas resolution var.
      * @private
@@ -374,6 +386,10 @@ Phaser.Text.prototype.updateText = function () {
     this.context.font = this.style.font;
 
     var outputText = this.text;
+
+    if (this.characterLimitSize > -1 && this.characterLimitSize < outputText.length) {
+        outputText = this.text.substring(0, this.characterLimitSize) + this.characterLimitSuffix;
+    }
 
     if (this.style.wordWrap)
     {
@@ -1655,6 +1671,22 @@ Phaser.Text.prototype.getBounds = function (matrix) {
     return PIXI.Sprite.prototype.getBounds.call(this, matrix);
 
 };
+
+/**
+* Sets the character limit of the text, with a suffix.
+* If the text is longer than this limit, it is truncated and the suffix is appended.
+*
+* @method Phaser.Text#setCharacterLimit
+* @param {number} [characterLimit] - The x coordinate of the Text Bounds region.
+* @param {string} [suffix] - The suffix to append to the truncated text.
+*/
+Phaser.Text.prototype.setCharacterLimit = function (characterLimit, suffix) {
+
+    this.characterLimitSuffix = suffix == undefined ? '' : suffix;
+    this.characterLimitSize = characterLimit;
+
+    this.updateText();
+}
 
 /**
 * The text to be displayed by this Text object.


### PR DESCRIPTION
This PR changes (delete as applicable)

* Documentation
* The public-facing API

Describe the changes below:
This is a feature that I implemented at the stage level in previous projects that I thought would be a nice feature of the text object. The feature allows a user to set a character limit on a text, as well as a suffix to append. If the text set is longer than this character limit, then the text is truncated and the suffix is appended (the length of the suffix is not taken into consideration in the length calculation). Useful for things like high-score boards, usernames, generated names with unpredictable lengths etc.

```
text = game.add.text(game.world.centerX, game.world.centerY, "This is a long text! Wow!", {
        font: "65px Arial",
        fill: "#ff0044",
        align: "center"
    });
```
![without_limit](https://cloud.githubusercontent.com/assets/12958979/20789681/a6ba8636-b7b5-11e6-9949-8f283bbd1745.png)

```
text = game.add.text(game.world.centerX, game.world.centerY, "This is a long text! Wow!", {
        font: "65px Arial",
        fill: "#ff0044",
        align: "center"
    });

    text.setCharacterLimit(15, '...');
```

![with_characterlimit](https://cloud.githubusercontent.com/assets/12958979/20789700/b9f52b8e-b7b5-11e6-87d1-f41eb4c16cf6.png)



