### PR TITLE
Fixed SwapPosition bug

### DIFF
--- a/v3/src/scene/global/inc/SwapPosition.js
+++ b/v3/src/scene/global/inc/SwapPosition.js
@@ -22,10 +22,19 @@ var SwapPosition = function (scene1, scene2)
     var index1 = (typeof scene1 === 'string') ? this.getActiveSceneIndexByKey(scene1) : this.getActiveSceneIndex(scene1);
     var index2 = (typeof scene2 === 'string') ? this.getActiveSceneIndexByKey(scene2) : this.getActiveSceneIndex(scene2);
 
-    if (index1 !== -1 && index2 !== -1)
+    if (index1 !== -1 && index2 !== -1 && index1 !== index2)
     {
-        this.active[index1].index = index2;
-        this.active[index2].index = index1;
+        this.active.forEach(function(scene){
+          if(scene.scene === this.scenes[index1])
+          {
+            scene.index = index2;
+          }
+
+          if(scene.scene === this.scenes[index2])
+          {
+            scene.index = index1;
+          }
+        }, this)
 
         this.active.sort(SortScenes);
     }


### PR DESCRIPTION
** >> Make sure you describe your PR to the README Change Log section! << **

This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

This is a possible fix for #3075. The index of the scene in the scenes array can't be used to identify the scene in the active array. They won't necessarily have the same index. So instead I loop through the active scenes to find the right one and then set the index property. I also added logic to skip the swap if index1 matches index2. This won't always be caught by the initial if statement comparing scene1 and scene2.
