### PR TITLE
Add missing letterSpacing to DynamicBitmapText

### DIFF
--- a/src/gameobjects/bitmaptext/dynamic/DynamicBitmapText.js
+++ b/src/gameobjects/bitmaptext/dynamic/DynamicBitmapText.js
@@ -116,6 +116,16 @@ var DynamicBitmapText = new Class({
          */
         this.fontSize = size || this.fontData.size;
 
+        /**
+         * Adds/Removes spacing between characters
+         * Can be a negative or positive number
+         *
+         * @name Phaser.GameObjects.DynamicBitmapText#letterSpacing
+         * @type {number}
+         * @since 3.4.1
+         */
+        this.letterSpacing = 0;
+
         this.setTexture(entry.texture, entry.frame);
         this.setPosition(x, y);
         this.setOrigin(0, 0);


### PR DESCRIPTION
This PR changes
* Nothing, it's a bug fix

Newly added `letterSpacing` in BitmapText was missing in the Dynamic variant, which broke bounds calculation due to letterSpacing being undefined. Which subsequently broke rendering in WebGL and aligning.
Fixes #3558 
