### PR TITLE
Added missing physics property to GameConfig

### DIFF
--- a/src/boot/Config.js
+++ b/src/boot/Config.js
@@ -98,6 +98,7 @@ var ValueToColor = require('../display/color/ValueToColor');
  * @property {object} [images] - [description]
  * @property {string} [images.default] - [description]
  * @property {string} [images.missing] - [description]
+ * @property {object} [physics=null] - [description]
  */
 
 /**


### PR DESCRIPTION
** >> Make sure you describe your PR to the README Change Log section! << **
I didn't know if this was a big enough change to warrant a change in the README change log.

This PR changes (delete as applicable)

* Documentation
* TypeScript Defs

Describe the changes below:
The typescript typings for GameConfig are missing the physics property, so I added it.
This is my first time contributing, so I apologize if I did this wrong.
