### PR TITLE
restart and _paused

### DIFF
--- a/v3/src/gameobjects/components/animation/Restart.js
+++ b/v3/src/gameobjects/components/animation/Restart.js
@@ -7,6 +7,7 @@ var Restart = function (includeDelay)
     this.forward = true;
     this.isPlaying = true;
     this.pendingRepeat = false;
+    this._paused = false;
 
     //  Set frame
     this.updateFrame(this.currentAnim.frames[0]);


### PR DESCRIPTION
Within **animation data.js**

Restart -> Pause (paused) -> Restart -> Pause (not paused)
So, we have the issue with _paused status which is not changed after restart process.