### PR TITLE
Fixed JSDoc error in RND.shuffle param

### DIFF
--- a/src/math/random-data-generator/RandomDataGenerator.js
+++ b/src/math/random-data-generator/RandomDataGenerator.js
@@ -457,7 +457,7 @@ var RandomDataGenerator = new Class({
      * @method Phaser.Math.RandomDataGenerator#shuffle
      * @since 3.4.0
      * 
-     * @param {array[]} [array] - The array to be shuffled.
+     * @param {array} [array] - The array to be shuffled.
      *
      * @return {array} The shuffled array.
      */


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:
The JSDoc was generating it as an array of arrays as opposed to a one dimensional array.
