### PR TITLE
Added shuffle to RND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * TransformMatrix.destroy is a new method that will clear out the array and object used by a Matrix internally.
 * BaseSound, and by extension WebAudioSound and HTMLAudioSound, will now emit a `destroy` event when they are destroyed (thanks @rexrainbow)
 * A new property was added to the Scene config: `mapAdd` which is used to extend the default injection map of a scene instead of overwriting it (thanks @sebashwa)
+* A new method was added to RandomDataGenerator, 'shuffle' which uses the current seed as the basis for an array shuffle.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ A special mention must go to @orblazer for their outstanding assistance in helpi
 * SoundManager.setVolume is a chainable method to allow you to set the global volume of the SoundManager.
 * BaseSound.setRate is a chainable method to allow you to set the playback rate of the BaseSound.
 * BaseSound.setDetune is a chainable method to allow you to set the detuning value of the BaseSound.
+* A new method was added to RandomDataGenerator, 'shuffle' which uses the current seed as the basis for an array shuffle.
 
 ### Bug Fixes
 

--- a/src/math/random-data-generator/RandomDataGenerator.js
+++ b/src/math/random-data-generator/RandomDataGenerator.js
@@ -449,6 +449,29 @@ var RandomDataGenerator = new Class({
         }
 
         return [ '!rnd', this.c, this.s0, this.s1, this.s2 ].join(',');
+    },
+
+    /**
+     * Returns a shuffled copy of the array.
+     *
+     * @method Phaser.Math.RandomDataGenerator#shuffle
+     * @since 3.4.0
+     * 
+     * @param {array[]} [array] - The array to be shuffled.
+     *
+     * @return {array} Shuffled copy of the provided array.
+     */
+    shuffle: function (array)
+    {
+        var len = array.length - 1;
+        for (var i = len; i > 0; i--) {
+            var randomIndex = this.integerInRange(0, len);
+            var itemAtIndex = array[randomIndex];
+
+            array[randomIndex] = array[i];
+            array[i] = itemAtIndex;
+        }
+        return array;
     }
 
 });

--- a/src/math/random-data-generator/RandomDataGenerator.js
+++ b/src/math/random-data-generator/RandomDataGenerator.js
@@ -464,7 +464,8 @@ var RandomDataGenerator = new Class({
     shuffle: function (array)
     {
         var len = array.length - 1;
-        for (var i = len; i > 0; i--) {
+        for (var i = len; i > 0; i--)
+        {
             var randomIndex = this.integerInRange(0, len);
             var itemAtIndex = array[randomIndex];
 

--- a/src/math/random-data-generator/RandomDataGenerator.js
+++ b/src/math/random-data-generator/RandomDataGenerator.js
@@ -452,14 +452,14 @@ var RandomDataGenerator = new Class({
     },
 
     /**
-     * Returns a shuffled copy of the array.
+     * A standard array shuffle implementation using the seed as a basis.
      *
      * @method Phaser.Math.RandomDataGenerator#shuffle
      * @since 3.4.0
      * 
      * @param {array[]} [array] - The array to be shuffled.
      *
-     * @return {array} Shuffled copy of the provided array.
+     * @return {array} The shuffled array.
      */
     shuffle: function (array)
     {


### PR DESCRIPTION
This PR changes (delete as applicable)

* Documentation
* TypeScript Defs
* The public-facing API

Describe the changes below:
Added a shuffle method to RandomDataGenerator which allows the currently stored seed to be used as the basis.
