### PR TITLE
(WebGL) updating currentScissor on game.resize

### DIFF
--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -480,6 +480,8 @@ var WebGLRenderer = new Class({
         {
             pipelines[pipelineName].resize(width, height, resolution);
         }
+                
+        this.currentScissor.set([ 0, 0, this.width, this.height ]);
 
         return this;
     },


### PR DESCRIPTION
with the array now being updated it solves the issue with the global background not being fully redraw after resizing the game while using webgl.

This PR changes (delete as applicable)

* Nothing, it's a bug fix