### PR TITLE
Added shuffle method to RND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ being passed to the simulation. The default value is 1 to remain consistent with
 * Graphics.slice allows you to easily draw a Pacman, or slice of pie shape to a Graphics object.
 * List.addCallback is a new optional callback that is invoked every time a new child is added to the List. You can use this to have a callback fire when children are added to the Display List.
 * List.removeCallback is a new optional callback that is invoked every time a new child is removed from the List. You can use this to have a callback fire when children are removed from the Display List.
+* A new method was added to RandomDataGenerator, 'shuffle' which uses the current seed as the basis for an array shuffle.
 
 ### Bug Fixes
 

--- a/src/math/random-data-generator/RandomDataGenerator.js
+++ b/src/math/random-data-generator/RandomDataGenerator.js
@@ -449,6 +449,29 @@ var RandomDataGenerator = new Class({
         }
 
         return [ '!rnd', this.c, this.s0, this.s1, this.s2 ].join(',');
+    },
+
+    /**
+     * Returns a shuffled copy of the array.
+     *
+     * @method Phaser.Math.RandomDataGenerator#shuffle
+     * @since 3.4.0
+     * 
+     * @param {array[]} [array] - The array to be shuffled.
+     *
+     * @return {array} Shuffled copy of the provided array.
+     */
+    shuffle: function (array)
+    {
+        var len = array.length - 1;
+        for (var i = len; i > 0; i--) {
+            var randomIndex = this.integerInRange(0, len);
+            var itemAtIndex = array[randomIndex];
+
+            array[randomIndex] = array[i];
+            array[i] = itemAtIndex;
+        }
+        return array;
     }
 
 });


### PR DESCRIPTION
This PR changes (delete as applicable)

* Documentation
* TypeScript Defs
* The public-facing API

Describe the changes below:
Added a method to the RandomDataGenerator for array shuffling that uses the current seed as the basis.
