### PR TITLE
Remove lazer from ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Grab the source and join in the fun!
 - [Requirements](#requirements)
 - [Road Map](#road-map)
 - [Change Log](#change-log)
-- [Lazer](#lazer)
 - [Contributing](#contributing)
 
 <a name="whats-new"></a>


### PR DESCRIPTION
This PR changes:

* Documentation

Describe the changes below:

Remove a Lazer reference from the ToC. Lazer content removed previously in 65cc4cca3443e8179aaafa9a6844095c203f22aa :metal: 
