### PR TITLE
Fixed DataManager changedata event emits original value instead of new value

### DIFF
--- a/src/data/DataManager.js
+++ b/src/data/DataManager.js
@@ -318,8 +318,8 @@ var DataManager = new Class({
                     {
                         list[key] = value;
 
-                        events.emit('changedata', parent, key, data);
-                        events.emit('changedata_' + key, parent, data);
+                        events.emit('changedata', parent, key, value);
+                        events.emit('changedata_' + key, parent, value);
                     }
                 }
 


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:

The DataManager `changedata` event currently emits the originally set value instead of the newly assigned one.

