### PR TITLE
Use webpack-shell-plugin `onBuildExit` event

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
         }),
 
         new WebpackShellPlugin({
-            onBuildEnd: 'node copy-to-examples.js'
+            onBuildExit: 'node copy-to-examples.js'
         })
 
     ],


### PR DESCRIPTION
With this change, `webpack watch` will update the build in the `phaser3-examples` repository too, making it easier to test quick changes in the examples repository.

([Reference](https://github.com/1337programming/webpack-shell-plugin#api).)