### PR TITLE
Add 'destroy' event of sound object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Utils.Array.SetAll will set a property on all elements of an array to the given value, with optional range limits.
 * Utils.Array.Swap will swap the position of two elements in an array.
 * TransformMatrix.destroy is a new method that will clear out the array and object used by a Matrix internally.
+* Add 'destroy' event in sound object.
 
 ### Bug Fixes
 

--- a/src/sound/BaseSound.js
+++ b/src/sound/BaseSound.js
@@ -522,6 +522,7 @@ var BaseSound = new Class({
             return;
         }
 
+        this.emit('destroy', this);
         this.pendingRemove = true;
         this.manager = null;
         this.key = '';


### PR DESCRIPTION
** >> Make sure you describe your PR to the README Change Log section! << **

This PR changes (delete as applicable)

* The public-facing API

Describe the changes below:

Add 'destroy' event of sound object. A possible use-case is to free the reference of this destroyed sound object in other object.