### PR TITLE
undefined-checking skipframes

### DIFF
--- a/v2-community/src/animation/AnimationParser.js
+++ b/v2-community/src/animation/AnimationParser.js
@@ -31,6 +31,7 @@ Phaser.AnimationParser = {
         if (frameMax === undefined) { frameMax = -1; }
         if (margin === undefined) { margin = 0; }
         if (spacing === undefined) { spacing = 0; }
+        if (skipFrames === undefined) { skipFrames = 0; }
 
         var img = key;
 


### PR DESCRIPTION
** >> Make sure you describe your PR to the README Change Log section! << **

This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

the way it works currently it's not really optional. i noticed a behavior change upgrading from 2.6.2, where i would leave off the last 3 args to `cache.addSpriteSheet` and it worked fine -- now in 2.7.2 i need to zero them all out as that func calls this one leaving `skipFrames` undefined, so when it's added to `frameMax` it's NaN and everything goes to hell.