### PR TITLE
Fixed renderCanvas() call in Graphics.generateTexture()

### DIFF
--- a/src/gameobjects/graphics/Graphics.js
+++ b/src/gameobjects/graphics/Graphics.js
@@ -915,10 +915,10 @@ var Graphics = new Class({
     /**
      * Creates a pie-chart slice shape centered at `x`, `y` with the given radius.
      * You must define the start and end angle of the slice.
-     * 
+     *
      * Setting the `anticlockwise` argument to `true` creates a shape similar to Pacman.
      * Setting it to `false` creates a shape like a slice of pie.
-     * 
+     *
      * This method will begin a new path and close the path at the end of it.
      * To display the actual slice you need to call either `strokePath` or `fillPath` after it.
      *
@@ -1133,7 +1133,7 @@ var Graphics = new Class({
 
         if (ctx)
         {
-            this.renderCanvas(sys.game.renderer, this, 0, Graphics.TargetCamera, ctx);
+            this.renderCanvas(sys.game.renderer, this, 0.0, Graphics.TargetCamera, null, ctx);
 
             if (sys.game.renderer.gl && texture)
             {

--- a/src/gameobjects/graphics/GraphicsCanvasRenderer.js
+++ b/src/gameobjects/graphics/GraphicsCanvasRenderer.js
@@ -70,7 +70,7 @@ var GraphicsCanvasRenderer = function (renderer, src, interpolationPercentage, c
     }
 
     ctx.save();
-    if (parentMatrix !== undefined)
+    if (parentMatrix)
     {
         var matrix = parentMatrix.matrix;
         ctx.transform(matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5]);


### PR DESCRIPTION
Generating textures from graphics objects stopped working due to commit (c232642a) altering the signature of the `GraphicsCanvasRenderer`.

I've just updated the call to the renderer to pass null for the parent transform (the newly introduced parameter), which I assume is the correct thing to do here.

Glad I caught this before release. :)