### PR TITLE
Remove scene key in SceneManager

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -161,7 +161,7 @@ var SceneManager = new Class({
 
             //  Replace key in case the scene changed it
             key = newScene.sys.settings.key;
-                
+
             this.keys[key] = newScene;
 
             this.scenes.push(newScene);
@@ -356,7 +356,7 @@ var SceneManager = new Class({
 
             if (index > -1)
             {
-                this.keys[sceneKey] = undefined;
+                delete this.keys[sceneKey];
                 this.scenes.splice(index, 1);
 
                 if (this._start.indexOf(sceneKey) > -1)


### PR DESCRIPTION
When we remove scene we did set its key value to undefined. Because of that, when i would like to create a new scene with the same key(after removing the old scene), the `SceneManager#createSceneFromFunction` would throw exception `Cannot add a Scene with duplicate key`.

This fix deletes key from hash.
