### PR TITLE
Lgtm fixes

### DIFF
--- a/v3/src/gameobjects/mesh/Mesh.js
+++ b/v3/src/gameobjects/mesh/Mesh.js
@@ -40,12 +40,12 @@ var Mesh = new Class({
             throw new Error('Phaser: Vertex count must match UV count');
         }
 
-        if (colors.length > 0 && colors.length < (vertices.length / 2)|0)
+        if (colors.length > 0 && colors.length < ((vertices.length / 2)|0))
         {
             throw new Error('Phaser: Color count must match Vertex count');
         }
 
-        if (alphas.length > 0 && alphas.length < (vertices.length / 2)|0)
+        if (alphas.length > 0 && alphas.length < ((vertices.length / 2)|0))
         {
             throw new Error('Phaser: Alpha count must match Vertex count');
         }

--- a/v3/src/loader/filetypes/HTMLFile.js
+++ b/v3/src/loader/filetypes/HTMLFile.js
@@ -51,6 +51,7 @@ HTMLFile.prototype.onProcess = function (callback)
     data.push('</svg>');
 
     var svg = [ data.join('\n') ];
+    var _this = this;
 
     try
     {
@@ -68,8 +69,6 @@ HTMLFile.prototype.onProcess = function (callback)
     this.data = new Image();
 
     this.data.crossOrigin = this.crossOrigin;
-
-    var _this = this;
 
     this.data.onload = function ()
     {

--- a/v3/src/loader/filetypes/SVGFile.js
+++ b/v3/src/loader/filetypes/SVGFile.js
@@ -31,6 +31,7 @@ SVGFile.prototype.onProcess = function (callback)
     this.state = CONST.FILE_PROCESSING;
 
     var svg = [ this.xhrLoader.responseText ];
+    var _this = this;
 
     try
     {
@@ -49,7 +50,6 @@ SVGFile.prototype.onProcess = function (callback)
 
     this.data.crossOrigin = this.crossOrigin;
 
-    var _this = this;
     var retry = false;
 
     this.data.onload = function ()

--- a/v3/src/math/random-data-generator/RandomDataGenerator.js
+++ b/v3/src/math/random-data-generator/RandomDataGenerator.js
@@ -234,7 +234,7 @@ RandomDataGenerator.prototype = {
         var a = '';
         var b = '';
 
-        for (b = a = ''; a++ < 36; b +=~a % 5 | a * 3&4 ? (a^15 ? 8^this.frac() * (a^20 ? 16 : 4) : 4).toString(16) : '-')
+        for (b = a = ''; a++ < 36; b +=~a % 5 | a*3 & 4 ? (a^15 ? 8 ^ this.frac()*(a^20 ? 16 : 4) : 4).toString(16) : '-')
         {
         }
 

--- a/v3/src/renderer/webgl/renderers/effectrenderer/EffectRenderer.js
+++ b/v3/src/renderer/webgl/renderers/effectrenderer/EffectRenderer.js
@@ -167,7 +167,6 @@ EffectRenderer.prototype = {
     renderEffect: function (gameObject, camera, texture, textureWidth, textureHeight)
     {
         var tempMatrix = this.tempMatrix;
-        var alpha = 16777216;
         var vertexDataBuffer = this.vertexDataBuffer;
         var vertexBufferObjectF32 = vertexDataBuffer.floatView;
         var vertexBufferObjectU32 = vertexDataBuffer.uintView;

--- a/v3/src/renderer/webgl/renderers/spritebatch/SpriteBatch.js
+++ b/v3/src/renderer/webgl/renderers/spritebatch/SpriteBatch.js
@@ -435,7 +435,6 @@ SpriteBatch.prototype = {
     addSpriteTexture: function (gameObject, camera, texture, textureWidth, textureHeight)
     {
         var tempMatrix = this.tempMatrix;
-        var alpha = 16777216;
         var vertexDataBuffer = this.vertexDataBuffer;
         var vertexBufferObjectF32 = vertexDataBuffer.floatView;
         var vertexBufferObjectU32 = vertexDataBuffer.uintView;
@@ -528,7 +527,6 @@ SpriteBatch.prototype = {
     {
         var tempMatrix = this.tempMatrix;
         var frame = gameObject.frame;
-        var alpha = 16777216;
         var forceFlipY = (frame.texture.source[frame.sourceIndex].glTexture.isRenderTexture ? true : false);
         var flipX = gameObject.flipX;
         var flipY = gameObject.flipY ^ forceFlipY;

--- a/v3/src/utils/array/matrix/Rotate180.js
+++ b/v3/src/utils/array/matrix/Rotate180.js
@@ -1,4 +1,4 @@
-var RotateMatrix = require('./RotateMatrix)';
+var RotateMatrix = require('./RotateMatrix');
 
 var Rotate180 = function (matrix)
 {

--- a/v3/src/utils/array/matrix/RotateLeft.js
+++ b/v3/src/utils/array/matrix/RotateLeft.js
@@ -1,4 +1,4 @@
-var RotateMatrix = require('./RotateMatrix)';
+var RotateMatrix = require('./RotateMatrix');
 
 var RotateLeft = function (matrix)
 {

--- a/v3/src/utils/array/matrix/RotateRight.js
+++ b/v3/src/utils/array/matrix/RotateRight.js
@@ -1,4 +1,4 @@
-var RotateMatrix = require('./RotateMatrix)';
+var RotateMatrix = require('./RotateMatrix');
 
 var RotateRight = function (matrix)
 {


### PR DESCRIPTION
This PR changes (delete as applicable)
* Nothing, it's a bug fix

This is a new version of #3022 with changes restricted to `v3/src`. There are a few additional changes here in response to a few other things I found flagged up. 

22237d8..7d09434 are small maintainability related changes. d522461 fixes what appears to be a minor bug - `<` has higher precedence than `|`, so the right hand operands of these `&&` expressed `({colors,alphas}.length < (vertices.length / 2)) | 0` rather than truncating `vertices.length / 2`, causing an error to be skipped when `vertices.length === {colors,alphas}.length * 2 + 1`.

Results taken from https://lgtm.com/projects/g/photonstorm/phaser/alerts/.