### PR TITLE
[ISSUE #3363] Phaser Scene - passing data to scene init & create methods

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -180,7 +180,7 @@ var SceneManager = new Class({
         {
             entry = this._start[i];
 
-            this.start(entry);
+            this.start(entry, entry.scene.data);
         }
 
         this._start.length = 0;
@@ -219,7 +219,7 @@ var SceneManager = new Class({
             {
                 entry = this._start[i];
 
-                this.start(entry);
+                this.start(entry, entry.scene.data);
             }
 
             //  Clear the pending lists
@@ -309,7 +309,7 @@ var SceneManager = new Class({
         {
             if (this.game.isBooted)
             {
-                this.start(key);
+                this.start(key, newScene.sys.settings.data);
             }
             else
             {
@@ -695,6 +695,11 @@ var SceneManager = new Class({
             }
         }
 
+        if (sceneConfig.hasOwnProperty('data'))
+        {
+            newScene.data = sceneConfig.data;
+        }
+
         return newScene;
     },
 
@@ -951,7 +956,7 @@ var SceneManager = new Class({
                 if (entry.key === key)
                 {
                     entry.autoStart = true;
-                    entry.data = data;
+                    entry.scene.data = data;
                 }
             }
 


### PR DESCRIPTION
**[ISSUE #3363] Phaser Scene - passing data to scene init & create methods**

Fixing / workaround for issue #3363 

As described in [issue #3363](https://github.com/photonstorm/phaser/issues/3363), in Phaser 3.x the ability of Phaser 2.x passing arbitrary initial data (config) to a starting (boot) scene was broken, as it is not working as expected in the examples either: https://labs.phaser.io/edit.html?src=src\scenes\boot%20data.js ({ wibble: 456 } is never logged out, as it was in Phaser 2.x). 

The issue is, the optional data parameter in the .start() method is copied to entry.data, but after it is added to this._pending as scene, which will re-add the newScene on start, it is not copied further.

This commit uses a workaround by copying this optional data param onto the scene (where it is not the proper place i guess), hopefully without causing regression. 

Also, the idea overlaps a bit with the config's optional 'extend' prop, making it a bit redundant, but now starting a scene like this should be working, available in .init() and .create() methods of the scene, instead of the default empty object: 

`game.scene.start('boot', { someData: '...arbitrary data from BOOT' });`