### PR TITLE
Fix camera jitter

### DIFF
--- a/src/renderer/webgl/pipelines/FlatTintPipeline.js
+++ b/src/renderer/webgl/pipelines/FlatTintPipeline.js
@@ -168,7 +168,7 @@ var FlatTintPipeline = new Class({
     {
         WebGLPipeline.prototype.resize.call(this, width, height, resolution);
         this.projOrtho(0, this.width, this.height, 0, -1000.0, 1000.0);
-        
+
         return this;
     },
 
@@ -206,7 +206,7 @@ var FlatTintPipeline = new Class({
         {
             this.flush();
         }
-        
+
         var renderer = this.renderer;
         var resolution = renderer.config.resolution;
         var vertexViewF32 = this.vertexViewF32;
@@ -235,18 +235,6 @@ var FlatTintPipeline = new Class({
         var tx3 = xw * a + y * c + e;
         var ty3 = xw * b + y * d + f;
         var tint = Utils.getTintAppendFloatAlphaAndSwap(fillColor, fillAlpha);
-
-        if (roundPixels)
-        {
-            tx0 = ((tx0 * resolution)|0) / resolution;
-            ty0 = ((ty0 * resolution)|0) / resolution;
-            tx1 = ((tx1 * resolution)|0) / resolution;
-            ty1 = ((ty1 * resolution)|0) / resolution;
-            tx2 = ((tx2 * resolution)|0) / resolution;
-            ty2 = ((ty2 * resolution)|0) / resolution;
-            tx3 = ((tx3 * resolution)|0) / resolution;
-            ty3 = ((ty3 * resolution)|0) / resolution;
-        }
 
         vertexViewF32[vertexOffset + 0] = tx0;
         vertexViewF32[vertexOffset + 1] = ty0;
@@ -331,16 +319,6 @@ var FlatTintPipeline = new Class({
         var tx2 = x2 * a + y2 * c + e;
         var ty2 = x2 * b + y2 * d + f;
         var tint = Utils.getTintAppendFloatAlphaAndSwap(fillColor, fillAlpha);
-
-        if (roundPixels)
-        {
-            tx0 = ((tx0 * resolution)|0) / resolution;
-            ty0 = ((ty0 * resolution)|0) / resolution;
-            tx1 = ((tx1 * resolution)|0) / resolution;
-            ty1 = ((ty1 * resolution)|0) / resolution;
-            tx2 = ((tx2 * resolution)|0) / resolution;
-            ty2 = ((ty2 * resolution)|0) / resolution;
-        }
 
         vertexViewF32[vertexOffset + 0] = tx0;
         vertexViewF32[vertexOffset + 1] = ty0;
@@ -508,16 +486,6 @@ var FlatTintPipeline = new Class({
             tx2 = x2 * a + y2 * c + e;
             ty2 = x2 * b + y2 * d + f;
 
-            if (roundPixels)
-            {
-                tx0 = ((tx0 * resolution)|0) / resolution;
-                ty0 = ((ty0 * resolution)|0) / resolution;
-                tx1 = ((tx1 * resolution)|0) / resolution;
-                ty1 = ((ty1 * resolution)|0) / resolution;
-                tx2 = ((tx2 * resolution)|0) / resolution;
-                ty2 = ((ty2 * resolution)|0) / resolution;
-            }
-
             vertexViewF32[vertexOffset + 0] = tx0;
             vertexViewF32[vertexOffset + 1] = ty0;
             vertexViewU32[vertexOffset + 2] = tint;
@@ -666,7 +634,7 @@ var FlatTintPipeline = new Class({
         {
             this.flush();
         }
-        
+
         var renderer = this.renderer;
         var resolution = renderer.config.resolution;
         var a0 = currentMatrix[0];
@@ -711,18 +679,6 @@ var FlatTintPipeline = new Class({
         var bTint = getTint(bLineColor, lineAlpha);
         var vertexOffset = this.vertexCount * this.vertexComponentCount;
 
-        if (roundPixels)
-        {
-            x0 = ((x0 * resolution)|0) / resolution;
-            y0 = ((y0 * resolution)|0) / resolution;
-            x1 = ((x1 * resolution)|0) / resolution;
-            y1 = ((y1 * resolution)|0) / resolution;
-            x2 = ((x2 * resolution)|0) / resolution;
-            y2 = ((y2 * resolution)|0) / resolution;
-            x3 = ((x3 * resolution)|0) / resolution;
-            y3 = ((y3 * resolution)|0) / resolution;
-        }
-
         vertexViewF32[vertexOffset + 0] = x0;
         vertexViewF32[vertexOffset + 1] = y0;
         vertexViewU32[vertexOffset + 2] = bTint;
@@ -764,7 +720,7 @@ var FlatTintPipeline = new Class({
     batchGraphics: function (graphics, camera)
     {
         if (graphics.commandBuffer.length <= 0) { return; }
-        
+
         this.renderer.setPipeline(this);
 
         var cameraScrollX = camera.scrollX * graphics.scrollFactorX;
@@ -844,7 +800,7 @@ var FlatTintPipeline = new Class({
                         endAngle = startAngle;
                         startAngle = -ta;
                     }
-                    
+
                     while (iteration < 1)
                     {
                         ta = (endAngle - startAngle) * iteration + startAngle;
@@ -904,7 +860,7 @@ var FlatTintPipeline = new Class({
                             /* Graphics Game Object Properties */
                             srcX, srcY, srcScaleX, srcScaleY, srcRotation,
 
-                            /* Rectangle properties */ 
+                            /* Rectangle properties */
                             pathArray[pathArrayIndex].points,
                             fillColor,
                             fillAlpha,
@@ -928,7 +884,7 @@ var FlatTintPipeline = new Class({
                             /* Graphics Game Object Properties */
                             srcX, srcY, srcScaleX, srcScaleY, srcRotation,
 
-                            /* Rectangle properties */ 
+                            /* Rectangle properties */
                             path.points,
                             lineWidth,
                             lineColor,
@@ -942,14 +898,14 @@ var FlatTintPipeline = new Class({
                         );
                     }
                     break;
-                    
+
                 case Commands.FILL_RECT:
                     this.batchFillRect(
 
                         /* Graphics Game Object Properties */
                         srcX, srcY, srcScaleX, srcScaleY, srcRotation,
 
-                        /* Rectangle properties */ 
+                        /* Rectangle properties */
                         commands[cmdIndex + 1],
                         commands[cmdIndex + 2],
                         commands[cmdIndex + 3],
@@ -962,7 +918,7 @@ var FlatTintPipeline = new Class({
                         currentMatrix,
                         roundPixels
                     );
-                 
+
                     cmdIndex += 4;
                     break;
 
@@ -972,7 +928,7 @@ var FlatTintPipeline = new Class({
                         /* Graphics Game Object Properties */
                         srcX, srcY, srcScaleX, srcScaleY, srcRotation,
 
-                        /* Triangle properties */ 
+                        /* Triangle properties */
                         commands[cmdIndex + 1],
                         commands[cmdIndex + 2],
                         commands[cmdIndex + 3],
@@ -987,7 +943,7 @@ var FlatTintPipeline = new Class({
                         currentMatrix,
                         roundPixels
                     );
-                    
+
                     cmdIndex += 6;
                     break;
 
@@ -997,7 +953,7 @@ var FlatTintPipeline = new Class({
                         /* Graphics Game Object Properties */
                         srcX, srcY, srcScaleX, srcScaleY, srcRotation,
 
-                        /* Triangle properties */ 
+                        /* Triangle properties */
                         commands[cmdIndex + 1],
                         commands[cmdIndex + 2],
                         commands[cmdIndex + 3],
@@ -1013,7 +969,7 @@ var FlatTintPipeline = new Class({
                         currentMatrix,
                         roundPixels
                     );
-                    
+
                     cmdIndex += 6;
                     break;
 

--- a/src/renderer/webgl/pipelines/TextureTintPipeline.js
+++ b/src/renderer/webgl/pipelines/TextureTintPipeline.js
@@ -347,12 +347,12 @@ var TextureTintPipeline = new Class({
             }
 
             this.vertexBuffer = tilemap.vertexBuffer;
-            
+
             renderer.setTexture2D(frame.source.glTexture, 0);
             renderer.setPipeline(this);
 
             gl.drawArrays(this.topology, 0, tilemap.vertexCount);
-    
+
             this.vertexBuffer = pipelineVertexBuffer;
         }
 
@@ -397,7 +397,7 @@ var TextureTintPipeline = new Class({
         var texture = emitterManager.defaultFrame.source.glTexture;
 
         this.setTexture2D(texture, 0);
-        
+
         for (var emitterIndex = 0; emitterIndex < emitterCount; ++emitterIndex)
         {
             var emitter = emitters[emitterIndex];
@@ -464,18 +464,6 @@ var TextureTintPipeline = new Class({
                     var tx3 = xw * mva + y * mvc + mve;
                     var ty3 = xw * mvb + y * mvd + mvf;
                     var vertexOffset = this.vertexCount * vertexComponentCount;
-
-                    if (roundPixels)
-                    {
-                        tx0 = ((tx0 * resolution)|0) / resolution;
-                        ty0 = ((ty0 * resolution)|0) / resolution;
-                        tx1 = ((tx1 * resolution)|0) / resolution;
-                        ty1 = ((ty1 * resolution)|0) / resolution;
-                        tx2 = ((tx2 * resolution)|0) / resolution;
-                        ty2 = ((ty2 * resolution)|0) / resolution;
-                        tx3 = ((tx3 * resolution)|0) / resolution;
-                        ty3 = ((ty3 * resolution)|0) / resolution;
-                    }
 
                     vertexViewF32[vertexOffset + 0] = tx0;
                     vertexViewF32[vertexOffset + 1] = ty0;
@@ -582,21 +570,13 @@ var TextureTintPipeline = new Class({
                 var tx1 = xw * a + yh * c + e;
                 var ty1 = xw * b + yh * d + f;
 
-                if (roundPixels)
-                {
-                    tx0 = ((tx0 * resolution)|0) / resolution;
-                    ty0 = ((ty0 * resolution)|0) / resolution;
-                    tx1 = ((tx1 * resolution)|0) / resolution;
-                    ty1 = ((ty1 * resolution)|0) / resolution;
-                }
-            
                 // Bind Texture if texture wasn't bound.
                 // This needs to be here because of multiple
                 // texture atlas.
                 this.setTexture2D(frame.texture.source[frame.sourceIndex].glTexture, 0);
 
                 var vertexOffset = this.vertexCount * this.vertexComponentCount;
-            
+
                 vertexViewF32[vertexOffset + 0] = tx0;
                 vertexViewF32[vertexOffset + 1] = ty0;
                 vertexViewF32[vertexOffset + 2] = uvs.x0;
@@ -734,18 +714,6 @@ var TextureTintPipeline = new Class({
 
         vertexOffset = this.vertexCount * this.vertexComponentCount;
 
-        if (roundPixels)
-        {
-            tx0 = ((tx0 * resolution)|0) / resolution;
-            ty0 = ((ty0 * resolution)|0) / resolution;
-            tx1 = ((tx1 * resolution)|0) / resolution;
-            ty1 = ((ty1 * resolution)|0) / resolution;
-            tx2 = ((tx2 * resolution)|0) / resolution;
-            ty2 = ((ty2 * resolution)|0) / resolution;
-            tx3 = ((tx3 * resolution)|0) / resolution;
-            ty3 = ((ty3 * resolution)|0) / resolution;
-        }
-
         vertexViewF32[vertexOffset + 0] = tx0;
         vertexViewF32[vertexOffset + 1] = ty0;
         vertexViewF32[vertexOffset + 2] = uvs.x0;
@@ -851,12 +819,6 @@ var TextureTintPipeline = new Class({
             var y = vertices[index + 1];
             var tx = x * mva + y * mvc + mve;
             var ty = x * mvb + y * mvd + mvf;
-
-            if (roundPixels)
-            {
-                tx = ((tx * resolution)|0) / resolution;
-                tx = ((tx * resolution)|0) / resolution;
-            }
 
             vertexViewF32[vertexOffset + 0] = tx;
             vertexViewF32[vertexOffset + 1] = ty;
@@ -1054,20 +1016,8 @@ var TextureTintPipeline = new Class({
             {
                 this.flush();
             }
-            
-            vertexOffset = this.vertexCount * this.vertexComponentCount;
 
-            if (roundPixels)
-            {
-                tx0 = ((tx0 * resolution)|0) / resolution;
-                ty0 = ((ty0 * resolution)|0) / resolution;
-                tx1 = ((tx1 * resolution)|0) / resolution;
-                ty1 = ((ty1 * resolution)|0) / resolution;
-                tx2 = ((tx2 * resolution)|0) / resolution;
-                ty2 = ((ty2 * resolution)|0) / resolution;
-                tx3 = ((tx3 * resolution)|0) / resolution;
-                ty3 = ((ty3 * resolution)|0) / resolution;
-            }
+            vertexOffset = this.vertexCount * this.vertexComponentCount;
 
             vertexViewF32[vertexOffset + 0] = tx0;
             vertexViewF32[vertexOffset + 1] = ty0;
@@ -1099,7 +1049,7 @@ var TextureTintPipeline = new Class({
             vertexViewF32[vertexOffset + 27] = umax;
             vertexViewF32[vertexOffset + 28] = vmin;
             vertexViewU32[vertexOffset + 29] = tint3;
-        
+
             this.vertexCount += 6;
         }
     },
@@ -1250,7 +1200,7 @@ var TextureTintPipeline = new Class({
 
             glyphW = glyph.width;
             glyphH = glyph.height;
-            
+
             x = (indexCount + glyph.xOffset + xAdvance) - scrollX;
             y = (glyph.yOffset + yAdvance) - scrollY;
 
@@ -1357,20 +1307,8 @@ var TextureTintPipeline = new Class({
             {
                 this.flush();
             }
-            
-            vertexOffset = this.vertexCount * this.vertexComponentCount;
 
-            if (roundPixels)
-            {
-                tx0 = ((tx0 * resolution)|0) / resolution;
-                ty0 = ((ty0 * resolution)|0) / resolution;
-                tx1 = ((tx1 * resolution)|0) / resolution;
-                ty1 = ((ty1 * resolution)|0) / resolution;
-                tx2 = ((tx2 * resolution)|0) / resolution;
-                ty2 = ((ty2 * resolution)|0) / resolution;
-                tx3 = ((tx3 * resolution)|0) / resolution;
-                ty3 = ((ty3 * resolution)|0) / resolution;
-            }
+            vertexOffset = this.vertexCount * this.vertexComponentCount;
 
             vertexViewF32[vertexOffset + 0] = tx0;
             vertexViewF32[vertexOffset + 1] = ty0;
@@ -1402,7 +1340,7 @@ var TextureTintPipeline = new Class({
             vertexViewF32[vertexOffset + 27] = umax;
             vertexViewF32[vertexOffset + 28] = vmin;
             vertexViewU32[vertexOffset + 29] = tint3;
-        
+
             this.vertexCount += 6;
         }
 
@@ -1645,22 +1583,10 @@ var TextureTintPipeline = new Class({
         var v0 = (frameY / textureHeight) + vOffset;
         var u1 = (frameX + frameWidth) / textureWidth + uOffset;
         var v1 = (frameY + frameHeight) / textureHeight + vOffset;
-        
+
         this.setTexture2D(texture, 0);
 
         vertexOffset = this.vertexCount * this.vertexComponentCount;
-
-        if (roundPixels)
-        {
-            tx0 = ((tx0 * resolution)|0) / resolution;
-            ty0 = ((ty0 * resolution)|0) / resolution;
-            tx1 = ((tx1 * resolution)|0) / resolution;
-            ty1 = ((ty1 * resolution)|0) / resolution;
-            tx2 = ((tx2 * resolution)|0) / resolution;
-            ty2 = ((ty2 * resolution)|0) / resolution;
-            tx3 = ((tx3 * resolution)|0) / resolution;
-            ty3 = ((ty3 * resolution)|0) / resolution;
-        }
 
         vertexViewF32[vertexOffset + 0] = tx0;
         vertexViewF32[vertexOffset + 1] = ty0;


### PR DESCRIPTION
This fixes #3245.

This removes certain if() blocks added in 7b1ad0b in order to fix camera
jitter that occurs when both `roundPixels` is enabled and sprite
following is enabled.

**NOTE:** It's not clear to me what the if() blocks removed had been doing,
but the associated commit message suggested they were trying to make
`roundPixels` actually do something, as if that flag weren't having any effect.
However prior to that commit `roundPixels` seemed to be already working
normally. If the removed blocks actually were resolving a different
problem, then camera jitter will have to be resolved differently than
just removing those blocks.