### PR TITLE
Fix KeyboardManager keydown events keeps firing

### DIFF
--- a/src/input/keyboard/KeyboardManager.js
+++ b/src/input/keyboard/KeyboardManager.js
@@ -362,23 +362,26 @@ var KeyboardManager = new Class({
             var event = queue[i];
             var code = event.keyCode;
 
-            //  Will emit a keyboard or keyup event
-            this.emit(event.type, event);
-
             if (event.type === 'keydown')
             {
-                if (KeyMap[code])
+                if (KeyMap[code] && (keys[code] === undefined || (keys[code] && keys[code].isDown === false)))
                 {
+                    //  Will emit a keyboard or keyup event
+                    this.emit(event.type, event);
+
                     this.emit('keydown_' + KeyMap[code], event);
                 }
 
-                if (keys[code])
+                if (keys[code] && keys[code].isDown === false)
                 {
                     ProcessKeyDown(keys[code], event);
                 }
             }
             else
             {
+                //  Will emit a keyboard or keyup event
+                this.emit(event.type, event);
+
                 this.emit('keyup_' + KeyMap[code], event);
 
                 if (keys[code])

--- a/src/input/keyboard/KeyboardManager.js
+++ b/src/input/keyboard/KeyboardManager.js
@@ -372,7 +372,7 @@ var KeyboardManager = new Class({
                     this.emit('keydown_' + KeyMap[code], event);
                 }
 
-                if (keys[code] && keys[code].isDown === false)
+                if (keys[code])
                 {
                     ProcessKeyDown(keys[code], event);
                 }

--- a/src/input/keyboard/KeyboardManager.js
+++ b/src/input/keyboard/KeyboardManager.js
@@ -364,7 +364,7 @@ var KeyboardManager = new Class({
 
             if (event.type === 'keydown')
             {
-                if (KeyMap[code] && (keys[code] === undefined || (keys[code] && keys[code].isDown === false)))
+                if (KeyMap[code] && (keys[code] === undefined || keys[code].isDown === false))
                 {
                     //  Will emit a keyboard or keyup event
                     this.emit(event.type, event);

--- a/src/input/keyboard/keys/ProcessKeyDown.js
+++ b/src/input/keyboard/keys/ProcessKeyDown.js
@@ -34,10 +34,14 @@ var ProcessKeyDown = function (key, event)
     key.shiftKey = event.shiftKey;
     key.location = event.location;
 
-    key.isDown = true;
-    key.isUp = false;
-    key.timeDown = event.timeStamp;
-    key.duration = 0;
+    if (key.isDown === false)
+    {
+        key.isDown = true;
+        key.isUp = false;
+        key.timeDown = event.timeStamp;
+        key.duration = 0;
+    }
+
     key.repeats++;
 
     key._justDown = true;


### PR DESCRIPTION
Keydown event is fired repeatedly when holding down keys.
**This PR fixes this bug by changing ```Phaser.Input.Keyboard.KeyboardManager#update```:**
1. Global ```keydown``` and ```keydown_KEYCODE``` event is fired only when ```keys[code].isDown === false || key[code] === undefined```.
> About the condition ```key[code] === undefined ```, since I observed there is no other way to get the previous ```isDown``` state of keys that are not added in KeyboardManager, so global events will still be fired repeatedly during key holding down which isn't added in KeyboardManager.
2. ProcessKeyDown is fired only when ```keys[code].isDown === false``` (#3239 )

I don't confirmed if there is another better solution🤔

Thanks @agilul for the advice of this issue.