### PR TITLE
Missing loader parameter in File.call

### DIFF
--- a/src/loader/filetypes/ScriptFile.js
+++ b/src/loader/filetypes/ScriptFile.js
@@ -69,7 +69,7 @@ var ScriptFile = new Class({
             xhrSettings: xhrSettings
         };
 
-        File.call(this, fileConfig);
+        File.call(this, loader, fileConfig);
     },
 
     /**


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

File needs to be called with 2 parameters. First parameter - loader was missing.
