### PR TITLE
Fix wrong Extend target in MergeXHRSettings

### DIFF
--- a/src/loader/MergeXHRSettings.js
+++ b/src/loader/MergeXHRSettings.js
@@ -23,7 +23,7 @@ var XHRSettings = require('./XHRSettings');
  */
 var MergeXHRSettings = function (global, local)
 {
-    var output = (global === undefined) ? XHRSettings() : Extend(global);
+    var output = (global === undefined) ? XHRSettings() : Extend({}, global);
 
     if (local)
     {


### PR DESCRIPTION
MergeXHRSettings was actually copying `global` onto `window`.

Probably harmless, but it caused a problem for someone when evaluated with `this === undefined` (webpack!)