### PR TITLE
Update link to JavaScript Game Engines on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Phaser is a fast, free, and fun open source HTML5 game framework. It offers WebG
 
 Phaser is available in two versions: Phaser 3 and [Phaser CE - The Community Edition](https://github.com/photonstorm/phaser-ce). Phaser CE is a community-lead continuation of the Phaser 2 codebase and is hosted on its own repo. Phaser 3 is the next generation of Phaser.
 
-Along with the fantastic open source community, Phaser is actively developed and maintained by [Photon Storm](http://www.photonstorm.com). As a result of rapid support, and a developer friendly API, Phaser is currently one of the [most starred](https://github.com/showcases/javascript-game-engines) game frameworks on GitHub.
+Along with the fantastic open source community, Phaser is actively developed and maintained by [Photon Storm](http://www.photonstorm.com). As a result of rapid support, and a developer friendly API, Phaser is currently one of the [most starred](https://github.com/collections/javascript-game-engines) game frameworks on GitHub.
 
 Thousands of developers worldwide use Phaser. From indies and multi-national digital agencies, to schools and Universities. Each creating their own incredible [games](https://phaser.io/games/).
 


### PR DESCRIPTION
This PR changes... Documentation.

Simply changes the URL referenced in the `README.md` from https://github.com/showcases/javascript-game-engines to https://github.com/collections/javascript-game-engines 🤘 