### PR TITLE
Pass event to ProcessKeyCombo

### DIFF
--- a/src/input/keyboard/combo/KeyCombo.js
+++ b/src/input/keyboard/combo/KeyCombo.js
@@ -90,7 +90,7 @@ var KeyCombo = new Class({
                 return;
             }
 
-            var matched = ProcessKeyCombo(event.data, _this);
+            var matched = ProcessKeyCombo(event, _this);
 
             if (matched)
             {


### PR DESCRIPTION
This PR changes
* Nothing, it's a bug fix

Describe the changes below:

Thanks for updating the event emitter logic and great writeup in the latest Phaser World! :) It sounds like it will be a nice upgrade.

When updating my game to use the new beta, I noticed a small bug in `ProcessKeyCombo`:
<img width="579" alt="screen shot 2018-01-16 at 11 20 25 am" src="https://user-images.githubusercontent.com/360233/35003000-0c82ff5e-fab1-11e7-99d4-80837e8f707c.png">

It looks like `ProcessKeyCombo` was using `event.data` (a holdover from the old event logic I presume).

This PR updates `KeyCombo.js` to pass `event` instead of `event.data` to `ProcessKeyCombo`

Hope this helps! Thanks again!
