### PR TITLE
Fix error when no Light Manager exists

### DIFF
--- a/src/renderer/webgl/pipelines/ForwardDiffuseLightPipeline.js
+++ b/src/renderer/webgl/pipelines/ForwardDiffuseLightPipeline.js
@@ -73,6 +73,11 @@ var ForwardDiffuseLightPipeline = new Class({
     {
         var lightManager = scene.lights;
 
+        if (!lightManager)
+        {
+            return this;
+        }
+
         lightManager.culledLights.length = 0;
 
         if (lightManager.lights.length <= 0 || !lightManager.active)


### PR DESCRIPTION
It can be excluded by `sceneConfig.map` or `sceneConfig.plugins`.

> Uncaught TypeError: Cannot read property 'culledLights' of undefined

This PR changes

* Nothing, it's a bug fix
