### PR TITLE
[feat] scene.run can now pass data to .wake and .resume if it needs

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -140,7 +140,7 @@ var SceneManager = new Class({
                 });
             }
         }
-        
+
         game.events.once('ready', this.bootQueue, this);
     },
 
@@ -1011,7 +1011,7 @@ var SceneManager = new Class({
 
     /**
      * Runs the given Scene, but does not change the state of this Scene.
-     * 
+     *
      * If the given Scene is paused, it will resume it. If sleeping, it will wake it.
      * If not running at all, it will be started.
      *
@@ -1022,7 +1022,7 @@ var SceneManager = new Class({
      * @since 3.10.0
      *
      * @param {string} key - The Scene to run.
-     * @param {object} [data] - A data object that will be passed to the Scene that is run _only if the Scene isn't asleep or paused_.
+     * @param {object} [data] - A data object that will be passed to the Scene on start, wake, or resume.
      *
      * @return {Phaser.Scenes.SceneManager} This Scene Manager.
      */
@@ -1038,12 +1038,12 @@ var SceneManager = new Class({
         if (scene.sys.isSleeping())
         {
             //  Sleeping?
-            scene.sys.wake();
+            scene.sys.wake(data);
         }
         else if (scene.sys.isBooted && !scene.sys.isActive())
         {
             //  Paused?
-            scene.sys.resume();
+            scene.sys.resume(data);
         }
         else
         {

--- a/src/scene/Systems.js
+++ b/src/scene/Systems.js
@@ -211,7 +211,7 @@ var Systems = new Class({
 
         /**
          * The Scene Update function.
-         * 
+         *
          * This starts out as NOOP during init, preload and create, and at the end of create
          * it swaps to be whatever the Scene.update function is.
          *
@@ -368,9 +368,11 @@ var Systems = new Class({
      * @method Phaser.Scenes.Systems#resume
      * @since 3.0.0
      *
+     * @param {object} [data] - A data object that will be passed on the 'resume' event.
+     *
      * @return {Phaser.Scenes.Systems} This Systems object.
      */
-    resume: function ()
+    resume: function (data)
     {
         if (!this.settings.active)
         {
@@ -378,7 +380,7 @@ var Systems = new Class({
 
             this.settings.active = true;
 
-            this.events.emit('resume', this);
+            this.events.emit('resume', this, data);
         }
 
         return this;
@@ -415,9 +417,11 @@ var Systems = new Class({
      * @method Phaser.Scenes.Systems#wake
      * @since 3.0.0
      *
+     * @param {object} [data] - A data object that will be passed on the 'wake' event.
+     *
      * @return {Phaser.Scenes.Systems} This Systems object.
      */
-    wake: function ()
+    wake: function (data)
     {
         var settings = this.settings;
 
@@ -426,7 +430,7 @@ var Systems = new Class({
         settings.active = true;
         settings.visible = true;
 
-        this.events.emit('wake', this);
+        this.events.emit('wake', this, data);
 
         if (settings.isTransition)
         {


### PR DESCRIPTION
This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

scene.run can now pass data to .wake and .resume if it needs to invoke those methods from .run. This gives the ability to listen i.e. `on.wake(ref, data)` 