### PR TITLE
[fix] sceneManager .run will queueOp if scene not ready

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -140,7 +140,7 @@ var SceneManager = new Class({
                 });
             }
         }
-        
+
         game.events.once('ready', this.bootQueue, this);
     },
 
@@ -1011,7 +1011,7 @@ var SceneManager = new Class({
 
     /**
      * Runs the given Scene, but does not change the state of this Scene.
-     * 
+     *
      * If the given Scene is paused, it will resume it. If sleeping, it will wake it.
      * If not running at all, it will be started.
      *
@@ -1032,6 +1032,20 @@ var SceneManager = new Class({
 
         if (!scene)
         {
+            var isFound = false;
+            for (var i = 0; i < this._pending.length; i++)
+            {
+                if (this._pending[i].key === key)
+                {
+                    isFound = true;
+                    break;
+                }
+            }
+            if (isFound)
+            {
+                this.queueOp('stop', key);
+                this.queueOp('start', key, data);
+            }
             return this;
         }
 

--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -1032,18 +1032,13 @@ var SceneManager = new Class({
 
         if (!scene)
         {
-            var isFound = false;
             for (var i = 0; i < this._pending.length; i++)
             {
                 if (this._pending[i].key === key)
                 {
-                    isFound = true;
+                    this.queueOp('start', key, data);
                     break;
                 }
-            }
-            if (isFound)
-            {
-                this.queueOp('start', key, data);
             }
             return this;
         }

--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -1043,7 +1043,6 @@ var SceneManager = new Class({
             }
             if (isFound)
             {
-                this.queueOp('stop', key);
                 this.queueOp('start', key, data);
             }
             return this;


### PR DESCRIPTION
This PR 

* Fixes a bug

Fixes `.run` in game sceneManager to `queueOp` an unready scene. Since we don't yet know if the key is valid, we look for it first in the `_pending` queue, unlike in the `scenePlugin` where we already know it is valid.

