### PR TITLE
fixed camera offset when combining zoom+follow

### DIFF
--- a/src/cameras/2d/Camera.js
+++ b/src/cameras/2d/Camera.js
@@ -852,8 +852,8 @@ var Camera = new Class({
             originX = follow.x;
             originY = follow.y;
 
-            this.scrollX = originX - width * 0.5;
-            this.scrollY = originY - height * 0.5;
+            this.scrollX = (originX - width * 0.5)/zoom;
+            this.scrollY = (originY - height * 0.5)/zoom;
         }
 
         if (this.useBounds)

--- a/src/cameras/2d/Camera.js
+++ b/src/cameras/2d/Camera.js
@@ -852,8 +852,8 @@ var Camera = new Class({
             originX = follow.x;
             originY = follow.y;
 
-            this.scrollX = (originX - width * 0.5)/zoom;
-            this.scrollY = (originY - height * 0.5)/zoom;
+            this.scrollX = (originX - width * 0.5) / zoom;
+            this.scrollY = (originY - height * 0.5) / zoom;
         }
 
         if (this.useBounds)


### PR DESCRIPTION
This PR changes

* Nothing, it's a bug fix

Describe the changes below:

fixes bug mentioned in: #3353 

Camera scroll did not account for zoom level when following a sprite causing it to gain an offset
this change fixed it based on my tests so far.

```
this.scrollX = (originX - width * 0.5) / zoom;
this.scrollY = (originY - height * 0.5) / zoom;
```


