### PR TITLE
fix drag/overlap interaction

### DIFF
--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -764,6 +764,7 @@ var InputPlugin = new Class({
             }
 
             pointer.dragState = 0;
+            list.splice(0);
         }
 
         return 0;


### PR DESCRIPTION
This PR changes:

* Nothing, it's a bug fix

Describe the changes below:

changes: when dragend resets draglist. 
this fixes: overoutevents from a gameobject not firing after it being dragged.
