### PR TITLE
Fix error when calling `timeline.resetTweens()`

### DIFF
--- a/src/tweens/Timeline.js
+++ b/src/tweens/Timeline.js
@@ -546,6 +546,21 @@ var Timeline = new Class({
     },
 
     /**
+     * Delegates #makeActive to the Tween manager.
+     *
+     * @method Phaser.Tweens.Timeline#makeActive
+     * @since 3.3.0
+     *
+     * @param {Phaser.Tweens.Tween} tween - The tween object to make active.
+     *
+     * @return {Phaser.Tweens.TweenManager} The Timeline's Tween Manager object.
+     */
+    makeActive: function (tween)
+    {
+        return this.manager.makeActive(tween);
+    },
+
+    /**
      * [description]
      *
      * @method Phaser.Tweens.Timeline#play
@@ -561,7 +576,7 @@ var Timeline = new Class({
         if (this.paused)
         {
             this.paused = false;
-        
+
             this.manager.makeActive(this);
 
             return;
@@ -823,7 +838,7 @@ var Timeline = new Class({
                 return true;
             }
         }
-        
+
         return false;
     },
 


### PR DESCRIPTION
**Issue**
`Phaser.Tweens.Timeline.resetTweens()` throws `TypeError: this.parent.makeActive is not a function` ([Tween.js:619](https://github.com/photonstorm/phaser/blob/935a89342da540cc9bdf502e8ded56ce16b4557d/src/tweens/tween/Tween.js#L619)).

**Versions**
Phaser: 3.2.0
Browser: Firefox 58.0.2
OS: Ubuntu 17.10

**Repro**
```javascript
function create() {
    sprite = this.add.sprite(0, 0, 'pointer');
    timeline = this.tweens.createTimeline();
    timeline.add({
        targets: sprite,
        x: 42,
        y: 42,
        duration: 1000
    });
    timeline.play();
}

function update() {
    timeline.resetTweens();
}
```
(Throws the error after the timeline is completed.)

**Expected Behavior**
Well, it's not documented, but I believe the intent for `#resetTweens` (looking at the code) is to essentially invoke `#play` on all the child tweens of the timeline. I was expecting to have the ability to "replay" the timeline after it has been completed after an event, e.g. 'pointerdown'.

**Explanation** _(Copied verbatim from commit message)_
This fixes a bug when calling Timeline#resetTweens() while the tweens are pending removal or completed. Delegating the #makeActive method here was chosen to:
- Follow "tell, don't ask" (http://pragprog.com/articles/tell-dont-ask)
- Prevent an additional branch conditional in Tween.js
- Prevent a Law of Demeter violation, e.g.

```javascript
// src/tweens/tween/Tween.js
if (this.parentIsTimeline) // "asking"
{
    this.parent.manager.makeActive(this); // LoD violation
}
else
{
    this.parent.makeActive(this);
}
```

**Misc**
I left a message in the `#general` Slack channel; I didn't delve too deeply into the code, so I'm not sure what code styles/patterns are preferred... just went with my dogma and preference. Happy to refactor/revise as needed.

:beers: