### PR TITLE
Add reference of GameObject class

### DIFF
--- a/src/gameobjects/index.js
+++ b/src/gameobjects/index.js
@@ -17,6 +17,7 @@ var GameObjects = {
 
     Components: require('./components'),
 
+    GameObject: require('./GameObject'),
     BitmapText: require('./bitmaptext/static/BitmapText'),
     Blitter: require('./blitter/Blitter'),
     DynamicBitmapText: require('./bitmaptext/dynamic/DynamicBitmapText'),

--- a/src/gameobjects/index.js
+++ b/src/gameobjects/index.js
@@ -17,6 +17,8 @@ var GameObjects = {
 
     Components: require('./components'),
 
+    BuildGameObject: require('./BuildGameObject'),
+    BuildGameObjectAnimation: require('./BuildGameObjectAnimation'),
     GameObject: require('./GameObject'),
     BitmapText: require('./bitmaptext/static/BitmapText'),
     Blitter: require('./blitter/Blitter'),


### PR DESCRIPTION
* The public-facing API

This changing won't change any behavior, just put `GameObject` reference into `Phaser.GameObjects.GameObject`, which allow developer to create new game object based on `GameObject` class.

