### PR TITLE
Fix: .sub and .len to .subtract and .length

### DIFF
--- a/src/camera/3d/Camera3D.js
+++ b/src/camera/3d/Camera3D.js
@@ -298,7 +298,7 @@ var Camera3D = new Class({
             dir.set(x, y, z);
         }
 
-        dir.sub(this.position).normalize();
+        dir.subtract(this.position).normalize();
 
         //  Calculate right vector
         tmpVec3.copy(dir).cross(up).normalize();
@@ -319,7 +319,7 @@ var Camera3D = new Class({
 
     rotateAround: function (point, radians, axis)
     {
-        tmpVec3.copy(point).sub(this.position);
+        tmpVec3.copy(point).subtract(this.position);
 
         this.translate(tmpVec3);
         this.rotate(radians, axis);
@@ -391,7 +391,7 @@ var Camera3D = new Class({
 
         direction.unproject(viewport, mtx);
 
-        direction.sub(origin).normalize();
+        direction.subtract(origin).normalize();
 
         return this.ray;
     },
@@ -419,7 +419,7 @@ var Camera3D = new Class({
         var dir = dirvec.set(this.direction).negate();
 
         // Better view-aligned billboards might use this:
-        // var dir = tmp.set(camera.position).sub(p).normalize();
+        // var dir = tmp.set(camera.position).subtract(p).normalize();
         
         var right = rightvec.set(this.up).cross(dir).normalize();
         var up = tmpVec3.set(dir).cross(right).normalize();

--- a/src/curves/curve/inc/GetTangent.js
+++ b/src/curves/curve/inc/GetTangent.js
@@ -39,7 +39,7 @@ var GetTangent = function (t, out)
     this.getPoint(t1, this._tmpVec2A);
     this.getPoint(t2, out);
 
-    return out.sub(this._tmpVec2A).normalize();
+    return out.subtract(this._tmpVec2A).normalize();
 };
 
 module.exports = GetTangent;

--- a/src/curves/line/LineCurve.js
+++ b/src/curves/line/LineCurve.js
@@ -59,7 +59,7 @@ var LineCurve = new Class({
             return out.copy(this.p1);
         }
 
-        out.copy(this.p1).sub(this.p0).scale(t).add(this.p0);
+        out.copy(this.p1).subtract(this.p0).scale(t).add(this.p0);
 
         return out;
     },
@@ -72,7 +72,7 @@ var LineCurve = new Class({
 
     getTangent: function ()
     {
-        var tangent = tmpVec2.copy(this.p1).sub(this.p0);
+        var tangent = tmpVec2.copy(this.p1).subtract(this.p0);
 
         return tangent.normalize();
     },

--- a/src/curves/path/inc/EllipseTo.js
+++ b/src/curves/path/inc/EllipseTo.js
@@ -26,7 +26,7 @@ var EllipseTo = function (xRadius, yRadius, startAngle, endAngle, clockwise, rot
     //  Calculate where to center the ellipse
     var start = ellipse.getStartPoint(this._tmpVec2B);
 
-    end.sub(start);
+    end.subtract(start);
 
     ellipse.x = end.x;
     ellipse.y = end.y;

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -168,7 +168,7 @@ var Quaternion = new Class({
 
         if (dot < -0.999999)
         {
-            if (tmpvec.copy(xUnitVec3).cross(a).len() < EPSILON)
+            if (tmpvec.copy(xUnitVec3).cross(a).length() < EPSILON)
             {
                 tmpvec.copy(yUnitVec3).cross(a);
             }


### PR DESCRIPTION
Renamed no longer existing Vector2/3 .sub and .len to .subtract and .length:

.sub and .len have been removed from Math.Vector2 and Math.Vector3, but several files were still using them