### PR TITLE
XHR parameters are optional in Phaser.Loader.FileTypes

### DIFF
--- a/src/loader/filetypes/AnimationJSONFile.js
+++ b/src/loader/filetypes/AnimationJSONFile.js
@@ -16,7 +16,7 @@ var JSONFile = require('./JSONFile.js');
  * @param {string} key - The key of the file within the loader.
  * @param {string} url - The url to load the file from.
  * @param {string} path - The path of the file.
- * @param {XHRSettingsObject} xhrSettings - Optional file specific XHR settings.
+ * @param {XHRSettingsObject} [xhrSettings] - Optional file specific XHR settings.
  *
  * @return {Phaser.Loader.FileTypes.AnimationJSONFile} A File instance to be added to the Loader.
  */

--- a/src/loader/filetypes/AtlasJSONFile.js
+++ b/src/loader/filetypes/AtlasJSONFile.js
@@ -18,8 +18,8 @@ var JSONFile = require('./JSONFile.js');
  * @param {string} textureURL - The url to load the texture file from.
  * @param {string} atlasURL - The url to load the atlas file from.
  * @param {string} path - The path of the file.
- * @param {XHRSettingsObject} textureXhrSettings - Optional texture file specific XHR settings.
- * @param {XHRSettingsObject} atlasXhrSettings - Optional atlas file specific XHR settings.
+ * @param {XHRSettingsObject} [textureXhrSettings] - Optional texture file specific XHR settings.
+ * @param {XHRSettingsObject} [atlasXhrSettings] - Optional atlas file specific XHR settings.
  *
  * @return {object} An object containing two File objects to be added to the loader.
  */

