### PR TITLE
Line.PointA&B fix

### DIFF
--- a/src/geom/line/Line.js
+++ b/src/geom/line/Line.js
@@ -171,7 +171,7 @@ var Line = new Class({
     {
         if (vec2 === undefined) { vec2 = new Vector2(); }
 
-        vec2.setTo(this.x1, this.y1);
+        vec2.set(this.x1, this.y1);
 
         return vec2;
     },
@@ -192,7 +192,7 @@ var Line = new Class({
     {
         if (vec2 === undefined) { vec2 = new Vector2(); }
 
-        vec2.setTo(this.x2, this.y2);
+        vec2.set(this.x2, this.y2);
 
         return vec2;
     },


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:
It fixes the 2 methods line.pointA and line.pointB as the object Vector2 can only handle .set(..).
This also fixes the issues 41 42 and 44 of the phaser3-example repo.

