### PR TITLE
jsdoc / tsdef: fix correct type reference on Scene#load

### DIFF
--- a/src/events/EventEmitter.js
+++ b/src/events/EventEmitter.js
@@ -94,6 +94,7 @@ var EventEmitter = new Class({
  * @since 3.0.0
  *
  * @param {(string|symbol)} event - The event name.
+ * @param {...*} [args] - Additional arguments that will be passed to the event handler.
  *
  * @return {boolean} `true` if the event had listeners, else `false`.
  */

--- a/src/scene/Scene.js
+++ b/src/scene/Scene.js
@@ -198,7 +198,7 @@ var Scene = new Class({
          * This property will only be available if defined in the Scene Injection Map and the plugin is installed.
          *
          * @name Phaser.Scene#load
-         * @type {Phaser.Loader.LoadPlugin}
+         * @type {Phaser.Loader.LoaderPlugin}
          * @since 3.0.0
          */
         this.load;


### PR DESCRIPTION
This PR changes (delete as applicable)

* TypeScript Defs

Describe the changes below:

TypeScript definition errored at Phaser.Scenes.Scene.load as it tried to reference Phaser.Loader.LoadPlugin (should be Phaser.Loader.LoaderPlugin)
