### PR TITLE
arcade colliders take gameobjects, not arcade bodies

### DIFF
--- a/src/physics/arcade/Collider.js
+++ b/src/physics/arcade/Collider.js
@@ -17,8 +17,8 @@ var Class = require('../../utils/Class');
  *
  * @param {Phaser.Physics.Arcade.World} world - [description]
  * @param {boolean} overlapOnly - [description]
- * @param {Phaser.GameObjects.GameObject} object1 - The first object to check for collision.
- * @param {Phaser.GameObjects.GameObject} object2 - The second object to check for collision.
+ * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object1 - The first object to check for collision.
+ * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object2 - The second object to check for collision.
  * @param {ArcadePhysicsCallback} collideCallback - The callback to invoke when the two objects collide.
  * @param {ArcadePhysicsCallback} processCallback - The callback to invoke when the two objects collide. Must return a boolean.
  * @param {object} callbackContext - The scope in which to call the callbacks.

--- a/src/physics/arcade/Collider.js
+++ b/src/physics/arcade/Collider.js
@@ -17,8 +17,8 @@ var Class = require('../../utils/Class');
  *
  * @param {Phaser.Physics.Arcade.World} world - [description]
  * @param {boolean} overlapOnly - [description]
- * @param {Phaser.Physics.Arcade.Body} object1 - The first object to check for collision.
- * @param {Phaser.Physics.Arcade.Body} object2 - The second object to check for collision.
+ * @param {Phaser.GameObjects.GameObject} object1 - The first object to check for collision.
+ * @param {Phaser.GameObjects.GameObject} object2 - The second object to check for collision.
  * @param {ArcadePhysicsCallback} collideCallback - The callback to invoke when the two objects collide.
  * @param {ArcadePhysicsCallback} processCallback - The callback to invoke when the two objects collide. Must return a boolean.
  * @param {object} callbackContext - The scope in which to call the callbacks.

--- a/src/physics/arcade/Factory.js
+++ b/src/physics/arcade/Factory.js
@@ -63,8 +63,8 @@ var Factory = new Class({
      * @method Phaser.Physics.Arcade.Factory#collider
      * @since 3.0.0
      *
-     * @param {Phaser.GameObjects.GameObject} object1 - The first object to check for collision.
-     * @param {Phaser.GameObjects.GameObject} object2 - The second object to check for collision.
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object1 - The first object to check for collision.
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object2 - The second object to check for collision.
      * @param {ArcadePhysicsCallback} [collideCallback] - The callback to invoke when the two objects collide.
      * @param {ArcadePhysicsCallback} [processCallback] - The callback to invoke when the two objects collide. Must return a boolean.
      * @param {*} [callbackContext] - The scope in which to call the callbacks.
@@ -82,8 +82,8 @@ var Factory = new Class({
      * @method Phaser.Physics.Arcade.Factory#overlap
      * @since 3.0.0
      *
-     * @param {Phaser.Physics.Arcade.Body} object1 - The first object to check for overlap.
-     * @param {Phaser.Physics.Arcade.Body} object2 - The second object to check for overlap.
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object1 - The first object to check for overlap.
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object2 - The second object to check for overlap.
      * @param {ArcadePhysicsCallback} [collideCallback] - The callback to invoke when the two objects collide.
      * @param {ArcadePhysicsCallback} [processCallback] - The callback to invoke when the two objects collide. Must return a boolean.
      * @param {*} [callbackContext] - The scope in which to call the callbacks.

--- a/src/physics/arcade/Factory.js
+++ b/src/physics/arcade/Factory.js
@@ -63,8 +63,8 @@ var Factory = new Class({
      * @method Phaser.Physics.Arcade.Factory#collider
      * @since 3.0.0
      *
-     * @param {Phaser.Physics.Arcade.Body} object1 - The first object to check for collision.
-     * @param {Phaser.Physics.Arcade.Body} object2 - The second object to check for collision.
+     * @param {Phaser.GameObjects.GameObject} object1 - The first object to check for collision.
+     * @param {Phaser.GameObjects.GameObject} object2 - The second object to check for collision.
      * @param {ArcadePhysicsCallback} [collideCallback] - The callback to invoke when the two objects collide.
      * @param {ArcadePhysicsCallback} [processCallback] - The callback to invoke when the two objects collide. Must return a boolean.
      * @param {*} [callbackContext] - The scope in which to call the callbacks.

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -621,8 +621,8 @@ var World = new Class({
      * @method Phaser.Physics.Arcade.World#addCollider
      * @since 3.0.0
      *
-     * @param {Phaser.Physics.Arcade.Body} object1 - The first object to check for collision.
-     * @param {Phaser.Physics.Arcade.Body} object2 - The second object to check for collision.
+     * @param {Phaser.GameObjects.GameObject} object1 - The first object to check for collision.
+     * @param {Phaser.GameObjects.GameObject} object2 - The second object to check for collision.
      * @param {ArcadePhysicsCallback} [collideCallback] - The callback to invoke when the two objects collide.
      * @param {ArcadePhysicsCallback} [processCallback] - The callback to invoke when the two objects collide. Must return a boolean.
      * @param {*} [callbackContext] - The scope in which to call the callbacks.

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -621,8 +621,8 @@ var World = new Class({
      * @method Phaser.Physics.Arcade.World#addCollider
      * @since 3.0.0
      *
-     * @param {Phaser.GameObjects.GameObject} object1 - The first object to check for collision.
-     * @param {Phaser.GameObjects.GameObject} object2 - The second object to check for collision.
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object1 - The first object to check for collision.
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object2 - The second object to check for collision.
      * @param {ArcadePhysicsCallback} [collideCallback] - The callback to invoke when the two objects collide.
      * @param {ArcadePhysicsCallback} [processCallback] - The callback to invoke when the two objects collide. Must return a boolean.
      * @param {*} [callbackContext] - The scope in which to call the callbacks.
@@ -648,8 +648,8 @@ var World = new Class({
      * @method Phaser.Physics.Arcade.World#addOverlap
      * @since 3.0.0
      *
-     * @param {Phaser.Physics.Arcade.Body} object1 - The first object to check for overlap.
-     * @param {Phaser.Physics.Arcade.Body} object2 - The second object to check for overlap.
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object1 - The first object to check for overlap.
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object2 - The second object to check for overlap.
      * @param {ArcadePhysicsCallback} [collideCallback] - The callback to invoke when the two objects overlap.
      * @param {ArcadePhysicsCallback} [processCallback] - The callback to invoke when the two objects overlap. Must return a boolean.
      * @param {*} [callbackContext] - The scope in which to call the callbacks.
@@ -1351,8 +1351,8 @@ var World = new Class({
      * @method Phaser.Physics.Arcade.World#collideObjects
      * @since 3.0.0
      *
-     * @param {Phaser.GameObjects.GameObject} object1 - [description]
-     * @param {Phaser.GameObjects.GameObject} object2 - [description]
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object1 - [description]
+     * @param {(Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[])} object2 - [description]
      * @param {ArcadePhysicsCallback} collideCallback - [description]
      * @param {ArcadePhysicsCallback} processCallback - [description]
      * @param {*} callbackContext - [description]


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:
Adding an Arcade Physics Collider was throwing an error because it expected the passed objects to be Arcade Bodies (which is incorrect since you can pass in groups, arrays, tilemap layers, etc). This PR updates the param types for that method (and a couple of others) to match the param types of the Arcade World's `collideObjects` function, which takes in GameObjects instead.