### PR TITLE
fix Timeline#destroy

### DIFF
--- a/src/tweens/Timeline.js
+++ b/src/tweens/Timeline.js
@@ -852,7 +852,7 @@ var Timeline = new Class({
     {
         for (var i = 0; i < this.data.length; i++)
         {
-            this.data[i].destroy();
+            this.data[i].stop();
         }
 
     }


### PR DESCRIPTION
This PR changes:
* Nothing, it's a bug fix

Tweens don't have `destroy` they have `stop`.