### PR TITLE
Bug fix: font might not sync to context

### DIFF
--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -486,6 +486,8 @@ var Text = new Class({
     {
         if (text === undefined) { text = this.text; }
 
+        this.style.syncFont(this.canvas, this.context);
+
         var wrappedLines = this.runWordWrap(text);
 
         return wrappedLines.split(this.splitRegExp);

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -12,6 +12,7 @@ module.exports = {
 
     FileTypes: require('./filetypes'),
 
+    CONST: require('./const'),
     File: require('./File'),
     FileTypesManager: require('./FileTypesManager'),
     GetURL: require('./GetURL'),


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Sync font before runWordWrap.

#3389 
In Text.updateText() function, **style.syncFont()** will be invoked before Text.runWordWrap(). But Text.getWrappedText() won't call style.syncFont(), therefore the wrapping result between Text.updateText() and Text.getWrappedText() might not be equal.

