### PR TITLE
TimerEvent startAt field not scaled

### DIFF
--- a/src/time/Clock.js
+++ b/src/time/Clock.js
@@ -101,8 +101,6 @@ var Clock = new Class({
         {
             event = this._pendingInsertion[i];
 
-            event.elapsed = event.startAt * event.timeScale;
-
             this._active.push(event);
         }
 

--- a/src/time/TimerEvent.js
+++ b/src/time/TimerEvent.js
@@ -81,7 +81,7 @@ var TimerEvent = new Class({
 
         this.paused = GetFastValue(config, 'paused', false);
 
-        this.elapsed = 0;
+        this.elapsed = this.startAt;
         this.hasDispatched = false;
         this.repeatCount = (this.repeat === -1 || this.loop) ? 999999999999 : this.repeat;
 


### PR DESCRIPTION
A note regarding the feature `startAt` of `TimerEvent ` 

When an event gets added it should be either scaled by clock `timeScale` as well or not scaled at all - depending on the feature purpose.

```javascript
// Clock preUpdate loop
event = this._pendingInsertion[i];
event.elapsed = event.startAt * event.timeScale
```

In my understanding it should not be influenced by `timeScale` at all.
As a developer I would use the feature of `startAt` to specify the exact offset for my event.

In case I have looped `Timer` for one second and want to start the first loop in the middle, I would set the `startAt` to half a second. And scaling is applied during the timer run time as a factor of speed it elapses.

** >> Make sure you describe your PR to the README Change Log section! << **

This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

TimerEvent startAt field not scaled