### PR TITLE
Added additional check for node

### DIFF
--- a/src/device/OS.js
+++ b/src/device/OS.js
@@ -134,7 +134,7 @@ function init ()
         OS.cordova = true;
     }
     
-    if ((typeof process !== 'undefined') && (typeof process.versions.node !== 'undefined'))
+    if (process && process.versions && process.versions.node)
     {
         OS.node = true;
     }


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

If `process` is defined, but it has no `versions` property the check will fail with an error.
The detection of node is not working properly. 
In my case I have embedded phaser into a vue-cli@3 application, which is technically node but has no `versions` property.

This fixes the problem

