### PR TITLE
Fix ParticleEmitter#toJSON() output

### DIFF
--- a/src/gameobjects/particles/EmitterOp.js
+++ b/src/gameobjects/particles/EmitterOp.js
@@ -265,7 +265,7 @@ var EmitterOp = new Class({
      */
     toJSON: function ()
     {
-        return JSON.stringify(this.propertyValue);
+        return this.propertyValue;
     },
 
     /**

--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -256,6 +256,7 @@ var ParticleEmitter = new Class({
         this.configOpMap = [
             'accelerationX',
             'accelerationY',
+            'angle',
             'alpha',
             'bounce',
             'delay',


### PR DESCRIPTION
- `angle` was missing.
- EmitterOp properties were converted to strings, which could cause `emitter.fromJSON( emitter.toJSON() )` to fail.
