### PR TITLE
Removing use of reserved keyword 'static'

### DIFF
--- a/v3/src/physics/matter-js/components/Friction.js
+++ b/v3/src/physics/matter-js/components/Friction.js
@@ -1,6 +1,6 @@
 var Friction = {
 
-    setFriction: function (value, air, static)
+    setFriction: function (value, air, _static)
     {
         this.body.friction = value;
 
@@ -9,9 +9,9 @@ var Friction = {
             this.body.frictionAir = air;
         }
 
-        if (static !== undefined)
+        if (_static !== undefined)
         {
-            this.body.frictionStatic = static;
+            this.body.frictionStatic = _static;
         }
 
         return this;


### PR DESCRIPTION
static is a reserved keyword in ES6, which causes problems with parsing. I didn't know what to call it, so I just went with _static. Could probably use a better name.