### PR TITLE
BugFix for ScenePlugin.launch, data now passed to queued scenes

### DIFF
--- a/src/scene/ScenePlugin.js
+++ b/src/scene/ScenePlugin.js
@@ -158,7 +158,7 @@ var ScenePlugin = new Class({
         {
             if (this.settings.status !== CONST.RUNNING)
             {
-                this.manager.queueOp('start', key);
+                this.manager.queueOp('start', key, data);
             }
             else
             {


### PR DESCRIPTION
This PR changes

* Nothing, it's a bug fix

Fixed the scene plugin launch function so that data is passed to scenes queued for processing when they are not yet running.
