### PR TITLE
Fix JSDoc parameter type in Actions.GridAlign

### DIFF
--- a/src/actions/GridAlign.js
+++ b/src/actions/GridAlign.js
@@ -19,7 +19,7 @@ var tempZone = new Zone({ sys: { queueDepthSort: NOOP, events: { once: NOOP } } 
  *                                  If both this value and height are set to -1 then this value overrides it and the `height` value is ignored.
  * @property {integer} [height=-1] - The height of the grid in items (not pixels). -1 means lay all items out vertically, regardless of quantity.
  *                                   If both this value and `width` are set to -1 then `width` overrides it and this value is ignored.
- * @property {boolean} [cellWidth=1] - The width of the cell, in pixels, in which the item is positioned.
+ * @property {integer} [cellWidth=1] - The width of the cell, in pixels, in which the item is positioned.
  * @property {integer} [cellHeight=1] - The height of the cell, in pixels, in which the item is positioned.
  * @property {integer} [position=0] - The alignment position. One of the Phaser.Display.Align consts such as `TOP_LEFT` or `RIGHT_CENTER`.
  * @property {number} [x=0] - Optionally place the top-left of the final grid at this coordinate.


### PR DESCRIPTION
This PR
* Updates the Documentation

Describe the changes below:
`cellWidth` should be an integer instead of a boolean, as described by the default value and the description text.

