### PR TITLE
Quick fix for missing lineSpacing

### DIFF
--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -200,6 +200,11 @@ var Text = new Class({
         {
             this.setPadding(style.padding);
         }
+        
+        if (style && style.lineSpacing)
+        {
+            this._lineSpacing = style.lineSpacing;
+        }
 
         this.setText(text);
 


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Fix for #3215:
Reads lineSpacing if passed as attribute to `style` within text config.
