### PR TITLE
Remove string-generated Functions for CSP policies

### DIFF
--- a/src/structs/RTree.js
+++ b/src/structs/RTree.js
@@ -467,20 +467,25 @@ rbush.prototype = {
     {
         // data format (minX, minY, maxX, maxY accessors)
 
-        // uses eval-type function compilation instead of just accepting a toBBox function
-        // because the algorithms are very sensitive to sorting functions performance,
-        // so they should be dead simple and without inner calls
+        // Do not use string-generated Functions for CSP policies
+        // Instead a combination of anonymous functions and grabbing
+        // properties by string is used.
+        var compareArr = function(accessor) {
+            return function(a, b) {
+                return this[a + accessor] - this[b + accessor];
+            };
+        };
+        this.compareMinX = compareArr(format[0]);
+        this.compareMinY = compareArr(format[1]);
 
-        var compareArr = ['return a', ' - b', ';'];
-
-        this.compareMinX = new Function('a', 'b', compareArr.join(format[0]));
-        this.compareMinY = new Function('a', 'b', compareArr.join(format[1]));
-
-        this.toBBox = new Function('a',
-            'return {minX: a' + format[0] +
-            ', minY: a' + format[1] +
-            ', maxX: a' + format[2] +
-            ', maxY: a' + format[3] + '};');
+        this.toBBox = function (a) {
+            return {
+                minX: a + format[0],
+                minY: a + format[1],
+                maxX: a + format[2],
+                maxy: a + format[3]
+            };
+        };
     }
 };
 


### PR DESCRIPTION
### This PR changes:

- Nothing, it's a bug fix (*kinda*)

### Aim

The aim of this pull request is to address the issues noted in #3441, by replacing the use of generated Functions with the combination of anonymous functions and accessing properties by strings.


