### PR TITLE
Fixed typedefs for GetBounds

### DIFF
--- a/src/gameobjects/components/GetBounds.js
+++ b/src/gameobjects/components/GetBounds.js
@@ -25,8 +25,6 @@ var GetBounds = {
      * @method Phaser.GameObjects.Components.GetBounds#getCenter
      * @since 3.0.0
      *
-     * @generic {Phaser.Math.Vector2} O - [output,$return]
-     *
      * @param {(Phaser.Math.Vector2|object)} [output] - An object to store the values in. If not provided a new Vector2 will be created.
      *
      * @return {(Phaser.Math.Vector2|object)} The values stored in the output object.
@@ -47,8 +45,6 @@ var GetBounds = {
      *
      * @method Phaser.GameObjects.Components.GetBounds#getTopLeft
      * @since 3.0.0
-     *
-     * @generic {Phaser.Math.Vector2} O - [output,$return]
      *
      * @param {(Phaser.Math.Vector2|object)} [output] - An object to store the values in. If not provided a new Vector2 will be created.
      *
@@ -76,8 +72,6 @@ var GetBounds = {
      * @method Phaser.GameObjects.Components.GetBounds#getTopRight
      * @since 3.0.0
      *
-     * @generic {Phaser.Math.Vector2} O - [output,$return]
-     *
      * @param {(Phaser.Math.Vector2|object)} [output] - An object to store the values in. If not provided a new Vector2 will be created.
      *
      * @return {(Phaser.Math.Vector2|object)} The values stored in the output object.
@@ -103,8 +97,6 @@ var GetBounds = {
      *
      * @method Phaser.GameObjects.Components.GetBounds#getBottomLeft
      * @since 3.0.0
-     *
-     * @generic {Phaser.Math.Vector2} O - [output,$return]
      *
      * @param {(Phaser.Math.Vector2|object)} [output] - An object to store the values in. If not provided a new Vector2 will be created.
      *
@@ -132,8 +124,6 @@ var GetBounds = {
      * @method Phaser.GameObjects.Components.GetBounds#getBottomRight
      * @since 3.0.0
      *
-     * @generic {Phaser.Math.Vector2} O - [output,$return]
-     *
      * @param {(Phaser.Math.Vector2|object)} [output] - An object to store the values in. If not provided a new Vector2 will be created.
      *
      * @return {(Phaser.Math.Vector2|object)} The values stored in the output object.
@@ -159,8 +149,6 @@ var GetBounds = {
      *
      * @method Phaser.GameObjects.Components.GetBounds#getBounds
      * @since 3.0.0
-     *
-     * @generic {Phaser.Math.Vector2} O - [output,$return]
      *
      * @param {(Phaser.Geom.Rectangle|object)} [output] - An object to store the values in. If not provided a new Rectangle will be created.
      *


### PR DESCRIPTION
This PR changes:

* TypeScript Defs

Describe the changes below:

Removed the generic doc that caused the typedefs to complain:

`typescript/phaser.d.ts(11014,36): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11014,40): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11021,37): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11021,41): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11028,38): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11028,42): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11035,40): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11035,44): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11042,41): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11042,45): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11049,36): error TS2304: Cannot find name 'O'.
typescript/phaser.d.ts(11049,40): error TS2304: Cannot find name 'O'.`


