### PR TITLE
[fixes #3482] HueToComponent was not correctly exporting itself

### DIFF
--- a/src/display/color/HueToComponent.js
+++ b/src/display/color/HueToComponent.js
@@ -47,4 +47,4 @@ var HueToComponent = function (p, q, t)
     return p;
 };
 
-module.export = HueToComponent;
+module.exports = HueToComponent;


### PR DESCRIPTION
Pretty self explanatory -- `module.export` is a typo, needed to be `exports`. Filed associated bug #3482.