### PR TITLE
Fix stray let keywords

### DIFF
--- a/src/renderer/webgl/pipelines/components/ModelViewProjection.js
+++ b/src/renderer/webgl/pipelines/components/ModelViewProjection.js
@@ -469,8 +469,8 @@ var ModelViewProjection = {
     projPersp: function (fovy, aspectRatio, near, far)
     {
         var projectionMatrix = this.projectionMatrix;
-        let fov = 1.0 / Math.tan(fovy / 2.0);
-        let nearFar = 1.0 / (near - far);
+        var fov = 1.0 / Math.tan(fovy / 2.0);
+        var nearFar = 1.0 / (near - far);
         
         projectionMatrix[0] = fov / aspectRatio;
         projectionMatrix[1] = 0.0;


### PR DESCRIPTION
As Phaser 3 is supposed to be in ES5 those should be `var`s.
Noticed when using `webpack -p` and it complained about them 😋 