### PR TITLE
load.plugin now accepts class as an argument besides an url-string

### DIFF
--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -65,7 +65,7 @@ var File = new Class({
         {
             this.url = GetFastValue(fileConfig, 'path', '') + this.key + '.' + GetFastValue(fileConfig, 'extension', '');
         }
-        else if(typeof(this.url) !== "function")
+        else if (typeof(this.url) !== 'function')
         {
             this.url = GetFastValue(fileConfig, 'path', '').concat(this.url);
         }

--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -65,7 +65,7 @@ var File = new Class({
         {
             this.url = GetFastValue(fileConfig, 'path', '') + this.key + '.' + GetFastValue(fileConfig, 'extension', '');
         }
-        else
+        else if(typeof(this.url) !== "function")
         {
             this.url = GetFastValue(fileConfig, 'path', '').concat(this.url);
         }
@@ -118,7 +118,7 @@ var File = new Class({
          * @type {integer}
          * @since 3.0.0
          */
-        this.state = CONST.FILE_PENDING;
+        this.state = typeof(this.url) === "function" ? CONST.FILE_POPULATED : CONST.FILE_PENDING;
 
         /**
          * The total size of this file.

--- a/src/loader/filetypes/PluginFile.js
+++ b/src/loader/filetypes/PluginFile.js
@@ -34,6 +34,13 @@ var PluginFile = new Class({
 
     function PluginFile (key, url, path, xhrSettings)
     {
+        // If the url variable refers to a class, add the plugin directly
+        if(typeof url === "function"){
+            this.key = key;
+            window[key] = url;
+            window[key].register(PluginManager);
+        }
+
         var fileKey = (typeof key === 'string') ? key : GetFastValue(key, 'key', '');
 
         var fileConfig = {

--- a/src/loader/filetypes/PluginFile.js
+++ b/src/loader/filetypes/PluginFile.js
@@ -35,7 +35,8 @@ var PluginFile = new Class({
     function PluginFile (key, url, path, xhrSettings)
     {
         // If the url variable refers to a class, add the plugin directly
-        if(typeof url === "function"){
+        if (typeof url === 'function')
+        {
             this.key = key;
             window[key] = url;
             window[key].register(PluginManager);


### PR DESCRIPTION
Support for importing and adding plugin classes without an url to be loaded as discussed in #3228.

This approach is tested and works fine, however, I don't know if you find it too ugly. Basically, it free rides on the ordinary loader but skips making a file request. With this the url-parameter passed to load.plugin might not be an url but the plugin itself.