### PR TITLE
Make scene restartable

### DIFF
--- a/src/scene/ScenePlugin.js
+++ b/src/scene/ScenePlugin.js
@@ -105,18 +105,15 @@ var ScenePlugin = new Class({
     {
         if (key === undefined) { key = this.key; }
 
-        if (key !== this.key)
+        if (this.settings.status !== CONST.RUNNING)
         {
-            if (this.settings.status !== CONST.RUNNING)
-            {
-                this.manager.queueOp('stop', this.key);
-                this.manager.queueOp('start', key);
-            }
-            else
-            {
-                this.manager.stop(this.key);
-                this.manager.start(key, data);
-            }
+            this.manager.queueOp('stop', this.key);
+            this.manager.queueOp('start', key);
+        }
+        else
+        {
+            this.manager.stop(this.key);
+            this.manager.start(key, data);
         }
 
         return this;


### PR DESCRIPTION
This PR changes
* Nothing, it's a bug fix

Currently, a scene cannot restart itself.

    if (someCondition) {
        this.scene.start(); // not work.
    }

ScenePlugin.start() should not ignore the same scene key.
