### PR TITLE
[.Offscreen-For-WebGL-XXXXXXXX] render error

### DIFF
--- a/v3/src/gameobjects/text/static/TextWebGLRenderer.js
+++ b/v3/src/gameobjects/text/static/TextWebGLRenderer.js
@@ -2,7 +2,7 @@ var GameObject = require('../../GameObject');
 
 var TextWebGLRenderer = function (renderer, src, interpolationPercentage, camera)
 {
-    if (GameObject.RENDER_MASK !== src.renderFlags || (src.cameraFilter > 0 && (src.cameraFilter & camera._id)))
+    if (GameObject.RENDER_MASK !== src.renderFlags || (src.cameraFilter > 0 && (src.cameraFilter & camera._id)) || src.text === '')
     {
         return;
     }
@@ -12,7 +12,7 @@ var TextWebGLRenderer = function (renderer, src, interpolationPercentage, camera
         src.canvasTexture = renderer.uploadCanvasToGPU(src.canvas, src.canvasTexture, true);
         src.dirty = false;
     }
-
+    
     renderer.spriteBatch.addSpriteTexture(src, camera, src.canvasTexture, src.canvas.width, src.canvas.height);
 };
 


### PR DESCRIPTION
```
this.add.text(350, 250, '', { font: '16px Courier', fill: '#00ff00' });
```

Text with empty value produces WebGL render error.

<img width="1680" alt="no_texture" src="https://user-images.githubusercontent.com/13320555/30522512-d9886b38-9bd9-11e7-98dc-2201e7c8151c.png">

(**TextWebGLRenderer** call **SpriteBatch.addSpriteTexture** with _src.canvasTexture = null_)
