### PR TITLE
Fix `url` parameter processing.

### DIFF
--- a/v3/src/loader/File.js
+++ b/v3/src/loader/File.js
@@ -27,11 +27,11 @@ var File = new Class({
         }
 
         //  The URL of the file, not including baseURL
-        this.url = GetFastValue(fileConfig, 'url', '');
+        this.url = GetFastValue(fileConfig, 'url');
 
-        if (this.url === '')
+        if (this.url === undefined)
         {
-            this.url = GetFastValue(fileConfig, 'path', '') + this.key + GetFastValue(fileConfig, 'extension', '');
+            this.url = GetFastValue(fileConfig, 'path', '') + this.key + '.' + GetFastValue(fileConfig, 'extension', '');
         }
         else
         {


### PR DESCRIPTION
This pull request is a bug fix.

This PR fixes the `url` parameter processing, so it yields the intended value, guessing the file name and extension when a URL is omitted.

Note that I'm not trying to restore the former behavior where you could also pass an object config or even arrays to the method, only the `url` attribute processing. Also, a few examples from the Labs, the "Loader" ones in particular, are failing to load their file assets. I'm not sure if recent changes will revert that kind of usage, so I'm not trying to restore it in this PR.