--- a/src/loader/filetypes/AudioFile.js
+++ b/src/loader/filetypes/AudioFile.js
@@ -24,8 +24,8 @@ var HTML5AudioFile = require('./HTML5AudioFile');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
- * @param {AudioContext} audioContext - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
+ * @param {AudioContext} [audioContext] - [description]
  */
 var AudioFile = new Class({
 

--- a/src/loader/filetypes/BinaryFile.js
+++ b/src/loader/filetypes/BinaryFile.js
@@ -23,7 +23,7 @@ var GetFastValue = require('../../utils/object/GetFastValue');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  */
 var BinaryFile = new Class({
 

--- a/src/loader/filetypes/BitmapFontFile.js
+++ b/src/loader/filetypes/BitmapFontFile.js
@@ -18,8 +18,8 @@ var XMLFile = require('./XMLFile.js');
  * @param {string} textureURL - The url to load the texture file from.
  * @param {string} xmlURL - The url to load the atlas file from.
  * @param {string} path - The path of the file.
- * @param {XHRSettingsObject} textureXhrSettings - Optional texture file specific XHR settings.
- * @param {XHRSettingsObject} xmlXhrSettings - Optional atlas file specific XHR settings.
+ * @param {XHRSettingsObject} [textureXhrSettings] - Optional texture file specific XHR settings.
+ * @param {XHRSettingsObject} [xmlXhrSettings] - Optional atlas file specific XHR settings.
  *
  * @return {object} An object containing two File objects to be added to the loader.
  */

--- a/src/loader/filetypes/GLSLFile.js
+++ b/src/loader/filetypes/GLSLFile.js
@@ -23,7 +23,7 @@ var GetFastValue = require('../../utils/object/GetFastValue');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  */
 var GLSLFile = new Class({
 

--- a/src/loader/filetypes/HTML5AudioFile.js
+++ b/src/loader/filetypes/HTML5AudioFile.js
@@ -22,7 +22,7 @@ var GetURL = require('../GetURL');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} config - [description]
+ * @param {XHRSettingsObject} [config] - [description]
  */
 var HTML5AudioFile = new Class({
 

--- a/src/loader/filetypes/HTMLFile.js
+++ b/src/loader/filetypes/HTMLFile.js
@@ -25,7 +25,7 @@ var GetFastValue = require('../../utils/object/GetFastValue');
  * @param {number} width - [description]
  * @param {number} height - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  */
 var HTMLFile = new Class({
 

--- a/src/loader/filetypes/ImageFile.js
+++ b/src/loader/filetypes/ImageFile.js
@@ -23,8 +23,8 @@ var GetFastValue = require('../../utils/object/GetFastValue');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
- * @param {object} config - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
+ * @param {object} [config] - [description]
  */
 var ImageFile = new Class({
 

--- a/src/loader/filetypes/JSONFile.js
+++ b/src/loader/filetypes/JSONFile.js
@@ -23,7 +23,7 @@ var GetFastValue = require('../../utils/object/GetFastValue');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  */
 var JSONFile = new Class({
 

--- a/src/loader/filetypes/PluginFile.js
+++ b/src/loader/filetypes/PluginFile.js
@@ -24,7 +24,7 @@ var PluginManager = require('../../boot/PluginManager');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  */
 var PluginFile = new Class({
 

--- a/src/loader/filetypes/SVGFile.js
+++ b/src/loader/filetypes/SVGFile.js
@@ -23,7 +23,7 @@ var GetFastValue = require('../../utils/object/GetFastValue');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  */
 var SVGFile = new Class({
 

--- a/src/loader/filetypes/ScriptFile.js
+++ b/src/loader/filetypes/ScriptFile.js
@@ -23,7 +23,7 @@ var GetFastValue = require('../../utils/object/GetFastValue');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  */
 var ScriptFile = new Class({
 

--- a/src/loader/filetypes/SpriteSheetFile.js
+++ b/src/loader/filetypes/SpriteSheetFile.js
@@ -17,7 +17,7 @@ var ImageFile = require('./ImageFile.js');
  * @param {string} url - The url to load the texture file from.
  * @param {object} config - Optional texture file specific XHR settings.
  * @param {string} path - Optional texture file specific XHR settings.
- * @param {XHRSettingsObject} xhrSettings - Optional atlas file specific XHR settings.
+ * @param {XHRSettingsObject} [xhrSettings] - Optional atlas file specific XHR settings.
  *
  * @return {object} An object containing two File objects to be added to the loader.
  */

--- a/src/loader/filetypes/TextFile.js
+++ b/src/loader/filetypes/TextFile.js
@@ -22,7 +22,7 @@ var FileTypesManager = require('../FileTypesManager');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  */
 var TextFile = new Class({
 

--- a/src/loader/filetypes/TilemapCSVFile.js
+++ b/src/loader/filetypes/TilemapCSVFile.js
@@ -24,7 +24,7 @@ var TILEMAP_FORMATS = require('../../tilemaps/Formats');
  * @param {string} url - [description]
  * @param {string} path - [description]
  * @param {string} format - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  */
 var TilemapCSVFile = new Class({
 

--- a/src/loader/filetypes/TilemapJSONFile.js
+++ b/src/loader/filetypes/TilemapJSONFile.js
@@ -18,7 +18,7 @@ var TILEMAP_FORMATS = require('../../tilemaps/Formats');
  * @param {string} url - [description]
  * @param {string} path - [description]
  * @param {string} format - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  *
  * @return {object} An object containing two File objects to be added to the loader.
  */
@@ -83,7 +83,7 @@ FileTypesManager.register('tilemapTiledJSON', function (key, url, xhrSettings)
  *
  * @param {string} key - [description]
  * @param {string} url - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  *
  * @return {Phaser.Loader.LoaderPlugin} The Loader.
  */

--- a/src/loader/filetypes/UnityAtlasFile.js
+++ b/src/loader/filetypes/UnityAtlasFile.js
@@ -18,8 +18,8 @@ var TextFile = require('./TextFile.js');
  * @param {string} textureURL - The url to load the texture file from.
  * @param {string} atlasURL - The url to load the atlas file from.
  * @param {string} path - The path of the file.
- * @param {XHRSettingsObject} textureXhrSettings - Optional texture file specific XHR settings.
- * @param {XHRSettingsObject} atlasXhrSettings - Optional atlas file specific XHR settings.
+ * @param {XHRSettingsObject} [textureXhrSettings] - Optional texture file specific XHR settings.
+ * @param {XHRSettingsObject} [atlasXhrSettings] - Optional atlas file specific XHR settings.
  *
  * @return {object} An object containing two File objects to be added to the loader.
  */

--- a/src/loader/filetypes/XMLFile.js
+++ b/src/loader/filetypes/XMLFile.js
@@ -24,7 +24,7 @@ var ParseXML = require('../../dom/ParseXML');
  * @param {string} key - [description]
  * @param {string} url - [description]
  * @param {string} path - [description]
- * @param {XHRSettingsObject} xhrSettings - [description]
+ * @param {XHRSettingsObject} [xhrSettings] - [description]
  */
 var XMLFile = new Class({
 


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:
Made all XHR parameters optional in loader.filetypes 

