### PR TITLE
Update JSDocs

### DIFF
--- a/src/boot/Config.js
+++ b/src/boot/Config.js
@@ -79,16 +79,16 @@ var ValueToColor = require('../display/color/ValueToColor');
  * @property {string} [banner.text='#ffffff'] - [description]
  * @property {string[]} [banner.background] - [description]
  * @property {FPSConfig} [fps] - [description]
- * @property {boolean} [antialias=true] - [description]
- * @property {boolean} [pixelArt=false] - [description]
- * @property {boolean} [autoResize=false] - [description]
- * @property {boolean} [roundPixels=false] - [description]
- * @property {boolean} [transparent=false] - [description]
- * @property {boolean} [clearBeforeRender=true] - [description]
- * @property {boolean} [premultipliedAlpha=true] - [description]
- * @property {boolean} [preserveDrawingBuffer=false] - [description]
- * @property {boolean} [failIfMajorPerformanceCaveat=false] - [description]
- * @property {boolean} [powerPreference='default'] - "high-performance", "low-power" or "default"
+ * @property {boolean} [render.antialias=true] - [description]
+ * @property {boolean} [render.pixelArt=false] - [description]
+ * @property {boolean} [render.autoResize=false] - [description]
+ * @property {boolean} [render.roundPixels=false] - [description]
+ * @property {boolean} [render.transparent=false] - [description]
+ * @property {boolean} [render.clearBeforeRender=true] - [description]
+ * @property {boolean} [render.premultipliedAlpha=true] - [description]
+ * @property {boolean} [render.preserveDrawingBuffer=false] - [description]
+ * @property {boolean} [render.failIfMajorPerformanceCaveat=false] - [description]
+ * @property {string} [render.powerPreference='default'] - "high-performance", "low-power" or "default"
  * @property {(string|number)} [backgroundColor=0x000000] - [description]
  * @property {object} [callbacks] - [description]
  * @property {BootCallback} [callbacks.preBoot=NOOP] - [description]
