### PR TITLE
Bug fix: replace WebGLPipeline.Attribute by module Attribute

### DIFF
--- a/v3/src/renderer/webgl/utils/CreateAttribArray.js
+++ b/v3/src/renderer/webgl/utils/CreateAttribArray.js
@@ -1,10 +1,12 @@
+var Attribute = require('./Attribute');
+
 var CreateAttribArray = function (gl, program, attributeDescArray)
 {
     var attributes = [];
     for (var index = 0, length = attributeDescArray.length; index < length; ++index)
     {
         var desc = attributeDescArray[index];
-        attributes.push(new WebGLPipeline.Attribute(
+        attributes.push(new Attribute(
             gl.getAttribLocation(program, desc.name),
             desc.size,
             desc.type,


### PR DESCRIPTION
WebGLPipeline.Attribute doesn't exist. Replace by "Attribute" and import it.