### PR TITLE
Fix TileSprite destruction

### DIFF
--- a/src/gameobjects/tilesprite/TileSprite.js
+++ b/src/gameobjects/tilesprite/TileSprite.js
@@ -276,6 +276,14 @@ var TileSprite = new Class({
      */
     destroy: function ()
     {
+        //  This Game Object had already been destroyed
+        if (!this.renderer || this.ignoreDestroy)
+        {
+            return;
+        }
+
+        this.emit('destroy', this);
+
         if (this.renderer.gl)
         {
             this.renderer.deleteTexture(this.tileTexture);


### PR DESCRIPTION
- Run `destroy` only once (fixes #3661)
- Respect `ignoreDestroy`
- Emit 'destroy' event

This PR

* Fixes a bug