@@ -130,51 +130,162 @@ var Config = new Class({
 
         var defaultBannerTextColor = '#ffffff';
 
+        /**
+         * @const {(integer|string)} Phaser.Boot.Config#width - [description]
+         */
         this.width = GetValue(config, 'width', 1024);
+
+        /**
+         * @const {(integer|string)} Phaser.Boot.Config#height - [description]
+         */
         this.height = GetValue(config, 'height', 768);
+
+        /**
+         * @const {number} Phaser.Boot.Config#zoom - [description]
+         */
         this.zoom = GetValue(config, 'zoom', 1);
 
+
+        /**
+         * @const {number} Phaser.Boot.Config#resolution - [description]
+         */
         this.resolution = GetValue(config, 'resolution', 1);
 
+
+        /**
+         * @const {number} Phaser.Boot.Config#renderType - [description]
+         */
         this.renderType = GetValue(config, 'type', CONST.AUTO);
 
+
+        /**
+         * @const {?*} Phaser.Boot.Config#parent - [description]
+         */
         this.parent = GetValue(config, 'parent', null);
+
+        /**
+         * @const {?HTMLCanvasElement} Phaser.Boot.Config#canvas - [description]
+         */
         this.canvas = GetValue(config, 'canvas', null);
+
+        /**
+         * @const {?string} Phaser.Boot.Config#canvasStyle - [description]
+         */
         this.canvasStyle = GetValue(config, 'canvasStyle', null);
 
+
+        /**
+         * @const {?object} Phaser.Boot.Config#sceneConfig - [description]
+         */
         this.sceneConfig = GetValue(config, 'scene', null);
 
+
+        /**
+         * @const {string[]} Phaser.Boot.Config#seed - [description]
+         */
         this.seed = GetValue(config, 'seed', [ (Date.now() * Math.random()).toString() ]);
 
         MATH.RND.init(this.seed);
 
+
+        /**
+         * @const {string} Phaser.Boot.Config#gameTitle - [description]
+         */
         this.gameTitle = GetValue(config, 'title', '');
+
+        /**
+         * @const {string} Phaser.Boot.Config#gameURL - [description]
+         */
         this.gameURL = GetValue(config, 'url', 'https://phaser.io');
+
+        /**
+         * @const {string} Phaser.Boot.Config#gameVersion - [description]
+         */
         this.gameVersion = GetValue(config, 'version', '');
 
+
         //  Input
+        /**
+         * @const {boolean} Phaser.Boot.Config#inputKeyboard - [description]
+         */
         this.inputKeyboard = GetValue(config, 'input.keyboard', true);
+
+        /**
+         * @const {*} Phaser.Boot.Config#inputKeyboardEventTarget - [description]
+         */
         this.inputKeyboardEventTarget = GetValue(config, 'input.keyboard.target', window);
 
+
+        /**
+         * @const {(boolean|object)} Phaser.Boot.Config#inputMouse - [description]
+         */
         this.inputMouse = GetValue(config, 'input.mouse', true);
+
+        /**
+         * @const {?*} Phaser.Boot.Config#inputMouseEventTarget - [description]
+         */
         this.inputMouseEventTarget = GetValue(config, 'input.mouse.target', null);
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#inputMouseCapture - [description]
+         */
         this.inputMouseCapture = GetValue(config, 'input.mouse.capture', true);
 
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#inputTouch - [description]
+         */
         this.inputTouch = GetValue(config, 'input.touch', true);
+
+        /**
+         * @const {?*} Phaser.Boot.Config#inputTouchEventTarget - [description]
+         */
         this.inputTouchEventTarget = GetValue(config, 'input.touch.target', null);
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#inputTouchCapture - [description]
+         */
         this.inputTouchCapture = GetValue(config, 'input.touch.capture', true);
 
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#inputGamepad - [description]
+         */
         this.inputGamepad = GetValue(config, 'input.gamepad', false);
 
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#disableContextMenu - [description]
+         */
         this.disableContextMenu = GetValue(config, 'disableContextMenu', false);
 
+
+        /**
+         * @const {any} Phaser.Boot.Config#audio - [description]
+         */
         this.audio = GetValue(config, 'audio');
 
+
         //  If you do: { banner: false } it won't display any banner at all
+        /**
+         * @const {boolean} Phaser.Boot.Config#hideBanner - [description]
+         */
         this.hideBanner = (GetValue(config, 'banner', null) === false);
 
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#hidePhaser - [description]
+         */
         this.hidePhaser = GetValue(config, 'banner.hidePhaser', false);
+
+        /**
+         * @const {string} Phaser.Boot.Config#bannerTextColor - [description]
+         */
         this.bannerTextColor = GetValue(config, 'banner.text', defaultBannerTextColor);
+
+        /**
+         * @const {string[]} Phaser.Boot.Config#bannerBackgroundColor - [description]
+         */
         this.bannerBackgroundColor = GetValue(config, 'banner.background', defaultBannerColor);
 
         if (this.gameTitle === '' && this.hidePhaser)
@@ -190,6 +301,9 @@ var Config = new Class({
         //          deltaHistory: 10
         //     }
 
+        /**
+         * @const {?FPSConfig} Phaser.Boot.Config#fps - [description]
+         */
         this.fps = GetValue(config, 'fps', null);
 
         //  Renderer Settings
@@ -197,19 +311,62 @@ var Config = new Class({
 
         var renderConfig = GetValue(config, 'render', config);
 
+        /**
+         * @const {boolean} Phaser.Boot.Config#antialias - [description]
+         */
         this.antialias = GetValue(renderConfig, 'antialias', true);
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#pixelArt - [description]
+         */
         this.pixelArt = GetValue(renderConfig, 'pixelArt', false);
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#autoResize - [description]
+         */
         this.autoResize = GetValue(renderConfig, 'autoResize', false);
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#roundPixels - [description]
+         */
         this.roundPixels = GetValue(renderConfig, 'roundPixels', false);
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#transparent - [description]
+         */
         this.transparent = GetValue(renderConfig, 'transparent', false);
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#zoclearBeforeRenderom - [description]
+         */
         this.clearBeforeRender = GetValue(renderConfig, 'clearBeforeRender', true);
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#premultipliedAlpha - [description]
+         */
         this.premultipliedAlpha = GetValue(renderConfig, 'premultipliedAlpha', true);
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#preserveDrawingBuffer - [description]
+         */
         this.preserveDrawingBuffer = GetValue(renderConfig, 'preserveDrawingBuffer', false);
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#failIfMajorPerformanceCaveat - [description]
+         */
         this.failIfMajorPerformanceCaveat = GetValue(renderConfig, 'failIfMajorPerformanceCaveat', false);
+
+        /**
+         * @const {string} Phaser.Boot.Config#powerPreference - [description]
+         */
         this.powerPreference = GetValue(renderConfig, 'powerPreference', 'default');
+
 
         var bgc = GetValue(config, 'backgroundColor', 0);
 
+        /**
+         * @const {Phaser.Display.Color} Phaser.Boot.Config#backgroundColor - [description]
+         */
         this.backgroundColor = ValueToColor(bgc);
 
         if (bgc === 0 && this.transparent)
@@ -217,9 +374,18 @@ var Config = new Class({
             this.backgroundColor.alpha = 0;
         }
 
+
         //  Callbacks
+        /**
+         * @const {BootCallback} Phaser.Boot.Config#preBoot - [description]
+         */
         this.preBoot = GetValue(config, 'callbacks.preBoot', NOOP);
+
+        /**
+         * @const {BootCallback} Phaser.Boot.Config#postBoot - [description]
+         */
         this.postBoot = GetValue(config, 'callbacks.postBoot', NOOP);
+
 
         //  Physics
         //  physics: {
@@ -229,27 +395,82 @@ var Config = new Class({
         //      cellSize: 64
         //  }
 
+        /**
+         * @const {object} Phaser.Boot.Config#physics - [description]
+         */
         this.physics = GetValue(config, 'physics', {});
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#defaultPhysicsSystem - [description]
+         */
         this.defaultPhysicsSystem = GetValue(this.physics, 'default', false);
 
+
         //  Loader Defaults
+        /**
+         * @const {string} Phaser.Boot.Config#loaderBaseURL - [description]
+         */
         this.loaderBaseURL = GetValue(config, 'loader.baseURL', '');
+
+        /**
+         * @const {string} Phaser.Boot.Config#loaderPath - [description]
+         */
         this.loaderPath = GetValue(config, 'loader.path', '');
+
+        /**
+         * @const {integer} Phaser.Boot.Config#loaderMaxParallelDownloads - [description]
+         */
         this.loaderMaxParallelDownloads = GetValue(config, 'loader.maxParallelDownloads', 32);
+
+        /**
+         * @const {(string|undefined)} Phaser.Boot.Config#loaderCrossOrigin - [description]
+         */
         this.loaderCrossOrigin = GetValue(config, 'loader.crossOrigin', undefined);
+
+        /**
+         * @const {string} Phaser.Boot.Config#loaderResponseType - [description]
+         */
         this.loaderResponseType = GetValue(config, 'loader.responseType', '');
+
+        /**
+         * @const {boolean} Phaser.Boot.Config#loaderAsync - [description]
+         */
         this.loaderAsync = GetValue(config, 'loader.async', true);
+
+        /**
+         * @const {string} Phaser.Boot.Config#loaderUser - [description]
+         */
         this.loaderUser = GetValue(config, 'loader.user', '');
+
+        /**
+         * @const {string} Phaser.Boot.Config#loaderPassword - [description]
+         */
         this.loaderPassword = GetValue(config, 'loader.password', '');
+
+        /**
+         * @const {integer} Phaser.Boot.Config#loaderTimeout - [description]
+         */
         this.loaderTimeout = GetValue(config, 'loader.timeout', 0);
 
+
         //  Scene Plugins
+        /**
+         * @const {any} Phaser.Boot.Config#defaultPlugins - [description]
+         */
         this.defaultPlugins = GetValue(config, 'plugins', Plugins.DefaultScene);
+
 
         //  Default / Missing Images
         var pngPrefix = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAg';
 
+        /**
+         * @const {string} Phaser.Boot.Config#defaultImage - [description]
+         */
         this.defaultImage = GetValue(config, 'images.default', pngPrefix + 'AQMAAABJtOi3AAAAA1BMVEX///+nxBvIAAAAAXRSTlMAQObYZgAAABVJREFUeF7NwIEAAAAAgKD9qdeocAMAoAABm3DkcAAAAABJRU5ErkJggg==');
+        
+        /**
+         * @const {string} Phaser.Boot.Config#missingImage - [description]
+         */
         this.missingImage = GetValue(config, 'images.missing', pngPrefix + 'CAIAAAD8GO2jAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAJ9JREFUeNq01ssOwyAMRFG46v//Mt1ESmgh+DFmE2GPOBARKb2NVjo+17PXLD8a1+pl5+A+wSgFygymWYHBb0FtsKhJDdZlncG2IzJ4ayoMDv20wTmSMzClEgbWYNTAkQ0Z+OJ+A/eWnAaR9+oxCF4Os0H8htsMUp+pwcgBBiMNnAwF8GqIgL2hAzaGFFgZauDPKABmowZ4GL369/0rwACp2yA/ttmvsQAAAABJRU5ErkJggg==');
     }
 


### PR DESCRIPTION
This PR:
* Updates the Documentation

Describe the changes below:
- Update GameConfig to explicit the `render` subobject
- GameConfig#render.powerPreference is documented as string instead of boolean
- Add comments to the members of the `Config` object

I used `@const` for the members of `Config` so that they are marked "readonly" in the generated TS definitions and the comment is still only one line. Otherwise I have to do: 
```js
/**
 * @readonly
 * @member {type} name
 */
```

If you prefer the longer version or a version similar to the properties of `Game` with `@name`, `@type`, `@readonly` and `@since`, I can update my PR.
