### PR TITLE
Change structs for generic types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 Thumbs.db
 .DS_Store
 .idea
+.vscode
 *.suo
 *.sublime-project
 *.sublime-workspace

--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -80,7 +80,7 @@ var AnimationManager = new Class({
          * [description]
          *
          * @name Phaser.Animations.AnimationManager#anims
-         * @type {Phaser.Structs.Map}
+         * @type {Phaser.Structs.Map<string, Phaser.Animations.Animation>}
          * @protected
          * @since 3.0.0
          */

--- a/src/cache/BaseCache.js
+++ b/src/cache/BaseCache.js
@@ -33,7 +33,7 @@ var BaseCache = new Class({
          * You can query the Map directly or use the BaseCache methods.
          *
          * @name Phaser.Cache.BaseCache#entries
-         * @type {Phaser.Structs.Map}
+         * @type {Phaser.Structs.Map.<String, *>}
          * @since 3.0.0
          */
         this.entries = new CustomMap();
@@ -54,9 +54,9 @@ var BaseCache = new Class({
      * This event is fired by the Cache each time a new object is added to it.
      *
      * @event Phaser.Cache.BaseCache#addEvent
-     * @param {Phaser.Cache.BaseCache} The BaseCache to which the object was added.
-     * @param {string} The key of the object added to the cache.
-     * @param {*} A reference to the object added to the cache.
+     * @param {Phaser.Cache.BaseCache} base - The BaseCache to which the object was added.
+     * @param {string} key - The key of the object added to the cache.
+     * @param {*} object - A reference to the object added to the cache.
      */
 
     /**

--- a/src/cache/CacheManager.js
+++ b/src/cache/CacheManager.js
@@ -10,7 +10,7 @@ var Class = require('../utils/Class');
 /**
  * @classdesc
  * The Cache Manager is the global cache owned and maintained by the Game instance.
- * 
+ *
  * Various systems, such as the file Loader, rely on this cache in order to store the files
  * it has loaded. The manager itself doesn't store any files, but instead owns multiple BaseCache
  * instances, one per type of file. You can also add your own custom caches.
@@ -145,7 +145,7 @@ var CacheManager = new Class({
          * Add to this via the `addCustom` method.
          *
          * @name Phaser.Cache.CacheManager#custom
-         * @type {object.<Phaser.Cache.BaseCache>}
+         * @type {Object.<Phaser.Cache.BaseCache>}
          * @protected
          * @since 3.0.0
          */

--- a/src/gameobjects/blitter/Blitter.js
+++ b/src/gameobjects/blitter/Blitter.js
@@ -90,7 +90,7 @@ var Blitter = new Class({
          * [description]
          *
          * @name Phaser.GameObjects.Blitter#children
-         * @type {Phaser.Structs.List}
+         * @type {Phaser.Structs.List.<Phaser.GameObjects.Blitter.Blitter>}
          * @since 3.0.0
          */
         this.children = new List();
@@ -153,7 +153,7 @@ var Blitter = new Class({
      *
      * @param {BlitterFromCallback} callback - The callback to invoke after creating a bob. It will be sent two arguments: The Bob and the index of the Bob.
      * @param {integer} quantity - The quantity of Bob objects to create.
-     * @param {string} [frame] - The Frame the Bobs will use. It must be part of the Blitter Texture.
+     * @param {(string|integer|Phaser.Textures.Frame|string[]|integer[]|Phaser.Textures.Frame[])} [frame] - The Frame the Bobs will use. It must be part of the Blitter Texture.
      * @param {boolean} [visible=true] - [description]
      *
      * @return {Phaser.GameObjects.Blitter.Bob[]} An array of Bob objects that were created.
@@ -179,7 +179,7 @@ var Blitter = new Class({
      * @since 3.0.0
      *
      * @param {integer} quantity - The quantity of Bob objects to create.
-     * @param {string} [frame] - The Frame the Bobs will use. It must be part of the Blitter Texture.
+     * @param {(string|integer|Phaser.Textures.Frame|string[]|integer[]|Phaser.Textures.Frame[])} [frame] - The Frame the Bobs will use. It must be part of the Blitter Texture.
      * @param {boolean} [visible=true] - [description]
      *
      * @return {Phaser.GameObjects.Blitter.Bob[]} An array of Bob objects that were created.

--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -86,7 +86,7 @@ var Sprite = require('../sprite/Sprite');
  * @since 3.0.0
  *
  * @param {Phaser.Scene} scene - [description]
- * @param {array} children - [description]
+ * @param {Phaser.GameObjects.GameObject[]} children - [description]
  * @param {GroupConfig} config - [description]
  */
 var Group = new Class({
@@ -114,7 +114,7 @@ var Group = new Class({
          * [description]
          *
          * @name Phaser.GameObjects.Group#children
-         * @type {Phaser.Structs.Set}
+         * @type {Phaser.Structs.Set.<Phaser.GameObjects.GameObject>}
          * @since 3.0.0
          */
         this.children = new Set(children);

--- a/src/gameobjects/particles/ParticleEmitterManager.js
+++ b/src/gameobjects/particles/ParticleEmitterManager.js
@@ -114,7 +114,7 @@ var ParticleEmitterManager = new Class({
          * A list of Emitters being managed by this Emitter Manager.
          *
          * @name Phaser.GameObjects.Particles.ParticleEmitterManager#emitters
-         * @type {Phaser.Structs.List}
+             * @type {Phaser.Structs.List.<Phaser.GameObjects.Particles.ParticleEmitter>}
          * @since 3.0.0
          */
         this.emitters = new List(this);
@@ -123,7 +123,7 @@ var ParticleEmitterManager = new Class({
          * A list of Gravity Wells being managed by this Emitter Manager.
          *
          * @name Phaser.GameObjects.Particles.ParticleEmitterManager#wells
-         * @type {Phaser.Structs.List}
+         * @type {Phaser.Structs.List.<Phaser.GameObjects.Particles.GravityWell>}
          * @since 3.0.0
          */
         this.wells = new List(this);

--- a/src/loader/LoaderPlugin.js
+++ b/src/loader/LoaderPlugin.js
@@ -15,6 +15,14 @@ var PluginManager = require('../boot/PluginManager');
 var XHRSettings = require('./XHRSettings');
 
 /**
+ * @typedef {object} LinkFileObject
+ *
+ * @property {string} type - [description]
+ * @property {Phaser.Loader.File} fileA - [description]
+ * @property {Phaser.Loader.File} fileB - [description]
+ */
+
+/**
  * @typedef {object} LoaderFileObject
  *
  * @property {string} key - [description]
@@ -188,7 +196,7 @@ var LoaderPlugin = new Class({
          * [description]
          *
          * @name Phaser.Loader.LoaderPlugin#list
-         * @type {Phaser.Structs.Set}
+         * @type {Phaser.Structs.Set.<Phaser.Loader.File>}
          * @since 3.0.0
          */
         this.list = new CustomSet();
@@ -197,7 +205,7 @@ var LoaderPlugin = new Class({
          * [description]
          *
          * @name Phaser.Loader.LoaderPlugin#inflight
-         * @type {Phaser.Structs.Set}
+         * @type {Phaser.Structs.Set.<Phaser.Loader.File>}
          * @since 3.0.0
          */
         this.inflight = new CustomSet();
@@ -206,7 +214,7 @@ var LoaderPlugin = new Class({
          * [description]
          *
          * @name Phaser.Loader.LoaderPlugin#failed
-         * @type {Phaser.Structs.Set}
+         * @type {Phaser.Structs.Set.<Phaser.Loader.File>}
          * @since 3.0.0
          */
         this.failed = new CustomSet();
@@ -215,7 +223,7 @@ var LoaderPlugin = new Class({
          * [description]
          *
          * @name Phaser.Loader.LoaderPlugin#queue
-         * @type {Phaser.Structs.Set}
+         * @type {Phaser.Structs.Set.<Phaser.Loader.File>}
          * @since 3.0.0
          */
         this.queue = new CustomSet();
@@ -224,7 +232,7 @@ var LoaderPlugin = new Class({
          * [description]
          *
          * @name Phaser.Loader.LoaderPlugin#storage
-         * @type {Phaser.Structs.Set}
+         * @type {Phaser.Structs.Set.<(Phaser.Loader.File|LinkFileObject)>}
          * @since 3.0.0
          */
         this.storage = new CustomSet();

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -121,7 +121,7 @@ var World = new Class({
          * Dynamic Bodies
          *
          * @name Phaser.Physics.Arcade.World#bodies
-         * @type {Phaser.Structs.Set}
+         * @type {Phaser.Structs.Set.<Phaser.Physics.Arcade.Body>}
          * @since 3.0.0
          */
         this.bodies = new Set();
@@ -130,7 +130,7 @@ var World = new Class({
          * Static Bodies
          *
          * @name Phaser.Physics.Arcade.World#staticBodies
-         * @type {Phaser.Structs.Set}
+         * @type {Phaser.Structs.Set.<Phaser.Physics.Arcade.StaticBody>}
          * @since 3.0.0
          */
         this.staticBodies = new Set();
@@ -139,7 +139,7 @@ var World = new Class({
          * Static Bodies
          *
          * @name Phaser.Physics.Arcade.World#pendingDestroy
-         * @type {Phaser.Structs.Set}
+         * @type {Phaser.Structs.Set.<(Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody)>}
          * @since 3.1.0
          */
         this.pendingDestroy = new Set();
@@ -148,7 +148,7 @@ var World = new Class({
          * [description]
          *
          * @name Phaser.Physics.Arcade.World#colliders
-         * @type {Phaser.Structs.ProcessQueue}
+         * @type {Phaser.Structs.ProcessQueue.<Phaser.Physics.Arcade.Collider>}
          * @since 3.0.0
          */
         this.colliders = new ProcessQueue();

--- a/src/physics/impact/World.js
+++ b/src/physics/impact/World.js
@@ -108,7 +108,7 @@ var World = new Class({
          * [description]
          *
          * @name Phaser.Physics.Impact.World#bodies
-         * @type {Phaser.Structs.Set}
+         * @type {Phaser.Structs.Set.<Phaser.Physics.Impact.Body>}
          * @since 3.0.0
          */
         this.bodies = new Set();

--- a/src/structs/List.js
+++ b/src/structs/List.js
@@ -8,14 +8,17 @@ var Class = require('../utils/Class');
 
 /**
  * @callback EachListCallback
+ * @template T
  *
- * @param {*} item - [description]
+ * @param {T} item - [description]
  * @param {...*} [arguments] - Additional arguments that will be passed to the callback, after the child.
  */
 
 /**
  * @classdesc
  * [description]
+ *
+ * @generic T
  *
  * @class List
  * @memberOf Phaser.Structs
@@ -43,7 +46,7 @@ var List = new Class({
          * The objects that belong to this collection.
          *
          * @name Phaser.Structs.List#list
-         * @type {array}
+         * @type {Array.<*>}
          * @default []
          * @since 3.0.0
          */
@@ -66,9 +69,9 @@ var List = new Class({
      * @method Phaser.Structs.List#add
      * @since 3.0.0
      *
-     * @param {object} child - [description]
+     * @param {*} child - [description]
      *
-     * @return {object} [description]
+     * @return {*} [description]
      */
     add: function (child)
     {
@@ -88,10 +91,10 @@ var List = new Class({
      * @method Phaser.Structs.List#addAt
      * @since 3.0.0
      *
-     * @param {object} child - [description]
+     * @param {*} child - [description]
      * @param {integer} index - [description]
      *
-     * @return {object} [description]
+     * @return {*} [description]
      */
     addAt: function (child, index)
     {
@@ -119,9 +122,9 @@ var List = new Class({
      * @method Phaser.Structs.List#addMultiple
      * @since 3.0.0
      *
-     * @param {array} children - [description]
+     * @param {Array.<*>} children - [description]
      *
-     * @return {array} [description]
+     * @return {Array.<*>} [description]
      */
     addMultiple: function (children)
     {
@@ -144,7 +147,7 @@ var List = new Class({
      *
      * @param {integer} index - [description]
      *
-     * @return {object} [description]
+     * @return {*} [description]
      */
     getAt: function (index)
     {
@@ -157,7 +160,7 @@ var List = new Class({
      * @method Phaser.Structs.List#getIndex
      * @since 3.0.0
      *
-     * @param {object} child - [description]
+     * @param {*} child - [description]
      *
      * @return {integer} [description]
      */
@@ -174,9 +177,9 @@ var List = new Class({
      * @method Phaser.Structs.List#sort
      * @since 3.0.0
      *
-     * @param {array} children - [description]
+     * @param {Array.<*>} children - [description]
      *
-     * @return {array} [description]
+     * @return {Array.<*>} [description]
      */
     sort: function (children)
     {
@@ -191,8 +194,8 @@ var List = new Class({
      * @method Phaser.Structs.List#sortIndexHandler
      * @since 3.0.0
      *
-     * @param {object} childA - [description]
-     * @param {object} childB - [description]
+     * @param {*} childA - [description]
+     * @param {*} childB - [description]
      *
      * @return {integer} [description]
      */
@@ -334,7 +337,7 @@ var List = new Class({
      * @param {integer} [startIndex=0] - The first child index to start the search from.
      * @param {integer} [endIndex] - The last child index to search up until.
      *
-     * @return {array} [description]
+     * @return {Array.<*>} [description]
      */
     getAll: function (property, value, startIndex, endIndex)
     {
@@ -397,8 +400,8 @@ var List = new Class({
      * @method Phaser.Structs.List#swap
      * @since 3.0.0
      *
-     * @param {object} child1 - [description]
-     * @param {object} child2 - [description]
+     * @param {*} child1 - [description]
+     * @param {*} child2 - [description]
      */
     swap: function (child1, child2)
     {
@@ -425,10 +428,10 @@ var List = new Class({
      * @method Phaser.Structs.List#moveTo
      * @since 3.0.0
      *
-     * @param {object} child - [description]
+     * @param {*} child - [description]
      * @param {integer} index - [description]
      *
-     * @return {object} [description]
+     * @return {*} [description]
      */
     moveTo: function (child, index)
     {
@@ -454,9 +457,9 @@ var List = new Class({
      * @method Phaser.Structs.List#remove
      * @since 3.0.0
      *
-     * @param {object} child - [description]
+     * @param {*} child - [description]
      *
-     * @return {object} [description]
+     * @return {*} [description]
      */
     remove: function (child)
     {
@@ -478,7 +481,7 @@ var List = new Class({
      *
      * @param {integer} index - [description]
      *
-     * @return {object} [description]
+     * @return {*} [description]
      */
     removeAt: function (index)
     {
@@ -501,7 +504,7 @@ var List = new Class({
      * @param {integer} beginIndex - [description]
      * @param {integer} endIndex - [description]
      *
-     * @return {array} [description]
+     * @return {Array.<*>} [description]
      */
     removeBetween: function (beginIndex, endIndex)
     {
@@ -552,9 +555,9 @@ var List = new Class({
      * @method Phaser.Structs.List#bringToTop
      * @since 3.0.0
      *
-     * @param {object} child - [description]
+     * @param {*} child - [description]
      *
-     * @return {object} [description]
+     * @return {*} [description]
      */
     bringToTop: function (child)
     {
@@ -573,9 +576,9 @@ var List = new Class({
      * @method Phaser.Structs.List#sendToBack
      * @since 3.0.0
      *
-     * @param {object} child - [description]
+     * @param {*} child - [description]
      *
-     * @return {object} [description]
+     * @return {*} [description]
      */
     sendToBack: function (child)
     {
@@ -594,9 +597,9 @@ var List = new Class({
      * @method Phaser.Structs.List#moveUp
      * @since 3.0.0
      *
-     * @param {object} child - [description]
+     * @param {*} child - [description]
      *
-     * @return {object} [description]
+     * @return {*} [description]
      */
     moveUp: function (child)
     {
@@ -621,9 +624,9 @@ var List = new Class({
      * @method Phaser.Structs.List#moveDown
      * @since 3.0.0
      *
-     * @param {object} child - [description]
+     * @param {*} child - [description]
      *
-     * @return {object} [description]
+     * @return {*} [description]
      */
     moveDown: function (child)
     {
@@ -684,10 +687,10 @@ var List = new Class({
      * @method Phaser.Structs.List#replace
      * @since 3.0.0
      *
-     * @param {object} oldChild - The child in this List that will be replaced.
-     * @param {object} newChild - The child to be inserted into this List.
+     * @param {*} oldChild - The child in this List that will be replaced.
+     * @param {*} newChild - The child to be inserted into this List.
      *
-     * @return {object} Returns the oldChild that was replaced within this group.
+     * @return {*} Returns the oldChild that was replaced within this group.
      */
     replace: function (oldChild, newChild)
     {
@@ -709,7 +712,7 @@ var List = new Class({
      * @method Phaser.Structs.List#exists
      * @since 3.0.0
      *
-     * @param {object} child - [description]
+     * @param {*} child - [description]
      *
      * @return {boolean} True if the item is found in the list, otherwise false.
      */
@@ -744,8 +747,8 @@ var List = new Class({
      * @method Phaser.Structs.List#each
      * @since 3.0.0
      *
-     * @param {EachListCallback} callback - The function to call.
-     * @param {object} [thisArg] - Value to use as `this` when executing callback.
+     * @param {EachListCallback.<T>} callback - The function to call.
+     * @param {*} [thisArg] - Value to use as `this` when executing callback.
      * @param {...*} [arguments] - Additional arguments that will be passed to the callback, after the child.
      */
     each: function (callback, thisArg)

--- a/src/structs/Map.js
+++ b/src/structs/Map.js
@@ -8,9 +8,10 @@ var Class = require('../utils/Class');
 
 /**
  * @callback EachMapCallback
+ * @template T
  *
  * @param {string} key - [description]
- * @param {*} entry - [description]
+ * @param {T} entry - [description]
  *
  * @return {?boolean} [description]
  */
@@ -24,12 +25,14 @@ var Class = require('../utils/Class');
  *    [ 3, 'three' ]
  * ]);
  *
+ * @generic T
+ *
  * @class Map
  * @memberOf Phaser.Structs
  * @constructor
  * @since 3.0.0
  *
- * @param {array} elements - [description]
+ * @param {Array.<*>} elements - [description]
  */
 var Map = new Class({
 
@@ -41,7 +44,7 @@ var Map = new Class({
          * [description]
          *
          * @name Phaser.Structs.Map#entries
-         * @type {Object.<string, any>}
+         * @type {Object.<string, *>}
          * @default {}
          * @since 3.0.0
          */
@@ -112,7 +115,7 @@ var Map = new Class({
      * @method Phaser.Structs.Map#getArray
      * @since 3.0.0
      *
-     * @return {array} [description]
+     * @return {Array.<*>} [description]
      */
     getArray: function ()
     {
@@ -203,7 +206,7 @@ var Map = new Class({
      * @method Phaser.Structs.Map#values
      * @since 3.0.0
      *
-     * @return {array} [description]
+     * @return {Array.<*>} [description]
      */
     values: function ()
     {
@@ -246,7 +249,7 @@ var Map = new Class({
      * @method Phaser.Structs.Map#each
      * @since 3.0.0
      *
-     * @param {EachMapCallback} callback - [description]
+     * @param {EachMapCallback.<T>} callback - [description]
      *
      * @return {Phaser.Structs.Map} This Map object.
      */

--- a/src/structs/ProcessQueue.js
+++ b/src/structs/ProcessQueue.js
@@ -10,6 +10,8 @@ var Class = require('../utils/Class');
  * @classdesc
  * [description]
  *
+ * @generic T
+ *
  * @class ProcessQueue
  * @memberOf Phaser.Structs
  * @constructor
@@ -25,7 +27,7 @@ var ProcessQueue = new Class({
          * [description]
          *
          * @name Phaser.Structs.ProcessQueue#_pending
-         * @type {array}
+         * @type {Array.<*>}
          * @private
          * @default []
          * @since 3.0.0
@@ -36,7 +38,7 @@ var ProcessQueue = new Class({
          * [description]
          *
          * @name Phaser.Structs.ProcessQueue#_active
-         * @type {array}
+         * @type {Array.<*>}
          * @private
          * @default []
          * @since 3.0.0
@@ -47,7 +49,7 @@ var ProcessQueue = new Class({
          * [description]
          *
          * @name Phaser.Structs.ProcessQueue#_destroy
-         * @type {array}
+         * @type {Array.<*>}
          * @private
          * @default []
          * @since 3.0.0
@@ -110,7 +112,7 @@ var ProcessQueue = new Class({
      * @method Phaser.Structs.ProcessQueue#update
      * @since 3.0.0
      *
-     * @return {array} [description]
+     * @return {Array.<*>} [description]
      */
     update: function ()
     {
@@ -167,7 +169,7 @@ var ProcessQueue = new Class({
      * @method Phaser.Structs.ProcessQueue#getActive
      * @since 3.0.0
      *
-     * @return {array} [description]
+     * @return {Array.<*>} [description]
      */
     getActive: function ()
     {

--- a/src/structs/Set.js
+++ b/src/structs/Set.js
@@ -8,8 +8,9 @@ var Class = require('../utils/Class');
 
 /**
  * @callback EachSetCallback
+ * @template T
  *
- * @param {*} entry - [description]
+ * @param {T} entry - [description]
  * @param {number} index - [description]
  *
  * @return {?boolean} [description]
@@ -19,12 +20,14 @@ var Class = require('../utils/Class');
  * @classdesc
  * A Set is a collection of unique elements.
  *
+ * @generic T
+ *
  * @class Set
  * @memberOf Phaser.Structs
  * @constructor
  * @since 3.0.0
  *
- * @param {array} [elements] - [description]
+ * @param {Array.<*>} [elements] - [description]
  */
 var Set = new Class({
 
@@ -36,7 +39,7 @@ var Set = new Class({
          * [description]
          *
          * @name Phaser.Structs.Set#entries
-         * @type {array}
+         * @type {Array.<*>}
          * @default []
          * @since 3.0.0
          */
@@ -157,8 +160,8 @@ var Set = new Class({
      * @method Phaser.Structs.Set#each
      * @since 3.0.0
      *
-     * @param {EachSetCallback} callback - [description]
-     * @param {object} callbackScope - [description]
+     * @param {EachSetCallback.<T>} callback - [description]
+     * @param {*} callbackScope - [description]
      *
      * @return {Phaser.Structs.Set} This Set object.
      */
@@ -198,8 +201,8 @@ var Set = new Class({
      * @method Phaser.Structs.Set#iterate
      * @since 3.0.0
      *
-     * @param {EachSetCallback} callback - [description]
-     * @param {object} callbackScope - [description]
+     * @param {EachSetCallback.<T>} callback - [description]
+     * @param {*} callbackScope - [description]
      *
      * @return {Phaser.Structs.Set} This Set object.
      */


### PR DESCRIPTION
This PR changes (delete as applicable)

* Documentation

Describe the changes below:

I have change the structs type for make generics types like `Array` and `Object` types.

I propose this struc for `@generic` :
```
@generic {[type]} [name] - [[property1],[property2],[return]]
```

Explain :
* `[type]` : Represent "extends type" of generic
* `[name]` Represent "name" of the generic like `VALUE`
* `[[property1],[property2],[return]]` : Represent the list of the property apply this generic. (i don't know how we can apply this on the structs, use an other tag like `@genericUse` ?)