### PR TITLE
fix KeyCombo [TypeError: Cannot read property 'on' of undefined]

### DIFF
--- a/v3/src/input/keyboard/KeyboardManager.js
+++ b/v3/src/input/keyboard/KeyboardManager.js
@@ -26,6 +26,8 @@ var KeyboardManager = new Class({
     {
         this.manager = inputManager;
 
+        this.events = inputManager.events;
+
         this.enabled = false;
 
         this.target;


### PR DESCRIPTION
Don't sure if it's a correct fix for this bug.

![keycombo](https://user-images.githubusercontent.com/13320555/30923551-d2b7316c-a3b4-11e7-8a9a-f567fb99ff16.png)
