### PR TITLE
Delete Texture only applicable on renderer.gl

### DIFF
--- a/src/gameobjects/tilesprite/TileSprite.js
+++ b/src/gameobjects/tilesprite/TileSprite.js
@@ -274,7 +274,7 @@ var TileSprite = new Class({
      */
     destroy: function ()
     {
-        if (this.renderer)
+        if (this.renderer.gl)
         {
             this.renderer.deleteTexture(this.tileTexture);
         }


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:

deleteTexture only applicable on renderer.gl, There is no deleteTexture on this.renderer when running on canvas, so destroying tilesprites (scene shutting down) would throw error.

