### PR TITLE
Pass `this.parent` instead of `this` in callback of removedata event

### DIFF
--- a/src/data/DataManager.js
+++ b/src/data/DataManager.js
@@ -456,7 +456,7 @@ var DataManager = new Class({
             delete this.list[key];
             delete this.values[key];
 
-            this.events.emit('removedata', this, key, data);
+            this.events.emit('removedata', this.parent, key, data);
         }
 
         return this;


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Pass this.parent at 1st argument of event callback, to consistent with other events, i.e. [`setdata`](https://github.com/photonstorm/phaser/blob/v3.10.1/src/data/DataManager.js#L330) event