### PR TITLE
Move loading __DEFAULT and __MISSING images to boot function.

### DIFF
--- a/v3/src/boot/Game.js
+++ b/v3/src/boot/Game.js
@@ -72,6 +72,8 @@ var Game = new Class({
 
         AddToDOM(this.canvas, this.config.parent);
 
+        this.textures.boot();
+
         this.anims.boot(this.textures);
 
         this.scene.boot();

--- a/v3/src/textures/TextureManager.js
+++ b/v3/src/textures/TextureManager.js
@@ -27,9 +27,12 @@ var TextureManager = new Class({
 
         this._tempCanvas = CanvasPool.create2D(this, 1, 1);
         this._tempContext = this._tempCanvas.getContext('2d');
+    },
 
-        this.addBase64('__DEFAULT', game.config.defaultImage);
-        this.addBase64('__MISSING', game.config.missingImage);
+    boot: function ()
+    {
+        this.addBase64('__DEFAULT', this.game.config.defaultImage);
+        this.addBase64('__MISSING', this.game.config.missingImage);
     },
 
     addBase64: function (key, data)


### PR DESCRIPTION
**TextureManager** loaded ___DEFAULT_ and ___MISSING_ images inside constructor function.
When we use Phaser.WEBGL **TextureSource** is trying to _createTexture_ inside _init_ function. [TextureSource, line 39]

But **game.renderer** is null because it's not yet created.

With Phaser.AUTO and Phaser.CANVAS there are no any errors.

<img width="1535" alt="screenshot" src="https://user-images.githubusercontent.com/13320555/30515544-904d5444-9b32-11e7-9023-c80f7f279543.png">

<img width="1680" alt="createtexture" src="https://user-images.githubusercontent.com/13320555/30522551-9a5ab8d4-9bda-11e7-8d77-0fd721b22c04.png">
