### PR TITLE
Should sprite use it's custom anims config or only base animation config if it's existed?

### DIFF
--- a/v3/src/animation/frame/inc/Load.js
+++ b/v3/src/animation/frame/inc/Load.js
@@ -14,10 +14,10 @@ var Load = function (component, startFrame)
         component.duration = this.duration;
         component.msPerFrame = this.msPerFrame;
         component.skipMissedFrames = this.skipMissedFrames;
-        component._delay = this.delay;
-        component._repeat = this.repeat;
-        component._repeatDelay = this.repeatDelay;
-        component._yoyo = this.yoyo;
+        component._delay = component._delay || this.delay;
+        component._repeat = component._repeat || this.repeat;
+        component._repeatDelay = component._repeatDelay || this.repeatDelay;
+        component._yoyo = component._yoyo || this.yoyo;
         component._callbackArgs[1] = this;
         component._updateParams = component._callbackArgs.concat(this.onUpdateParams);
     }


### PR DESCRIPTION
1. We create animation with attributes delay/repeat/repeatDelay/yoyo.
2. We create sprite (via _make_) with custom animation (anims) config and with key of the animation which we have created in 1 step.
3. When sprite animation is loading it's overwritten by base animation config.

Question: should sprite use it's custom anims config or only base animation config if it's existed?

Reproduce:
```
this.anims.create({ key: 'blast', 
   frames: this.anims.generateFrameNames('lazer', 
      { prefix: 'lazer_', start: 0, end: 22, zeroPad: 2 }), repeat: -1, repeatDelay: 5 });

this.make.sprite({
        key: 'lazer',
        frame: 'lazer_01',
        x: 50,
        y: 50,
        anims: {
            key: 'blast',
            repeat: -1,
            repeatDelay: 7,
            delayedPlay: function ()
            {
                return 1;
            }
        }
    });
```
Will result sprite animation with repeatDelay = 5 but looks like it should be 7.