### PR TITLE
Update Tiled Base64Decode function

### DIFF
--- a/src/tilemaps/parsers/tiled/Base64Decode.js
+++ b/src/tilemaps/parsers/tiled/Base64Decode.js
@@ -18,7 +18,7 @@ var Base64Decode = function (data)
 {
     var binaryString = window.atob(data);
     var len = binaryString.length;
-    var bytes = new Array(len);
+    var bytes = new Array(len / 4);
 
     // Interpret binaryString as an array of bytes representing little-endian encoded uint32 values.
     for (var i = 0; i < len; i += 4)


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

The array length should be 1/4 the size of the raw binary string, otherwise you end up with a bunch of undefined array values at the end.
