### PR TITLE
Fix geom/point/Normalize.js

### DIFF
--- a/src/geom/point/Normalize.js
+++ b/src/geom/point/Normalize.js
@@ -12,7 +12,7 @@ var GetMagnitude = require('./GetMagnitude');
  */
 var Normalize = function (point)
 {
-    if (point.x !== 0 && point.y !== 0)
+    if (point.x !== 0 || point.y !== 0)
     {
         var m = GetMagnitude(point);
 


### PR DESCRIPTION
This PR changes
* Nothing, it's a bug fix

Describe the changes below:
Tiny fix to point Normalize(), which was ignoring points with only one zero component (e.g. `{ x: 0, y: 0.2 }`