### PR TITLE
Remove 'shutdown' and 'destroy' callbacks in createSceneFromObject

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -655,7 +655,7 @@ var SceneManager = new Class({
 
         //  Extract callbacks
 
-        var defaults = [ 'init', 'preload', 'create', 'update', 'render', 'shutdown', 'destroy' ];
+        var defaults = [ 'init', 'preload', 'create', 'update', 'render' ];
 
         for (var i = 0; i < defaults.length; i++)
         {


### PR DESCRIPTION
Phaser copies any 'shutdown' or 'destroy' methods of a scene object onto the scene, but it never calls those methods.

This change affects users who include 'shutdown' or 'destroy' methods on a scene object and then call those methods themselves (as those methods will now be undefined). They should move those methods onto the `extend.shutdown` and `extend.destroy`.

Users who have not included a 'shutdown' or 'destroy' methods on a scene object are unaffected.

This PR changes

* The public-facing API:
  
  - Phaser.Scenes.SceneManager#createSceneFromObject
