### PR TITLE
Fix 'scene is not defined' in GroupCreator

### DIFF
--- a/v3/src/gameobjects/group/GroupCreator.js
+++ b/v3/src/gameobjects/group/GroupCreator.js
@@ -5,5 +5,5 @@ var Group = require('./Group');
 
 GameObjectCreator.register('group', function (config)
 {
-    return new Group(scene, null, config);
+    return new Group(this.scene, null, config);
 });


### PR DESCRIPTION
```
var group = this.make.group({ key: 'block', frameQuantity: 12 });
```
<img width="1680" alt="scene_is_not_defined" src="https://user-images.githubusercontent.com/13320555/30522812-eef2b528-9bde-11e7-8d2b-71ec516748b5.png">
