### PR TITLE
Factor out a truncated upper bound

### DIFF
--- a/v3/src/gameobjects/mesh/Mesh.js
+++ b/v3/src/gameobjects/mesh/Mesh.js
@@ -40,12 +40,14 @@ var Mesh = new Class({
             throw new Error('Phaser: Vertex count must match UV count');
         }
 
-        if (colors.length > 0 && colors.length < ((vertices.length / 2)|0))
+        var verticesUB = (vertices.length / 2) | 0;
+
+        if (colors.length > 0 && colors.length < verticesUB)
         {
             throw new Error('Phaser: Color count must match Vertex count');
         }
 
-        if (alphas.length > 0 && alphas.length < ((vertices.length / 2)|0))
+        if (alphas.length > 0 && alphas.length < verticesUB)
         {
             throw new Error('Phaser: Alpha count must match Vertex count');
         }
@@ -54,7 +56,7 @@ var Mesh = new Class({
 
         if (colors.length === 0)
         {
-            for (i = 0; i < (vertices.length / 2)|0; ++i)
+            for (i = 0; i < verticesUB; ++i)
             {
                 colors[i] = 0xFFFFFF;
             }
@@ -62,7 +64,7 @@ var Mesh = new Class({
 
         if (alphas.length === 0)
         {
-            for (i = 0; i < (vertices.length / 2)|0; ++i)
+            for (i = 0; i < verticesUB; ++i)
             {
                 alphas[i] = 1.0;
             }


### PR DESCRIPTION
This PR changes (delete as applicable)
* Nothing, it's a bug fix

Describe the changes below:

Follow up to https://github.com/photonstorm/phaser/commit/58751d5f353d2fa8cd5f21f3a73d83d12937b963 - there were a couple of cases later in the file of the same thing, so it seemed to make sense to factor this out to a variable.

Results found at https://lgtm.com/projects/g/photonstorm/phaser/alerts/ under "Whitespace contradicts operator precedence".