### PR TITLE
Support MultiAtlas with TexturePackers "Phaser 3" atlas format 

### DIFF
--- a/src/loader/LoaderPlugin.js
+++ b/src/loader/LoaderPlugin.js
@@ -656,7 +656,7 @@ var LoaderPlugin = new Class({
                 //  Yup, add them to the Texture Manager
 
                 //  Is the data JSON Hash or JSON Array?
-                if (Array.isArray(data[0].frames))
+                if (Array.isArray(data[0].textures) || Array.isArray(data[0].frames))
                 {
                     textures.addAtlasJSONArray(key, images, data);
                 }

--- a/src/textures/TextureManager.js
+++ b/src/textures/TextureManager.js
@@ -314,9 +314,11 @@ var TextureManager = new Class({
 
         if (Array.isArray(data))
         {
-            for (var i = 0; i < data.length; i++)
+            var singleAtlasFile = (data.length === 1); // multi-pack with one atlas file for all images
+            for (var i = 0; i < texture.source.length; i++)
             {
-                Parser.JSONArray(texture, i, data[i]);
+                var atlasData = singleAtlasFile ? data[0] : data[i];
+                Parser.JSONArray(texture, i, atlasData);
             }
         }
         else

--- a/src/textures/parsers/JSONArray.js
+++ b/src/textures/parsers/JSONArray.js
@@ -34,7 +34,7 @@ var JSONArray = function (texture, sourceIndex, json)
     texture.add('__BASE', sourceIndex, 0, 0, source.width, source.height);
 
     //  By this stage frames is a fully parsed array
-    var frames = (Array.isArray(json.textures)) ? json.textures[0].frames : json.frames;
+    var frames = (Array.isArray(json.textures)) ? json.textures[sourceIndex].frames : json.frames;
 
     var newFrame;
 


### PR DESCRIPTION
TexturePacker's new JSON atlas format "Phaser 3" exports one combined atlas file for all image files when multi-pack (MultiAtlas) is used.
This change enables Phaser to load the textures with the combined atlas file:

`this.load.multiatlas('sheet', ['sheet-0.png', 'sheet-1.png'], 'sheet.json');`