### PR TITLE
[fixes #3535] Fix constructed functions in RTree

### DIFF
--- a/src/structs/RTree.js
+++ b/src/structs/RTree.js
@@ -474,9 +474,9 @@ rbush.prototype = {
         format = format.map(
             function (f)
             {
-                return f.substring(1)
+                return f.substring(1);
             }
-        )
+        );
 
         // Do not use string-generated Functions for CSP policies
         // Instead a combination of anonymous functions and grabbing properties
@@ -486,12 +486,12 @@ rbush.prototype = {
 
         var mkCompareFn = function(attr) {
           return function(a, b) {
-            return a[attr] - b[attr]
-          }
-        }
+            return a[attr] - b[attr];
+          };
+        };
 
-        this.compareMinX = mkCompareFn(format[0])
-        this.compareMinY = mkCompareFn(format[1])
+        this.compareMinX = mkCompareFn(format[0]);
+        this.compareMinY = mkCompareFn(format[1]);
 
         this.toBBox = function(a)
         {
@@ -500,8 +500,8 @@ rbush.prototype = {
                 minY: a[format[1]],
                 maxX: a[format[2]],
                 maxY: a[format[3]],
-            }
-        }
+            };
+        };
     }
 };
 

--- a/src/structs/RTree.js
+++ b/src/structs/RTree.js
@@ -465,31 +465,43 @@ rbush.prototype = {
 
     _initFormat: function (format)
     {
-        // data format (minX, minY, maxX, maxY accessors)
+        // format: [minX, minY, maxX, maxY accessors]
+        // accessors will be dotted names
+
+        // Because we have historically used eval-based function constructor
+        // the format accerrsors need to have their leading dots stripped to
+        // obtain the actual accessor
+        format = format.map(
+            function (f)
+            {
+                return f.substring(1)
+            }
+        )
 
         // Do not use string-generated Functions for CSP policies
-        // Instead a combination of anonymous functions and grabbing
-        // properties by string is used.
-        var compareArr = function (accessor)
-        {
-            return function (a, b)
-            {
-                return this[a + accessor] - this[b + accessor];
-            };
-        };
+        // Instead a combination of anonymous functions and grabbing properties
+        // by string is used.
+        // cf. https://github.com/photonstorm/phaser/issues/3441
+        // and https://github.com/photonstorm/phaser/issues/3535
 
-        this.compareMinX = compareArr(format[0]);
-        this.compareMinY = compareArr(format[1]);
+        var mkCompareFn = function(attr) {
+          return function(a, b) {
+            return a[attr] - b[attr]
+          }
+        }
 
-        this.toBBox = function (a)
+        this.compareMinX = mkCompareFn(format[0])
+        this.compareMinY = mkCompareFn(format[1])
+
+        this.toBBox = function(a)
         {
             return {
-                minX: a + format[0],
-                minY: a + format[1],
-                maxX: a + format[2],
-                maxy: a + format[3]
-            };
-        };
+                minX: a[format[0]],
+                minY: a[format[1]],
+                maxX: a[format[2]],
+                maxY: a[format[3]],
+            }
+        }
     }
 };
 


### PR DESCRIPTION
**Change type:** Bug fix, #3535

The previous patch didn't take into account that the accessors passed in as the format array were dot-prefixed due to the previous eval-based construction.

The only two uses of `RTree` that I found were in `World.js`:

```javascript
this.tree = new RTree(this.maxEntries, [ '.left', '.top', '.right', '.bottom' ]);
// ...
this.staticTree = new RTree(this.maxEntries, [ '.left', '.top', '.right', '.bottom' ]);
```

It's likely that this could be updated to just not pass dotted attribute names but I wasn't super comfortable that they weren't needed in this form elsewhere despite a quick search. I'd honestly say that it might be a better change if we remove the dots before merge but I'll leave that up to the discretion of the reviewers/merger.

I'm not super familiar with Phaser's style but I passed lint sooo :D

Buyer beware: I didn't verify this is still within the twitch CSP (it should be). I tested the following cases using slight variations of the repro code I left in the bug:

1. this.physics.world.collide(sprite, group)
1. this.physics.world.collide(group, sprite)
1. this.physics.world.collide(sprite, sprite)
1. this.physics.world.collide(group, group)