### PR TITLE
Update GetBounds.getBounds() JSDoc

### DIFF
--- a/src/gameobjects/components/GetBounds.js
+++ b/src/gameobjects/components/GetBounds.js
@@ -196,7 +196,7 @@ var GetBounds = {
      * @method Phaser.GameObjects.Components.GetBounds#getBounds
      * @since 3.0.0
      *
-     * @generic {Phaser.Math.Vector2} O - [output,$return]
+     * @generic {Phaser.Geom.Rectangle} O - [output,$return]
      *
      * @param {(Phaser.Geom.Rectangle|object)} [output] - An object to store the values in. If not provided a new Rectangle will be created.
      *


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:

Update GetBounds.getBounds() JSDoc so that @generic matches with @param and @return. It seems that this comment wasn't in sync with the rest of the block. Moreover since this comment is used to generate the TS definitions, I wasn't able to use `getBounds()` in TypeScript since the compiler tried to force a `Vector2` for the result.
