### PR TITLE
Fix incorrect and unnecessary uses of closePath

### DIFF
--- a/v3/src/input/local/inc/ProcessDownEvents.js
+++ b/v3/src/input/local/inc/ProcessDownEvents.js
@@ -18,10 +18,7 @@ var ProcessDownEvents = function (pointer)
 
         this.events.dispatch(new InputEvent.GAME_OBJECT_DOWN(pointer, gameObject));
 
-        if (gameObject.input)
-        {
-            gameObject.input.onDown(gameObject, pointer, gameObject.input.localX, gameObject.input.localY);
-        }
+        gameObject.input.onDown(gameObject, pointer, gameObject.input.localX, gameObject.input.localY);
 
         if (this.topOnly)
         {

--- a/v3/src/input/local/inc/ProcessMoveEvents.js
+++ b/v3/src/input/local/inc/ProcessMoveEvents.js
@@ -18,10 +18,7 @@ var ProcessMoveEvents = function (pointer)
 
         this.events.dispatch(new InputEvent.GAME_OBJECT_MOVE(pointer, gameObject));
 
-        if (gameObject.input)
-        {
-            gameObject.input.onMove(gameObject, pointer, gameObject.input.localX, gameObject.input.localY);
-        }
+        gameObject.input.onMove(gameObject, pointer, gameObject.input.localX, gameObject.input.localY);
 
         if (this.topOnly)
         {

--- a/v3/src/input/local/inc/ProcessOverOutEvents.js
+++ b/v3/src/input/local/inc/ProcessOverOutEvents.js
@@ -64,10 +64,7 @@ var ProcessOverOutEvents = function (pointer)
 
             this.events.dispatch(new InputEvent.GAME_OBJECT_OUT(pointer, gameObject));
 
-            if (gameObject.input)
-            {
-                gameObject.input.onOut(gameObject, pointer);
-            }
+            gameObject.input.onOut(gameObject, pointer);
 
             if (this.topOnly)
             {
@@ -97,10 +94,7 @@ var ProcessOverOutEvents = function (pointer)
 
             this.events.dispatch(new InputEvent.GAME_OBJECT_OVER(pointer, gameObject));
 
-            if (gameObject.input)
-            {
-                gameObject.input.onOver(gameObject, pointer, gameObject.input.localX, gameObject.input.localY);
-            }
+            gameObject.input.onOver(gameObject, pointer, gameObject.input.localX, gameObject.input.localY);
 
             if (this.topOnly)
             {

--- a/v3/src/input/local/inc/ProcessUpEvents.js
+++ b/v3/src/input/local/inc/ProcessUpEvents.js
@@ -18,10 +18,7 @@ var ProcessUpEvents = function (pointer)
 
         this.events.dispatch(new InputEvent.GAME_OBJECT_UP(pointer, gameObject));
 
-        if (gameObject.input)
-        {
-            gameObject.input.onUp(gameObject, pointer, gameObject.input.localX, gameObject.input.localY);
-        }
+        gameObject.input.onUp(gameObject, pointer, gameObject.input.localX, gameObject.input.localY);
 
         if (this.topOnly)
         {

--- a/v3/src/renderer/webgl/WebGLRenderer.js
+++ b/v3/src/renderer/webgl/WebGLRenderer.js
@@ -451,6 +451,7 @@ var WebGLRenderer = new Class({
 
         var list = children.list;
         var length = list.length;
+        var renderer;
 
         for (var index = 0; index < length; ++index)
         {


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

closePath moves the pen back to the start in order to close the loop. It does not need to be called for every path.