### PR TITLE
Fix for collideGroupVsSelf is undefined

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1364,10 +1364,11 @@ var World = new Class({
      */
     collideHandler: function (object1, object2, collideCallback, processCallback, callbackContext, overlapOnly)
     {
+        //  Collide Group with Self
         //  Only collide valid objects
         if (object2 === undefined && object1.isParent)
         {
-            return this.collideGroupVsSelf(object1, collideCallback, processCallback, callbackContext, overlapOnly);
+            return this.collideGroupVsGroup(object1, object1, collideCallback, processCallback, callbackContext, overlapOnly);
         }
 
         //  If neither of the objects are set then bail out


### PR DESCRIPTION


**This PR changes (delete as applicable)**

* Nothing, it's a bug fix

**Describe the changes below:**

This happens when you call collide with a single group as the first param.

Seems like the `collideGroupVsSelf` function was not implemented. I've changed it to just call the `collideGroupVsGroup` with the first object twice which worked when I tested it on my project.