### PR TITLE
Fix changing alpha in RenderTextureWebGLRenderer

### DIFF
--- a/src/gameobjects/rendertexture/RenderTextureWebGLRenderer.js
+++ b/src/gameobjects/rendertexture/RenderTextureWebGLRenderer.js
@@ -5,6 +5,7 @@
  */
 
 var GameObject = require('../GameObject');
+var Utils = require('../../renderer/webgl/Utils');
 
 /**
  * Renders this Game Object with the Canvas Renderer to the given Camera.
@@ -39,7 +40,7 @@ var RenderTextureWebGLRenderer = function (renderer, renderTexture, interpolatio
         renderTexture.scrollFactorX, renderTexture.scrollFactorY,
         renderTexture.displayOriginX, renderTexture.displayOriginY,
         0, 0, renderTexture.texture.width, renderTexture.texture.height,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        Utils.getTintAppendFloatAlpha(renderTexture.tintTopLeft, renderTexture.alphaTopLeft), Utils.getTintAppendFloatAlpha(renderTexture.tintTopRight, renderTexture.alphaTopRight), Utils.getTintAppendFloatAlpha(renderTexture.tintBottomLeft, renderTexture.alphaBottomLeft), Utils.getTintAppendFloatAlpha(renderTexture.tintBottomRight, renderTexture.alphaBottomRight),
         0, 0,
         camera
     );


### PR DESCRIPTION
This PR changes (delete as applicable)
* Nothing, it's a bug fix

Describe the changes below:
This is a fix for https://github.com/photonstorm/phaser/issues/3385. The tint of the texture was always set to 0xffffff and therefor the alpha values were ignored. The tint is now calculated using the alpha value.
