### PR TITLE
Fixed declarations of Phaser.Plugin.AStar in phaser.d.ts.

### DIFF
--- a/v2-community/README.md
+++ b/v2-community/README.md
@@ -332,6 +332,7 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 * Added tempPoint argument / undefined block to Graphics.containsPoint
 * Fixed Text.setCharacterLimit conditional check
 * Added resolution argument to LoaderParser.jsonBitmapFont
+* Fixed Phaser.Plugin.AStar TypeScript definitions to match plugin source
 
 ## Version 2.7.2 - 6th December 2016
 

--- a/v2-community/typescript/phaser.d.ts
+++ b/v2-community/typescript/phaser.d.ts
@@ -3663,8 +3663,8 @@ declare module Phaser {
         class AStar extends Phaser.Plugin {
 
             static VERSION: string;
-            static COST_ORTHAGONAL: number;
-            static COST_DIAGAONAL: number;
+            static COST_ORTHOGONAL: number;
+            static COST_DIAGONAL: number;
             static DISTANCE_MANHATTEN: string;
             static DISTANCE_EUCLIDIAN: string;
 
@@ -3698,9 +3698,9 @@ declare module Phaser {
 
             class AStarPath {
 
-                constructor(nodes: Phaser.Plugin.AStar.AStarNode[], start: Phaser.Plugin.AStar.AStarNode, goal: Phaser.Plugin.AStar.AStarNode);
+                constructor(nodes?: {x: number, y: number}[], start?: Phaser.Plugin.AStar.AStarNode, goal?: Phaser.Plugin.AStar.AStarNode);
 
-                nodes: Phaser.Plugin.AStar.AStarNode[];
+                nodes: {x: number, y: number}[];
                 start: Phaser.Plugin.AStar.AStarNode;
                 goal: Phaser.Plugin.AStar.AStarNode;
                 visited: Phaser.Plugin.AStar.AStarNode[];


### PR DESCRIPTION
** >> Make sure you describe your PR to the README Change Log section! << **

This PR changes (delete as applicable)

* TypeScript Defs

Describe the changes below:

Changed declarations of Phaser.Plugin.AStar to match the actual JavaScript source (at https://github.com/photonstorm/phaser-plugins/blob/master/AStar/AStar.js).

The AStar plugin also has bunch of issues (inconsistent AStarPath properties, ugly leaking of nodes that are modified later, returned path is reversed, too inflexible/tightly coupled with tilemap properties) so I didn't actually use it in the end, these are just some problems with the typescript declarations I noticed when I hacked a typescript version of the plugin it for my own use.