### PR TITLE
Elevate console message for loading data URIs

### DIFF
--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -272,7 +272,7 @@ var File = new Class({
 
             if (this.src.indexOf('data:') === 0)
             {
-                console.log('Local data URI');
+                console.warn('Local data URIs are not supported: ' + this.key);
             }
             else
             {


### PR DESCRIPTION
Use `console.warn` (since it's aborted).

This PR changes

* The public-facing API, very slightly


