### PR TITLE
Fixed Group doesn't remove children from Scene when cleared

### DIFF
--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -478,9 +478,9 @@ var Group = new Class({
         {
             var children = this.children;
 
-            for (var i = 0; i < children.length; i++)
+            for (var i = 0; i < children.size; i++)
             {
-                var gameObject = children[i];
+                var gameObject = children.entries[i];
 
                 this.scene.sys.displayList.remove(gameObject);
 


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

I noticed that when calling `Group#clear` with `removeFromScene = true` that children weren't actually removed from the Scene.

Note: if acceptable, I'll update the changelog once the next release section has been added.