### PR TITLE
Added rotation, scaling and flipping to TileSpriteCanvasRenderer

### DIFF
--- a/src/gameobjects/tilesprite/TileSpriteCanvasRenderer.js
+++ b/src/gameobjects/tilesprite/TileSpriteCanvasRenderer.js
@@ -61,6 +61,23 @@ var TileSpriteCanvasRenderer = function (renderer, src, interpolationPercentage,
     var tx = src.x - camera.scrollX * src.scrollFactorX;
     var ty = src.y - camera.scrollY * src.scrollFactorY;
 
+    var fx = 1;
+    var fy = 1;
+
+    // Flipping
+
+    if (src.flipX)
+    {
+        fx = -1;
+        dx += src.width;
+    }
+
+    if (src.flipY)
+    {
+        fy = -1;
+        dy += src.height;
+    }
+
     if (renderer.config.roundPixels)
     {
         dx |= 0;
@@ -75,10 +92,18 @@ var TileSpriteCanvasRenderer = function (renderer, src, interpolationPercentage,
 
     ctx.translate(tx, ty);
 
-    ctx.fillStyle = src.canvasPattern;
+    // Flip
+    ctx.scale(fx, fy);
 
+    // Rotate and scale around center
+    ctx.translate((src.originX * src.width), (src.originY * src.height));
+    ctx.rotate(fx * fy * src.rotation);
+    ctx.scale(this.scaleX, this.scaleY);
+    ctx.translate(-(src.originX * src.width), -(src.originY * src.height));
+
+    // Draw
     ctx.translate(-this.tilePositionX, -this.tilePositionY);
-
+    ctx.fillStyle = src.canvasPattern;
     ctx.fillRect(this.tilePositionX, this.tilePositionY, src.width, src.height);
 
     ctx.restore();


### PR DESCRIPTION
This PR changes

* Nothing, it's a bug fix

Describe the changes below:

Fix for #3231:

The tilesprite CANVAS renderer did not support rotation and scaling. Furthermore we discovered that it did not support flipping. This PR fixes the rotation and the flipping. Scaling of the tilesprite also works now, but we noticed there are still some texture scaling issues compared to webgl (see #3338).

[Jsfiddle](https://jsfiddle.net/goL3t8q6/20/) demonstrating rotation, scaling and flipping on the canvas renderer (adapted from phaser3 examples).

