### PR TITLE
Point compares "false" to null or undefined

### DIFF
--- a/v2/src/geom/Point.js
+++ b/v2/src/geom/Point.js
@@ -274,7 +274,7 @@ Phaser.Point.prototype = {
     */
     equals: function (a) {
 
-        return (a.x === this.x && a.y === this.y);
+        return (a && a.x === this.x && a.y === this.y);
 
     },
 


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

A slight change so that following code will return false instead of throwing a ReferenceError
```
const somePoint = new Phaser.Point();
const x = null;
return somePoint.equals(x)
```