### PR TITLE
Fix: PathFollower.setPath was still using PathFollower.start instead of PathFollower.startFollow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ being passed to the simulation. The default value is 1 to remain consistent with
 
 * In the WebGL Render Texture the tint of the texture was always set to 0xffffff and therefore the alpha values were ignored. The tint is now calculated using the alpha value. Fix #3385 (thanks @ger1995)
 * The RenderTexture now uses the ComputedSize component instead of Size (which requires a frame), allowing calls to getBounds to work. Fix #3451 (thanks @kuoruan)
+* PathFollower.start has been renamed to `startFollow`, but PathFollower.setPath was still using PathFollower.start. (thanks @samid737)
 
 ### Updates
 

--- a/src/gameobjects/pathfollower/PathFollower.js
+++ b/src/gameobjects/pathfollower/PathFollower.js
@@ -176,7 +176,7 @@ var PathFollower = new Class({
 
         if (config)
         {
-            this.start(config);
+            this.startFollow(config);
         }
 
         return this;


### PR DESCRIPTION
This PR changes:

* Nothing, it's a bug fix

Describe the changes below:

PathFollower.start has been renamed to `startFollow`, but PathFollower.setPath was still using PathFollower.start. This PR fixes this issue.