### PR TITLE
Clarify `group.exists`

### DIFF
--- a/v2-community/CHANGELOG.md
+++ b/v2-community/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Updates
 
+* Clarification of `group.exists` behavior
 * Clarification of fixedToCamera semantics
 * change Emitter.gravity from number to Phaser.Point
 * Fixed issue causing tsc to crap out under certain circumstances

--- a/v2-community/src/core/Group.js
+++ b/v2-community/src/core/Group.js
@@ -93,7 +93,7 @@ Phaser.Group = function (game, parent, name, addToStage, enableBody, physicsBody
     this.alive = true;
 
     /**
-    * If exists is true the group is updated, otherwise it is skipped.
+    * If exists is false the group will be excluded from collision checks and filters such as {@link forEachExists}. The group will not call `preUpdate` and `postUpdate` on its children and the children will not receive physics updates or camera/world boundary checks. The group will still be {@link #visible} and will still call `update` on its children.
     * @property {boolean} exists
     * @default
     */


### PR DESCRIPTION
This PR changes

* Documentation