### PR TITLE
Add `allowDrag`, `allowGravity`, `allowRotation` to Arcade.PhysicsGroup config

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1594,6 +1594,60 @@ var Body = new Class({
     },
 
     /**
+     * Enables or disables drag.
+     *
+     * @method Phaser.Physics.Arcade.Body#setAllowDrag
+     * @since 3.9.0
+     * @see Phaser.Physics.Arcade.Body#allowDrag
+     *
+     * @param {boolean} val - The value of `allowDrag`.
+     *
+     * @return {Phaser.Physics.Arcade.Body} This Body object.
+     */
+    setAllowDrag: function (val)
+    {
+        this.allowDrag = val;
+
+        return this;
+    },
+
+    /**
+     * Enables or disables gravity's effect on this Body.
+     *
+     * @method Phaser.Physics.Arcade.Body#setAllowGravity
+     * @since 3.9.0
+     * @see Phaser.Physics.Arcade.Body#allowGravity
+     *
+     * @param {boolean} val - The value of `allowGravity`.
+     *
+     * @return {Phaser.Physics.Arcade.Body} This Body object.
+     */
+    setAllowGravity: function (val)
+    {
+        this.allowGravity = val;
+
+        return this;
+    },
+
+    /**
+     * Enables or disables rotation.
+     *
+     * @method Phaser.Physics.Arcade.Body#setAllowRotation
+     * @since 3.9.0
+     * @see Phaser.Physics.Arcade.Body#allowRotation
+     *
+     * @param {boolean} val - The value of `allowRotation`.
+     *
+     * @return {Phaser.Physics.Arcade.Body} This Body object.
+     */
+    setAllowRotation: function (val)
+    {
+        this.allowRotation = val;
+
+        return this;
+    },
+
+    /**
      * Sets the Body's drag.
      *
      * @method Phaser.Physics.Arcade.Body#setDrag

--- a/src/physics/arcade/PhysicsGroup.js
+++ b/src/physics/arcade/PhysicsGroup.js
@@ -17,6 +17,9 @@ var Group = require('../../gameobjects/group/Group');
  * @property {boolean} [collideWorldBounds=false] - Sets {@link Phaser.Physics.Arcade.Body#collideWorldBounds}.
  * @property {number} [accelerationX=0] - Sets {@link Phaser.Physics.Arcade.Body#acceleration acceleration.x}.
  * @property {number} [accelerationY=0] - Sets {@link Phaser.Physics.Arcade.Body#acceleration acceleration.y}.
+ * @property {boolean} [allowDrag=true] - Sets {@link Phaser.Physics.Arcade.Body#allowDrag}.
+ * @property {boolean} [allowGravity=true] - Sets {@link Phaser.Physics.Arcade.Body#allowGravity}.
+ * @property {boolean} [allowRotation=true] - Sets {@link Phaser.Physics.Arcade.Body#allowRotation}.
  * @property {number} [bounceX=0] - Sets {@link Phaser.Physics.Arcade.Body#bounce bounce.x}.
  * @property {number} [bounceY=0] - Sets {@link Phaser.Physics.Arcade.Body#bounce bounce.y}.
  * @property {number} [dragX=0] - Sets {@link Phaser.Physics.Arcade.Body#drag drag.x}.
@@ -40,6 +43,9 @@ var Group = require('../../gameobjects/group/Group');
  * @property {boolean} setCollideWorldBounds - [description]
  * @property {number} setAccelerationX - [description]
  * @property {number} setAccelerationY - [description]
+ * @property {boolean} setAllowDrag - [description]
+ * @property {boolean} setAllowGravity - [description]
+ * @property {boolean} setAllowRotation - [description]
  * @property {number} setBounceX - [description]
  * @property {number} setBounceY - [description]
  * @property {number} setDragX - [description]
@@ -133,6 +139,9 @@ var PhysicsGroup = new Class({
             setCollideWorldBounds: GetFastValue(config, 'collideWorldBounds', false),
             setAccelerationX: GetFastValue(config, 'accelerationX', 0),
             setAccelerationY: GetFastValue(config, 'accelerationY', 0),
+            setAllowDrag: GetFastValue(config, 'allowDrag', true),
+            setAllowGravity: GetFastValue(config, 'allowGravity', true),
+            setAllowRotation: GetFastValue(config, 'allowRotation', true),
             setBounceX: GetFastValue(config, 'bounceX', 0),
             setBounceY: GetFastValue(config, 'bounceY', 0),
             setDragX: GetFastValue(config, 'dragX', 0),


### PR DESCRIPTION
This PR

* Adds a new feature

[To save looping](http://www.html5gamedevs.com/topic/37529-overlap-between-sprite-and-staticgroup-and-not-working/?tab=comments#comment-214347).
