### PR TITLE
Fix PIXI.DisplayObject::generateTexture method

### DIFF
--- a/v2-community/src/pixi/display/DisplayObject.js
+++ b/v2-community/src/pixi/display/DisplayObject.js
@@ -426,7 +426,7 @@ PIXI.DisplayObject.prototype = {
 
         var bounds = this.getLocalBounds();
 
-        var renderTexture = new Phaser.RenderTexture(null, bounds.width | 0, bounds.height | 0, renderer, scaleMode, resolution);
+        var renderTexture = new Phaser.RenderTexture(this.game, bounds.width | 0, bounds.height | 0, renderer, scaleMode, resolution);
         
         PIXI.DisplayObject._tempMatrix.tx = -bounds.x;
         PIXI.DisplayObject._tempMatrix.ty = -bounds.y;

--- a/v2-community/src/pixi/display/DisplayObject.js
+++ b/v2-community/src/pixi/display/DisplayObject.js
@@ -426,7 +426,7 @@ PIXI.DisplayObject.prototype = {
 
         var bounds = this.getLocalBounds();
 
-        var renderTexture = new Phaser.RenderTexture(bounds.width | 0, bounds.height | 0, renderer, scaleMode, resolution);
+        var renderTexture = new Phaser.RenderTexture(null, bounds.width | 0, bounds.height | 0, renderer, scaleMode, resolution);
         
         PIXI.DisplayObject._tempMatrix.tx = -bounds.x;
         PIXI.DisplayObject._tempMatrix.ty = -bounds.y;


### PR DESCRIPTION
This PR changes
* Nothing, it's a bug fix

Describe the changes below:
Fixes `PIXI.DisplayObject::generateTexture`: `new Phaser.RenderTexture` needs a reference to `this.game` as the first parameter, as described here: http://phaser.io/docs/2.6.2/Phaser.RenderTexture.html