### PR TITLE
Weighted randomize index arrays

### DIFF
--- a/src/gameobjects/tilemap/components/WeightedRandomize.js
+++ b/src/gameobjects/tilemap/components/WeightedRandomize.js
@@ -48,8 +48,10 @@ var WeightedRandomize = function (tileX, tileY, width, height, weightedIndexes, 
             sum += weightedIndexes[j].weight;
             if (rand <= sum)
             {
-                randomIndex = weightedIndexes[j].index;
-                break;
+                var chosen = weightedIndexes[j].index
+                randomIndex = Array.isArray(chosen)
+                    ? chosen[Math.floor(Math.random() * chosen.length)]
+                    : chosen
             }
         }
 

--- a/src/gameobjects/tilemap/components/WeightedRandomize.js
+++ b/src/gameobjects/tilemap/components/WeightedRandomize.js
@@ -20,7 +20,8 @@ var GetTilesWithin = require('./GetTilesWithin');
  * @param {integer} [width=max width based on tileX] - [description]
  * @param {integer} [height=max height based on tileY] - [description]
  * @param {object[]} [weightedIndexes] - An array of objects to randomly draw from during
- * randomization. They should be in the form: { index: 0, weight: 4 }.
+ * randomization. They should be in the form: { index: 0, weight: 4 } or
+ * { index: [0, 1], weight: 4 } if you wish to draw from multiple tile indexes.
  * @param {LayerData} layer - [description]
  */
 var WeightedRandomize = function (tileX, tileY, width, height, weightedIndexes, layer)

--- a/src/gameobjects/tilemap/components/WeightedRandomize.js
+++ b/src/gameobjects/tilemap/components/WeightedRandomize.js
@@ -49,10 +49,10 @@ var WeightedRandomize = function (tileX, tileY, width, height, weightedIndexes, 
             sum += weightedIndexes[j].weight;
             if (rand <= sum)
             {
-                var chosen = weightedIndexes[j].index
+                var chosen = weightedIndexes[j].index;
                 randomIndex = Array.isArray(chosen)
                     ? chosen[Math.floor(Math.random() * chosen.length)]
-                    : chosen
+                    : chosen;
             }
         }
 

--- a/src/gameobjects/tilemap/components/WeightedRandomize.js
+++ b/src/gameobjects/tilemap/components/WeightedRandomize.js
@@ -53,6 +53,7 @@ var WeightedRandomize = function (tileX, tileY, width, height, weightedIndexes, 
                 randomIndex = Array.isArray(chosen)
                     ? chosen[Math.floor(Math.random() * chosen.length)]
                     : chosen;
+                break;
             }
         }
 


### PR DESCRIPTION
This PR changes

* Documentation
* The public-facing API

Describe the changes below:

I found this feature to be a nice convenience for my game, where I had several variants of the same kind of tile (like 12 slightly different ground tiles) and just wanted to pick from any of them when that weight was chosen. There are other ways to solve it of course, like providing 12 different entries each with 1/12 the weight, or writing a function to generating this array and combine it with other weights, but this was nice for me.