### PR TITLE
Uncomment Loader.loadArray

### DIFF
--- a/v3/src/scene/plugins/Loader.js
+++ b/v3/src/scene/plugins/Loader.js
@@ -175,9 +175,8 @@ var Loader = new Class({
 
             this._multilist[key].push(multiKey);
         }
-    }
+    },
 
-    /*
     loadArray: function (files)
     {
         if (Array.isArray(files))
@@ -221,8 +220,6 @@ var Loader = new Class({
 
         return entry;
     },
-    */
-    
 });
 
 module.exports = Loader;


### PR DESCRIPTION
Should Loader.loadArray be uncommented?  This produced an errors while running 'render to texture' example where file array is used.