### PR TITLE
Skip drag checking on a dragging Game Object

### DIFF
--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -803,7 +803,7 @@ var InputPlugin = new Class({
             {
                 gameObject = currentlyOver[i];
 
-                if (gameObject.input.draggable)
+                if (gameObject.input.draggable && (gameObject.input.dragState === 0))
                 {
                     draglist.push(gameObject);
                 }


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Skip drag checking on a dragging Game Object to prevent multi-drag issue( #3757  )

