### PR TITLE
documenting UppercaseFirst

### DIFF
--- a/src/utils/string/UppercaseFirst.js
+++ b/src/utils/string/UppercaseFirst.js
@@ -5,14 +5,23 @@
  */
 
 /**
- * [description]
+ * Capitalizes the first letter of a string if there is one.
+ * @example
+ * UppercaseFirst('abc');
+ * // returns 'Abc'
+ * @example
+ * UppercaseFirst('the happy family');
+ * // returns 'The happy family'
+ * @example
+ * UppercaseFirst('');
+ * // returns ''
  *
  * @function Phaser.Utils.String.UppercaseFirst
  * @since 3.0.0
  *
- * @param {string} str - [description]
+ * @param {string} str - The string to capitalize.
  *
- * @return {string} [description]
+ * @return {string} A new string, same as the first, but with the first letter capitalized.
  */
 var UppercaseFirst = function (str)
 {


### PR DESCRIPTION
This PR changes (delete as applicable)

* Documentation

Describe the changes below:

Adds documentation to a utils/string/UppercaseFirst.js.

Submitting this by itself as I'm not 100% sure on how `@example` should be used. [JSDocs](http://usejsdoc.org/tags-example.html) has it with a separate `@example` tag per example, but [utils/array/NumberArrayStep.js](https://github.com/photonstorm/phaser/blob/master/src/utils/array/NumberArrayStep.js) has one tag with several examples underneath.

Unsure how this renders to make a decision. Let me know if I should change it!