### PR TITLE
Tweens can now have duration 0

### DIFF
--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -1214,7 +1214,7 @@ var Tween = new Class({
                 }
 
                 var forward = (tweenData.state === TWEEN_CONST.PLAYING_FORWARD);
-                var progress = elapsed / duration;
+                var progress = (duration > 0) ? elapsed / duration : 1;
 
                 var v;
 


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:

If the tween duration was 0, it crashed because of division by zero when calculating progress. Now it sets progress to 1 in that case.