### PR TITLE
Fix setter calls in BuildGameObjectAnimation

### DIFF
--- a/src/gameobjects/BuildGameObjectAnimation.js
+++ b/src/gameobjects/BuildGameObjectAnimation.js
@@ -58,10 +58,10 @@ var BuildGameObjectAnimation = function (sprite, config)
         var play = GetAdvancedValue(animConfig, 'play', false);
         var delayedPlay = GetAdvancedValue(animConfig, 'delayedPlay', 0);
 
-        anims.delay(delay);
-        anims.repeat(repeat);
-        anims.repeatDelay(repeatDelay);
-        anims.yoyo(yoyo);
+        anims.setDelay(delay);
+        anims.setRepeat(repeat);
+        anims.setRepeatDelay(repeatDelay);
+        anims.setYoyo(yoyo);
 
         if (play)
         {


### PR DESCRIPTION
This PR 

* Fixes a bug visible in [this example](http://labs.phaser.io/edit.html?src=src\animation\create%20from%20sprite%20config.js) - `Uncaught TypeError: anims.delay is not a function`

Describe the changes below:

added "set" verb to setter method calls on animation object instance.