### PR TITLE
Fix incorrect `active` state selection in Group#getHandler

### DIFF
--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -836,6 +836,10 @@ var Group = new Class({
                         break;
                     }
                 }
+                else
+                {
+                    gameObject = null;
+                }
             }
         }
         else
@@ -852,6 +856,10 @@ var Group = new Class({
                     {
                         break;
                     }
+                }
+                else
+                {
+                    gameObject = null;
                 }
             }
         }


### PR DESCRIPTION
This PR

* Fixes a bug

Group#getHandler was returning any member of the group, regardless of its `active` state.

E.g., group pools wouldn't grow beyond one active member: <http://labs.phaser.io/edit.html?src=src\pools\create%20pool.js>
