### PR TITLE
Allow tween onComplete listeners to affect tween state

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ A special mention must go to @orblazer for their outstanding assistance in helpi
 * PathFollower.resume has been renamed to `resumeFollow` to avoid conflicting with the Animation component.
 * PathFollower.stop has been renamed to `stopFollow` to avoid conflicting with the Animation component.
 * BaseSound.setRate has been renamed to `calculateRate` to avoid confusion over the setting of the sounds rate.
+* Phaser.Tweens.Tween now allows restarting the tween in the `onComplete` listener
 
 Please see the complete [Change Log]((https://github.com/photonstorm/phaser/blob/master/CHANGELOG.md)) for previous releases.
 

--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -991,14 +991,14 @@ var Tween = new Class({
 
                 if (this.countdown <= 0)
                 {
+                    this.state = TWEEN_CONST.PENDING_REMOVE;
+
                     var onComplete = this.callbacks.onComplete;
 
                     if (onComplete)
                     {
                         onComplete.func.apply(onComplete.scope, onComplete.params);
                     }
-
-                    this.state = TWEEN_CONST.PENDING_REMOVE;
                 }
 
                 break;

--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -574,6 +574,8 @@ var Tween = new Class({
         }
         else
         {
+            this.state = TWEEN_CONST.PENDING_REMOVE;
+            
             var onComplete = this.callbacks.onComplete;
 
             if (onComplete)
@@ -582,8 +584,6 @@ var Tween = new Class({
 
                 onComplete.func.apply(onComplete.scope, onComplete.params);
             }
-
-            this.state = TWEEN_CONST.PENDING_REMOVE;
         }
     },
 
@@ -864,6 +864,8 @@ var Tween = new Class({
         }
         else
         {
+            this.state = TWEEN_CONST.PENDING_REMOVE;
+            
             var onComplete = this.callbacks.onComplete;
 
             if (onComplete)
@@ -872,8 +874,6 @@ var Tween = new Class({
 
                 onComplete.func.apply(onComplete.scope, onComplete.params);
             }
-
-            this.state = TWEEN_CONST.PENDING_REMOVE;
         }
     },
 


### PR DESCRIPTION
Set the state of the tween to PENDING_REMOVE before calling the onComplete listener of the tween to allow the `onComplete` listener to affect the tween state and not be immediately overwritten upon finishing execution.

This is useful for conditionally restarting the tween upon its completion.

Example:

```
        var me = this;
        this.myTween = this.add.tween({
            targets: this.mySprite,
            x: 300,
            duration: 3000,
            onComplete: function(){
                if(someConditional){
                    me.myTween.restart();
                }
            }
        });
```

Before this change, the `restart` call's state change would be overwritten immediately after leaving execution of the on complete. 