### PR TITLE
swapped queue loop to use _queue prop rather than queueLength var

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -166,13 +166,13 @@ var SceneManager = new Class({
             return;
         }
 
-        for (i = 0; i < queueLength; i++)
+        for (i = 0; i < this._queue.length; i++)
         {
             entry = this._queue[i];
 
             this[entry.op](entry.keyA, entry.keyB);
         }
-        
+
         this._queue.length = 0;
     },
 
@@ -278,7 +278,7 @@ var SceneManager = new Class({
         if (scene.sys.load)
         {
             loader = scene.sys.load;
-                
+
             loader.reset();
         }
 
@@ -872,7 +872,7 @@ var SceneManager = new Class({
                     return this;
                 }
             }
-            
+
             this.bootScene(scene);
         }
 


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

In the `src/scene/SceneManager.js` file, in the `processQueue` method, the loop used to iterate over the `this._queue` and execute the operations therein was using the `queueLength` variable. This caused a bug where the `queueLength` variable would remain at 2 even though more commands were added to the queue. In turn the queue would never get past 2 commands and would be cleared before the other operations could execute.

By switching the loop to utilize the `this._queue.length` value instead it will be able to iterate over later commands.
