### PR TITLE
Fix [CameraManager].getCamera(<name>) 

### DIFF
--- a/src/cameras/2d/CameraManager.js
+++ b/src/cameras/2d/CameraManager.js
@@ -308,11 +308,11 @@ var CameraManager = new Class({
      */
     getCamera: function (name)
     {
-        for (var camera of this.cameras)
+        for (var i = 0; i < this.cameras.length; i++)
         {
-            if (camera.name === name)
+            if (this.cameras[i].name === name)
             {
-                return camera;
+                return this.cameras[i];
             }
         }
 

--- a/src/cameras/2d/CameraManager.js
+++ b/src/cameras/2d/CameraManager.js
@@ -308,13 +308,13 @@ var CameraManager = new Class({
      */
     getCamera: function (name)
     {
-        this.cameras.forEach(function (camera)
+        for (var camera of this.cameras)
         {
             if (camera.name === name)
             {
                 return camera;
             }
-        });
+        }
 
         return null;
     },

--- a/src/cameras/sprite3d/CameraManager.js
+++ b/src/cameras/sprite3d/CameraManager.js
@@ -155,13 +155,13 @@ var CameraManager = new Class({
      */
     getCamera: function (name)
     {
-        this.cameras.forEach(function (camera)
+        for (var i = 0; i < this.cameras.length; i++)
         {
-            if (camera.name === name)
+            if (this.cameras[i].name === name)
             {
-                return camera;
+                return this.cameras[i];
             }
-        });
+        }
 
         return null;
     },


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

[CameraManager].getCamera(<name>) returns the requested camera 