### PR TITLE
Ensure body is not null as a result of `Impact.World.remove(object)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * Tween.restart handles removed tweens properly and reads them back into the active queue for the TweenManager (thanks @wtravO)
 * Tween.resume will now call `Tween.play` on a tween that was paused due to its config object, not as a result of having its paused method called. Fix #3452 (thanks @jazen)
 * LoaderPlugin.isReady referenced a constant that no longer exists. Fix #3503 (thanks @Twilrom)
+* Ensure body is not null as a result of `Impact.World.remove(object)`.
 
 ### Updates
 

--- a/src/physics/impact/World.js
+++ b/src/physics/impact/World.js
@@ -609,34 +609,27 @@ var World = new Class({
 
         //  Update all active bodies
 
-        var i;
-        var body;
         var bodies = this.bodies.entries;
-        var len = bodies.length;
         var hash = {};
         var size = this.cellSize;
 
-        for (i = 0; i < len; i++)
+        bodies.forEach(function (body)
         {
-            body = bodies[i];
-
             if (body.enabled)
             {
                 body.update(clampedDelta);
             }
-        }
+        }.bind(this));
 
         //  Run collision against them all now they're in the new positions from the update
 
-        for (i = 0; i < len; i++)
+        bodies.forEach(function (body)
         {
-            body = bodies[i];
-
             if (!body.skipHash())
             {
                 this.checkHash(body, hash, size);
             }
-        }
+        }.bind(this));
 
         if (this.drawDebug)
         {
@@ -644,15 +637,13 @@ var World = new Class({
 
             graphics.clear();
 
-            for (i = 0; i < len; i++)
+            bodies.forEach(function (body)
             {
-                body = bodies[i];
-
                 if (body.willDrawDebug())
                 {
                     body.drawDebug(graphics);
                 }
-            }
+            }.bind(this));
         }
     },
 


### PR DESCRIPTION
## This PR changes

* Nothing, it's a bug fix

## Describe the changes below:

Calling `Impact.World.remove(body)` to remove an object from the world during an update call would crash on line 637 with error: 
```
Cannot read property 'skipHash' of undefined
```

This happens because `this.bodies.entries` is changed, while `len` in this scope is already defined.
By using forEach rather than C-style loops, the removed (and undefined) body will not end up in the loop, preventing this crash.

## Discussion: 

I ran some crude benchmarks which showed no significant performance loss between for and forEach. However, if this PR still turns out to have an undesired impact on performance, this could be solved by explicit null checks on body instead.