### PR TITLE
Fix TimerEvent.remove behaves opposite to what we expect

### DIFF
--- a/src/time/TimerEvent.js
+++ b/src/time/TimerEvent.js
@@ -274,7 +274,7 @@ var TimerEvent = new Class({
 
         this.elapsed = this.delay;
 
-        this.hasDispatched = !!dispatchCallback;
+        this.hasDispatched = !dispatchCallback;
 
         this.repeatCount = 0;
     },


### PR DESCRIPTION
This PR changes (delete as applicable)
* Nothing, it's a bug fix

When we call TimerEvent.remove(),
the event is dispatched immediately if 'dispatchCallback' is set to falsy,
just removed otherwise.

The argument is taken as opposite meaning.
