### PR TITLE
Added Feature: JustPressed and JustReleased for keyboard input

### DIFF
--- a/v2-community/src/input/Key.js
+++ b/v2-community/src/input/Key.js
@@ -82,6 +82,14 @@ Phaser.Key = function (game, keycode) {
     this.timeUp = -2500;
 
     /**
+    * If the key is up this value holds the duration of that key release and is constantly updated.
+    * If the key is down it holds the duration of the previous up session.
+    * @property {number} duration - The number of milliseconds this key has been up for.
+    * @default
+    */
+    this.durationUp = -2500;
+
+    /**
     * @property {number} repeats - If a key is held down this holds down the number of times the key has 'repeated'.
     * @default
     */
@@ -148,6 +156,10 @@ Phaser.Key.prototype = {
                 this.onHoldCallback.call(this.onHoldContext, this);
             }
         }
+        else
+        {
+            this.durationUp = this.game.time.time - this.timeUp;
+        }
 
     },
 
@@ -178,6 +190,7 @@ Phaser.Key.prototype = {
         this.isUp = false;
         this.timeDown = this.game.time.time;
         this.duration = 0;
+        this.durationUp = this.game.time.time - this.timeUp;
         this.repeats = 0;
 
         // _justDown will remain true until it is read via the justDown Getter
@@ -210,6 +223,7 @@ Phaser.Key.prototype = {
         this.isUp = true;
         this.timeUp = this.game.time.time;
         this.duration = this.game.time.time - this.timeDown;
+        this.durationUp = 0;
 
         // _justUp will remain true until it is read via the justUp Getter
         // this enables the game to poll for past presses, or reset it at the start of a new game state
@@ -236,6 +250,7 @@ Phaser.Key.prototype = {
         this.isUp = true;
         this.timeUp = this.game.time.time;
         this.duration = 0;
+        this.durationUp = -2500;
         this._enabled = true; // .enabled causes reset(false)
         this._justDown = false;
         this._justUp = false;
@@ -279,6 +294,32 @@ Phaser.Key.prototype = {
         if (duration === undefined) { duration = 50; }
 
         return (!this.isDown && ((this.game.time.time - this.timeUp) < duration));
+
+    },
+    
+    /**
+    * Returns `true` if the Key was just pressed down this update tick, or `false` if it either isn't down,
+    * or was pressed down on a previous update tick.
+    * 
+    * @method Phaser.Key#justPressed
+    * @return {boolean} True if the key was just pressed down this update tick.
+    */
+    justPressed: function () {
+
+        return (this.isDown && this.duration === 0);
+
+    },
+
+    /**
+    * Returns `true` if the Key was just released this update tick, or `false` if it either isn't up,
+    * or was released on a previous update tick.
+    * 
+    * @method Phaser.Key#justReleased
+    * @return {boolean} True if the key was just released this update tick.
+    */
+    justReleased: function () {
+
+        return (!this.isDown && this.durationUp === 0);
 
     }
 

--- a/v2-community/src/input/Keyboard.js
+++ b/v2-community/src/input/Keyboard.js
@@ -528,6 +528,32 @@ Phaser.Keyboard.prototype = {
 
     },
 
+    justPressed: function (keycode) {
+
+        if (this._keys[keycode])
+        {
+            return this._keys[keycode].justPressed();
+        }
+        else
+        {
+            return null;
+        }
+
+    },
+
+    justReleased: function (keycode) {
+
+        if (this._keys[keycode])
+        {
+            return this._keys[keycode].justReleased();
+        }
+        else
+        {
+            return null;
+        }
+
+    },
+
     /**
     * Returns true of the key is currently pressed down. Note that it can only detect key presses on the web browser.
     *


### PR DESCRIPTION
** >> Make sure you describe your PR to the README Change Log section! << **

This PR changes (delete as applicable)

* Documentation
* The public-facing API

Describe the changes below:
Added two functions to get if a key was either pressed or released in a given update tick. After I implemented this I saw the justDown/justUp bools, but the new functions have the advantage of always returning true during that tick of the update.

    /**
    * Returns `true` if the Key was just pressed down this update tick, or `false` if it either isn't down,
    * or was pressed down on a previous update tick.
    * 
    * @method Phaser.Key#justPressed
    * @return {boolean} True if the key was just pressed down this update tick.
    */
    justPressed: function () {

        return (this.isDown && this.duration === 0);

    },

    /**
    * Returns `true` if the Key was just released this update tick, or `false` if it either isn't up,
    * or was released on a previous update tick.
    * 
    * @method Phaser.Key#justReleased
    * @return {boolean} True if the key was just released this update tick.
    */
    justReleased: function () {

        return (!this.isDown && this.durationUp === 0);

    }

For justReleased I added a durationUp float to keep track of how long the key has been up.

    /**
    * If the key is up this value holds the duration of that key release and is constantly updated.
    * If the key is down it holds the duration of the previous up session.
    * @property {number} duration - The number of milliseconds this key has been up for.
    * @default
    */
    this.durationUp = -2500;

Works the same as duration.

    update: function () {

        if (!this._enabled) { return; }

        if (this.isDown)
        {
            this.duration = this.game.time.time - this.timeDown;
            this.repeats++;

            if (this.onHoldCallback)
            {
                this.onHoldCallback.call(this.onHoldContext, this);
            }
        }
        else
        {
            this.durationUp = this.game.time.time - this.timeUp;
        }

    }    

