### PR TITLE
fix offset in hitTest when resolution !== 1

### DIFF
--- a/src/input/InputManager.js
+++ b/src/input/InputManager.js
@@ -390,8 +390,8 @@ var InputManager = new Class({
                 continue;
             }
 
-            var px = tempPoint.x + (camera.scrollX * gameObject.scrollFactorX) - camera.scrollX;
-            var py = tempPoint.y + (camera.scrollY * gameObject.scrollFactorY) - camera.scrollY;
+            var px = tempPoint.x * this.game.config.resolution + (camera.scrollX * gameObject.scrollFactorX) - camera.scrollX;
+            var py = tempPoint.y * this.game.config.resolution + (camera.scrollY * gameObject.scrollFactorY) - camera.scrollY;
 
             TransformXY(px, py, gameObject.x, gameObject.y, gameObject.rotation, gameObject.scaleX, gameObject.scaleY, point);
 


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix
Fixes issue #3371

Describe the changes below:
Hit area was off when setting resolution to anything but 1.
I have multiplied the hit point with the resolution to make sure it adds up. 