### PR TITLE
Fixed floating button values

### DIFF
--- a/v2-community/CHANGELOG.md
+++ b/v2-community/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 
+* Floating Gamepad buttons now work correctly when partially pressing and releasing
 * Phaser.Line.intersectsRectangle() now works correctly for horizontal and vertical lines ([#2942](https://github.com/photonstorm/phaser/issues/2942)).
 * removeTextureAtlas now deletes the correct cache object.
 

--- a/v2-community/src/input/DeviceButton.js
+++ b/v2-community/src/input/DeviceButton.js
@@ -219,6 +219,9 @@ Phaser.DeviceButton.prototype = {
     */
     padFloat: function (value) {
 
+        this.isDown = false;
+        this.isUp = false;
+
         this.value = value;
 
         this.onFloat.dispatch(this, value);


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Using a floating button like the triggers on an Xbox 360 controller will not run the DeviceButton.start or DeviceButton.stop methods if the trigger is only partially pulled and released or partially released and pulled.  This can be demonstrated on [this example](https://phaser.io/examples/v2/input/gamepad-analog-button).  Notice that if you pull the trigger half way and quickly release it, the bar does not settle at the bottom.  This is because the button is still in the isUp state until the trigger is completely pressed, and it won't run DeviceButton.stop if isUp is true.

If the button is floating, I believe isDown and isUp should be false.  A isFloating property probably should be added.