### PR TITLE
Fix usage of @genericUse

### DIFF
--- a/src/structs/List.js
+++ b/src/structs/List.js
@@ -47,7 +47,7 @@ var List = new Class({
         /**
          * The objects that belong to this collection.
          *
-         * @genericUse {T[]} T - [$type]
+         * @genericUse {T[]} - [$type]
          *
          * @name Phaser.Structs.List#list
          * @type {Array.<*>}
@@ -73,7 +73,7 @@ var List = new Class({
      * @method Phaser.Structs.List#add
      * @since 3.0.0
      *
-     * @genericUse {T} T - [child,$return]
+     * @genericUse {T} - [child,$return]
      *
      * @param {*} child - [description]
      *
@@ -97,7 +97,7 @@ var List = new Class({
      * @method Phaser.Structs.List#addAt
      * @since 3.0.0
      *
-     * @genericUse {T} T - [child,$return]
+     * @genericUse {T} - [child,$return]
      *
      * @param {*} child - [description]
      * @param {integer} [index=0] - [description]
@@ -130,7 +130,7 @@ var List = new Class({
      * @method Phaser.Structs.List#addMultiple
      * @since 3.0.0
      *
-     * @genericUse {T[]} T - [children,$return]
+     * @genericUse {T[]} - [children,$return]
      *
      * @param {Array.<*>} children - [description]
      *
@@ -155,7 +155,7 @@ var List = new Class({
      * @method Phaser.Structs.List#getAt
      * @since 3.0.0
      *
-     * @genericUse {T} T - [$return]
+     * @genericUse {T} - [$return]
      *
      * @param {integer} index - [description]
      *
@@ -172,7 +172,7 @@ var List = new Class({
      * @method Phaser.Structs.List#getIndex
      * @since 3.0.0
      *
-     * @genericUse {T} T - [child]
+     * @genericUse {T} - [child]
      *
      * @param {*} child - [description]
      *
@@ -191,7 +191,7 @@ var List = new Class({
      * @method Phaser.Structs.List#sort
      * @since 3.0.0
      *
-     * @genericUse {T[]} T - [children,$return]
+     * @genericUse {T[]} - [children,$return]
      *
      * @param {Array.<*>} children - [description]
      *
@@ -210,7 +210,7 @@ var List = new Class({
      * @method Phaser.Structs.List#sortIndexHandler
      * @since 3.0.0
      *
-     * @genericUse {T} T - [childA,childB]
+     * @genericUse {T} - [childA,childB]
      *
      * @param {*} childA - [description]
      * @param {*} childB - [description]
@@ -244,8 +244,8 @@ var List = new Class({
      * @method Phaser.Structs.List#getByKey
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value]
-     * @genericUse {?T} T - [$return]
+     * @genericUse {T} - [value]
+     * @genericUse {?T} - [$return]
      *
      * @param {string} property - The property to check against the value.
      * @param {*} value - The value to check if the property strictly equals.
@@ -273,7 +273,7 @@ var List = new Class({
      * @method Phaser.Structs.List#getByName
      * @since 3.0.0
      *
-     * @genericUse {?T} T - [$return]
+     * @genericUse {?T} - [$return]
      *
      * @param {string} name - The name to search for.
      *
@@ -290,7 +290,7 @@ var List = new Class({
      * @method Phaser.Structs.List#getRandom
      * @since 3.0.0
      *
-     * @genericUse {?T} T - [$return]
+     * @genericUse {?T} - [$return]
      *
      * @param {integer} [startIndex=0] - Offset from the front of the group (lowest child).
      * @param {integer} [length=(to top)] - Restriction on the number of values you want to randomly select from.
@@ -318,8 +318,8 @@ var List = new Class({
      * @method Phaser.Structs.List#getFirst
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value]
-     * @genericUse {?T} T - [$return]
+     * @genericUse {T} - [value]
+     * @genericUse {?T} - [$return]
      *
      * @param {string} property - [description]
      * @param {*} value - [description]
@@ -360,8 +360,8 @@ var List = new Class({
      * @method Phaser.Structs.List#getAll
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value]
-     * @genericUse {T[]} T - [$return]
+     * @genericUse {T} - [value]
+     * @genericUse {T[]} - [$return]
      *
      * @param {string} [property] - An optional property to test against the value argument.
      * @param {*} [value] - If property is set then Child.property must strictly equal this value to be included in the results.
@@ -403,7 +403,7 @@ var List = new Class({
      * @method Phaser.Structs.List#count
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value]
+     * @genericUse {T} - [value]
      *
      * @param {string} property - [description]
      * @param {*} value - [description]
@@ -433,7 +433,7 @@ var List = new Class({
      * @method Phaser.Structs.List#swap
      * @since 3.0.0
      *
-     * @genericUse {T} T - [child1,child2]
+     * @genericUse {T} - [child1,child2]
      *
      * @param {*} child1 - [description]
      * @param {*} child2 - [description]
@@ -463,7 +463,7 @@ var List = new Class({
      * @method Phaser.Structs.List#moveTo
      * @since 3.0.0
      *
-     * @genericUse {T} T - [child,$return]
+     * @genericUse {T} - [child,$return]
      *
      * @param {*} child - [description]
      * @param {integer} index - [description]
@@ -494,7 +494,7 @@ var List = new Class({
      * @method Phaser.Structs.List#remove
      * @since 3.0.0
      *
-     * @genericUse {T} T - [child,$return]
+     * @genericUse {T} - [child,$return]
      *
      * @param {*} child - [description]
      *
@@ -518,7 +518,7 @@ var List = new Class({
      * @method Phaser.Structs.List#removeAt
      * @since 3.0.0
      *
-     * @genericUse {T} T - [$return]
+     * @genericUse {T} - [$return]
      *
      * @param {integer} index - [description]
      *
@@ -542,7 +542,7 @@ var List = new Class({
      * @method Phaser.Structs.List#removeBetween
      * @since 3.0.0
      *
-     * @genericUse {T[]} T - [$return]
+     * @genericUse {T[]} - [$return]
      *
      * @param {integer} [beginIndex=0] - [description]
      * @param {integer} [endIndex] - [description]
@@ -598,7 +598,7 @@ var List = new Class({
      * @method Phaser.Structs.List#bringToTop
      * @since 3.0.0
      *
-     * @generic {T} T - [child,$return]
+     * @generic {T} O - [child,$return]
      *
      * @param {*} child - [description]
      *
@@ -621,7 +621,7 @@ var List = new Class({
      * @method Phaser.Structs.List#sendToBack
      * @since 3.0.0
      *
-     * @generic {T} T - [child,$return]
+     * @generic {T} O - [child,$return]
      *
      * @param {*} child - [description]
      *
@@ -644,7 +644,7 @@ var List = new Class({
      * @method Phaser.Structs.List#moveUp
      * @since 3.0.0
      *
-     * @generic {T} T - [child,$return]
+     * @generic {T} O - [child,$return]
      *
      * @param {*} child - [description]
      *
@@ -673,7 +673,7 @@ var List = new Class({
      * @method Phaser.Structs.List#moveDown
      * @since 3.0.0
      *
-     * @generic {T} T - [child,$return]
+     * @generic {T} O - [child,$return]
      *
      * @param {*} child - [description]
      *
@@ -738,8 +738,7 @@ var List = new Class({
      * @method Phaser.Structs.List#replace
      * @since 3.0.0
      *
-     * @generic {T} T - [oldChild,$return]
-     * @genericUse {T} T - [newChild]
+     * @generic {T} O - [oldChild,newChild,$return]
      *
      * @param {*} oldChild - The child in this List that will be replaced.
      * @param {*} newChild - The child to be inserted into this List.
@@ -766,7 +765,7 @@ var List = new Class({
      * @method Phaser.Structs.List#exists
      * @since 3.0.0
      *
-     * @genericUse {T} T - [child]
+     * @genericUse {T} - [child]
      *
      * @param {*} child - [description]
      *
@@ -783,7 +782,7 @@ var List = new Class({
      * @method Phaser.Structs.List#setAll
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value]
+     * @genericUse {T} - [value]
      *
      * @param {string} key - [description]
      * @param {*} value - [description]
@@ -805,7 +804,9 @@ var List = new Class({
      * @method Phaser.Structs.List#each
      * @since 3.0.0
      *
-     * @param {EachListCallback.<T>} callback - The function to call.
+     * @genericUse {EachListCallback.<T>} - [callback]
+     *
+     * @param {EachListCallback} callback - The function to call.
      * @param {*} [thisArg] - Value to use as `this` when executing callback.
      * @param {...*} [args] - Additional arguments that will be passed to the callback, after the child.
      */

--- a/src/structs/Map.js
+++ b/src/structs/Map.js
@@ -31,7 +31,7 @@ var Class = require('../utils/Class');
  * @since 3.0.0
  *
  * @generic T
- * @genericUse {T[]} T - [elements]
+ * @genericUse {T[]} - [elements]
  *
  * @param {Array.<*>} elements - [description]
  */
@@ -44,7 +44,7 @@ var Map = new Class({
         /**
          * [description]
          *
-         * @genericUse {Object.<string, T>} T - [$type]
+         * @genericUse {Object.<string, T>} - [$type]
          *
          * @name Phaser.Structs.Map#entries
          * @type {Object.<string, *>}
@@ -78,7 +78,7 @@ var Map = new Class({
      * @method Phaser.Structs.Map#set
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value]
+     * @genericUse {T} - [value]
      *
      * @param {string} key - [description]
      * @param {*} value - [description]
@@ -102,7 +102,7 @@ var Map = new Class({
      * @method Phaser.Structs.Map#get
      * @since 3.0.0
      *
-     * @genericUse {T} T - [$return]
+     * @genericUse {T} - [$return]
      *
      * @param {string} key - [description]
      *
@@ -122,7 +122,7 @@ var Map = new Class({
      * @method Phaser.Structs.Map#getArray
      * @since 3.0.0
      *
-     * @genericUse {T[]} T - [$return]
+     * @genericUse {T[]} - [$return]
      *
      * @return {Array.<*>} [description]
      */
@@ -215,7 +215,7 @@ var Map = new Class({
      * @method Phaser.Structs.Map#values
      * @since 3.0.0
      *
-     * @genericUse {T[]} T - [$return]
+     * @genericUse {T[]} - [$return]
      *
      * @return {Array.<*>} [description]
      */
@@ -260,7 +260,9 @@ var Map = new Class({
      * @method Phaser.Structs.Map#each
      * @since 3.0.0
      *
-     * @param {EachMapCallback.<T>} callback - [description]
+     * @genericUse {EachMapCallback.<T>} - [callback]
+     *
+     * @param {EachMapCallback} callback - [description]
      *
      * @return {Phaser.Structs.Map} This Map object.
      */
@@ -285,7 +287,7 @@ var Map = new Class({
      * @method Phaser.Structs.Map#contains
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value]
+     * @genericUse {T} - [value]
      *
      * @param {*} value - [description]
      *

--- a/src/structs/ProcessQueue.js
+++ b/src/structs/ProcessQueue.js
@@ -26,7 +26,7 @@ var ProcessQueue = new Class({
         /**
          * [description]
          *
-         * @genericUse {T[]} T - [$type]
+         * @genericUse {T[]} - [$type]
          *
          * @name Phaser.Structs.ProcessQueue#_pending
          * @type {Array.<*>}
@@ -39,7 +39,7 @@ var ProcessQueue = new Class({
         /**
          * [description]
          *
-         * @genericUse {T[]} T - [$type]
+         * @genericUse {T[]} - [$type]
          *
          * @name Phaser.Structs.ProcessQueue#_active
          * @type {Array.<*>}
@@ -52,7 +52,7 @@ var ProcessQueue = new Class({
         /**
          * [description]
          *
-         * @genericUse {T[]} T - [$type]
+         * @genericUse {T[]} - [$type]
          *
          * @name Phaser.Structs.ProcessQueue#_destroy
          * @type {Array.<*>}
@@ -80,7 +80,7 @@ var ProcessQueue = new Class({
      * @method Phaser.Structs.ProcessQueue#add
      * @since 3.0.0
      *
-     * @genericUse {T} T - [item]
+     * @genericUse {T} - [item]
      *
      * @param {*} item - [description]
      *
@@ -101,7 +101,7 @@ var ProcessQueue = new Class({
      * @method Phaser.Structs.ProcessQueue#remove
      * @since 3.0.0
      *
-     * @genericUse {T} T - [item]
+     * @genericUse {T} - [item]
      *
      * @param {*} item - [description]
      *
@@ -122,7 +122,7 @@ var ProcessQueue = new Class({
      * @method Phaser.Structs.ProcessQueue#update
      * @since 3.0.0
      *
-     * @genericUse {T[]} T - [$return]
+     * @genericUse {T[]} - [$return]
      *
      * @return {Array.<*>} [description]
      */
@@ -181,7 +181,7 @@ var ProcessQueue = new Class({
      * @method Phaser.Structs.ProcessQueue#getActive
      * @since 3.0.0
      *
-     * @genericUse {T[]} T - [$return]
+     * @genericUse {T[]} - [$return]
      *
      * @return {Array.<*>} [description]
      */

--- a/src/structs/Set.js
+++ b/src/structs/Set.js
@@ -26,7 +26,7 @@ var Class = require('../utils/Class');
  * @since 3.0.0
  *
  * @generic T
- * @genericUse {T[]} T - [elements]
+ * @genericUse {T[]} - [elements]
  *
  * @param {Array.<*>} [elements] - [description]
  */
@@ -39,7 +39,7 @@ var Set = new Class({
         /**
          * [description]
          *
-         * @genericUse {T[]} T - [$type]
+         * @genericUse {T[]} - [$type]
          *
          * @name Phaser.Structs.Set#entries
          * @type {Array.<*>}
@@ -63,7 +63,7 @@ var Set = new Class({
      * @method Phaser.Structs.Set#set
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value]
+     * @genericUse {T} - [value]
      *
      * @param {*} value - [description]
      *
@@ -85,7 +85,7 @@ var Set = new Class({
      * @method Phaser.Structs.Set#get
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value,$return]
+     * @genericUse {T} - [value,$return]
      *
      * @param {string} property - [description]
      * @param {*} value - [description]
@@ -111,7 +111,7 @@ var Set = new Class({
      * @method Phaser.Structs.Set#getArray
      * @since 3.0.0
      *
-     * @genericUse {T[]} T - [$return]
+     * @genericUse {T[]} - [$return]
      *
      * @return {Array.<*>} [description]
      */
@@ -126,7 +126,7 @@ var Set = new Class({
      * @method Phaser.Structs.Set#delete
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value]
+     * @genericUse {T} - [value]
      *
      * @param {*} value - [description]
      *
@@ -171,7 +171,9 @@ var Set = new Class({
      * @method Phaser.Structs.Set#each
      * @since 3.0.0
      *
-     * @param {EachSetCallback.<T>} callback - [description]
+     * @genericUse {EachSetCallback.<T>} - [callback]
+     *
+     * @param {EachSetCallback} callback - [description]
      * @param {*} callbackScope - [description]
      *
      * @return {Phaser.Structs.Set} This Set object.
@@ -212,7 +214,9 @@ var Set = new Class({
      * @method Phaser.Structs.Set#iterate
      * @since 3.0.0
      *
-     * @param {EachSetCallback.<T>} callback - [description]
+     * @genericUse {EachSetCallback.<T>} - [callback]
+     *
+     * @param {EachSetCallback} callback - [description]
      * @param {*} callbackScope - [description]
      *
      * @return {Phaser.Structs.Set} This Set object.
@@ -300,7 +304,7 @@ var Set = new Class({
      * @method Phaser.Structs.Set#contains
      * @since 3.0.0
      *
-     * @genericUse {T} T - [value]
+     * @genericUse {T} - [value]
      *
      * @param {*} value - [description]
      *


### PR DESCRIPTION
This PR changes (delete as applicable)

* Documentation

Describe the changes below:

I have fix the usage of my `@genericUse` because i have useless parameter (thanks @Antriel).

## New structure of `@genericUse` :

```
@genericUse {[type2]} - [[property1],[property2],[$return]]
```

Explain :
* [type2] : Reprensent the new type
* [name] Represent "name" of the generic like VALUE
* [[property1],[property2],[$return]] : Represent the list of the property apply this generic. For replace `@type` use and $type and for `@return`, '$return`