### PR TITLE
StaticBody.setOffset fix for issue #3465

### DIFF
--- a/src/physics/arcade/StaticBody.js
+++ b/src/physics/arcade/StaticBody.js
@@ -443,7 +443,13 @@ var StaticBody = new Class({
 
         this.world.staticTree.remove(this);
 
+        this.position.x -= this.offset.x;
+        this.position.y -= this.offset.y;
+
         this.offset.set(x, y);
+
+        this.position.x += this.offset.x;
+        this.position.y += this.offset.y;
 
         this.updateCenter();
 


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

------------------------

Per discussion on issue https://github.com/photonstorm/phaser/issues/3465 Static Bodies were throwing errors in 3.3.0 missing the setOffset method.  Prior to my PR, a change was made to provide the method fixing the error, but StaticBodies still did not benefit from the feature of Offsetting their bodies positions.

With my change, `StaticBody.setOffset(x,y)` will negate the previous offset and apply the new one.

Going with forgiveness rather than permission on this one I guess, we can have the discussion after someone takes a look.

I have a quick test proving this works below (I am linking the `build/phaser.js` to the codepen through their `Settings>External JavaScript.` Serving it via `http-server` on my localhost:8080, but it should be easy enough to replicate with my code): 

https://codepen.io/anon/pen/oqJYey?editors=0010

My question is - should calling `Sprite.setPosition(x,y);` on a Sprite with a StaticBody affect the position of that body / take into account its offset? it currently does not in 3.4.  I've included a sample of that test in the codepen provided as well.

Cheers