### PR TITLE
Add a config to merge keys into scene InjectionMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* A new property was added to the scene config, `mapAdd` which is used to extend the default injection map of a scene instead of overwriting it.
 * A new property was added to Matter.World, `correction` which is used in the Engine.update call and allows you to adjust the time
 being passed to the simulation. The default value is 1 to remain consistent with previous releases.
 * Group.destroy has a new optional argument `destroyChildren` which will automatically call `destroy` on all children of a Group if set to true (the default is false, hence it doesn't change the public API). Fix #3246 (thanks @DouglasLapsley)

--- a/src/scene/Settings.js
+++ b/src/scene/Settings.js
@@ -19,7 +19,8 @@ var InjectionMap = require('./InjectionMap');
  * @property {boolean} [visible=true] - [description]
  * @property {(false|LoaderFileObject[])} [files=false] - [description]
  * @property {?(InputJSONCameraObject|InputJSONCameraObject[])} [cameras=null] - [description]
- * @property {Object.<string, string>} [map] - [description]
+ * @property {Object.<string, string>} [map] - Overwrites the default injection map for a scene.
+ * @property {Object.<string, string>} [mapAdd] - Extends the injection map for a scene.
  * @property {object} [physics={}] - [description]
  * @property {object} [loader={}] - [description]
  * @property {(false|*)} [plugins=false] - [description]

--- a/src/scene/Settings.js
+++ b/src/scene/Settings.js
@@ -6,6 +6,7 @@
 
 var CONST = require('./const');
 var GetValue = require('../utils/object/GetValue');
+var Merge = require('../utils/object/Merge');
 var InjectionMap = require('./InjectionMap');
 
 // TODO 22/03/2018 Fix "plugins" type
@@ -87,7 +88,7 @@ var Settings = {
 
             //  Scene Property Injection Map
 
-            map: GetValue(config, 'map', InjectionMap),
+            map: GetValue(config, 'map', Merge(InjectionMap, GetValue(config, 'mapAdd', {}))),
 
             //  Physics
 


### PR DESCRIPTION
This PR changes

* The public-facing API

Describe the changes below:

This adds a new config option namely mapAdd for a scene which merges the given key value pairs with the default scene injection values.
