### PR TITLE
set default gamepad button threshold to 1

### DIFF
--- a/src/input/gamepad/Button.js
+++ b/src/input/gamepad/Button.js
@@ -69,7 +69,7 @@ var Button = new Class({
          * @default 0
          * @since 3.0.0
          */
-        this.threshold = 0;
+        this.threshold = 1;
 
         /**
          * Is the Button being pressed down or not?


### PR DESCRIPTION
this.threshold = 0  was making all gamepad buttons to be always pressed down (this.pressed = true). 
this.threshold = 1 will correct the issue and in the case of analogue buttons it will only emit the event when the 'pressure' is at max.

This PR changes (delete as applicable)

* Nothing, it's a bug fix
