### PR TITLE
set data to KeyCombo for KeyComboMatchEvent

### DIFF
--- a/src/input/keyboard/combo/KeyComboMatchEvent.js
+++ b/src/input/keyboard/combo/KeyComboMatchEvent.js
@@ -11,9 +11,7 @@ var KeyComboMatchEvent = new Class({
     {
         Event.call(this, 'KEY_COMBO_MATCH_EVENT');
 
-        this.target = keyCombo;
-
-        this.data = keyboardEvent;
+        this.data = keyCombo;
     }
 
 });


### PR DESCRIPTION
This PR changes:
* Nothing, it's a bug fix

Describe the changes below:

When using the `KEY_COMBO_MATCH_EVENT`, we're unable to determine which KeyCombo triggered the event.

This PR updates `KeyComboMatchEvent.js` to return the `KeyCombo` reference in the `data` attribute of the event. It also removes the line setting the `target` as it was getting overwritten anyways.

Closes #3155 
