### PR TITLE
Add missing comma to Frame Rate Config

### DIFF
--- a/v3/src/boot/Config.js
+++ b/v3/src/boot/Config.js
@@ -68,7 +68,7 @@ var Config = new Class({
         //      fps: {
         //          min: 10,
         //          target: 60,
-        //          max: 120
+        //          max: 120,
         //          forceSetTimeOut: false,
         //          deltaHistory: 10
         //     }


### PR DESCRIPTION
This PR changes:

* Documentation

Describe the changes below:

As I was experimenting with Phaser 3 I copied and pasted the example FPS config only to find it was missing a comma.