### PR TITLE
Fix extra argument passing in Array.Each

### DIFF
--- a/src/utils/array/Each.js
+++ b/src/utils/array/Each.js
@@ -22,7 +22,7 @@ var Each = function (array, callback, context)
     var i;
     var args = [ null ];
 
-    for (i = 2; i < arguments.length; i++)
+    for (i = 3; i < arguments.length; i++)
     {
         args.push(arguments[i]);
     }

--- a/src/utils/array/Each.js
+++ b/src/utils/array/Each.js
@@ -13,7 +13,7 @@
  * @param {array} array - The array to search.
  * @param {function} callback - A callback to be invoked for each item in the array.
  * @param {object} context - The context in which the callback is invoked.
- * @param {...*} [args] - Additional arguments that will be passed to the callback, after the child.
+ * @param {...*} [args] - Additional arguments that will be passed to the callback, after the current array item.
  *
  * @return {array} The input array.
  */


### PR DESCRIPTION
This PR

* Fixes a bug

Array.Each started copying `arguments` at the wrong index and was passing the `context` argument to the callback.

