### PR TITLE
pass data to the manager queue when starting a scene

### DIFF
--- a/src/scene/ScenePlugin.js
+++ b/src/scene/ScenePlugin.js
@@ -108,7 +108,7 @@ var ScenePlugin = new Class({
         if (this.settings.status !== CONST.RUNNING)
         {
             this.manager.queueOp('stop', this.key);
-            this.manager.queueOp('start', key);
+            this.manager.queueOp('start', key, data);
         }
         else
         {


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

When the scene start is delayed, add the data as well as the key in the queue