### PR TITLE
Fix Sprite animation with BuildGameObject

### DIFF
--- a/v3/src/gameobjects/BuildGameObject.js
+++ b/v3/src/gameobjects/BuildGameObject.js
@@ -96,6 +96,11 @@ var BuildGameObject = function (scene, gameObject, config)
     if (add)
     {
         scene.sys.displayList.add(gameObject);
+
+        if (gameObject.preUpdate)
+        {
+            scene.sys.updateList.add(gameObject);
+        }
     }
 
     return gameObject;


### PR DESCRIPTION
The flow **GameObjectCreator -> SpriteCreator -> BuildGameObject** doesn't add sprite object into **sys.updateList** list.

But **GameObjectFactory** does.

To reproduce:
- this.add.sprite(400, 400, 'gems').play('ruby'); **works**
- this.make.sprite(config) **doesn't work**