### PR TITLE
Unified usage of "framerate" into "frameRate".

### DIFF
--- a/v3/src/animation/frame/Animation.js
+++ b/v3/src/animation/frame/Animation.js
@@ -26,7 +26,7 @@ var Animation = new Class({
         this.frames = GetFrames(manager.textureManager, GetValue(config, 'frames', []));
 
         //  The frame rate of playback in frames per second (default 24 if duration is null)
-        this.frameRate = GetValue(config, 'framerate', null);
+        this.frameRate = GetValue(config, 'frameRate', null);
 
         //  How long the animation should play for. If frameRate is set it overrides this value
         //  otherwise frameRate is derived from duration

--- a/v3/src/animation/frame/ToJSON.js
+++ b/v3/src/animation/frame/ToJSON.js
@@ -4,7 +4,7 @@ var ToJSON = function ()
         key: this.key,
         type: this.type,
         frames: [],
-        framerate: this.frameRate,
+        frameRate: this.frameRate,
         duration: this.duration,
         skipMissedFrames: this.skipMissedFrames,
         delay: this.delay,

--- a/v3/src/animation/frame/config.json
+++ b/v3/src/animation/frame/config.json
@@ -5,8 +5,8 @@
         { key: textureKey, frame: textureFrame, visible: boolean },
         { key: textureKey, frame: textureFrame, onUpdate: function }
     ],
-    framerate: integer,
-    duration: float (seconds, optional, ignored if framerate is set),
+    frameRate: integer,
+    duration: float (seconds, optional, ignored if frameRate is set),
     skipMissedFrames: boolean,
     delay: integer,
     repeat: integer (-1 = forever),

--- a/v3/src/gameobjects/components/Animation.js
+++ b/v3/src/gameobjects/components/Animation.js
@@ -35,8 +35,8 @@ var Animation = new Class({
         //  The frame rate of playback in frames per second (default 24 if duration is null)
         this.frameRate = 0;
 
-        //  How long the animation should play for. If framerate is set it overrides this value
-        //  otherwise framerate is derived from duration
+        //  How long the animation should play for. If frameRate is set it overrides this value
+        //  otherwise frameRate is derived from duration
         this.duration = 0;
 
         //  ms per frame (without including frame specific modifiers)


### PR DESCRIPTION
This PR changes:

* Documentation
* The public-facing API

Describe the changes below:

Unified usage of "framerate" into "frameRate".