### PR TITLE
static is reserved keyword 

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -695,7 +695,7 @@ var World = new Class({
         var body;
 
         var dynamic = this.bodies;
-        var static = this.staticBodies;
+        var statik = this.staticBodies;
         var pending = this.pendingDestroy;
 
         var bodies = dynamic.entries;
@@ -727,7 +727,7 @@ var World = new Class({
                 }
             }
 
-            bodies = static.entries;
+            bodies = statik.entries;
             len = bodies.length;
 
             for (i = 0; i < len; i++)
@@ -761,7 +761,7 @@ var World = new Class({
                 else if (body.physicsType === CONST.STATIC_BODY)
                 {
                     staticTree.remove(body);
-                    static.delete(body);
+                    statik.delete(body);
                 }
 
                 body.world = undefined;


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Static keyword should not be used as an identifier.
