### PR TITLE
fixed JsDoc for Phaser.Tilemaps.Tilemap#createBlankDynamicLayer

### DIFF
--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -372,13 +372,15 @@ var Tilemap = new Class({
      *
      * @param {string} name - The name of this layer. Must be unique within the map.
      * @param {Phaser.Tilemaps.Tileset} tileset - The tileset the new layer will use.
-     * @param {integer} width - The width of the layer in tiles. If not specified, it will default
+     * @param {number} [x=0] - The world x position where the top left of this layer will be placed.
+     * @param {number} [y=0] - The world y position where the top left of this layer will be placed.
+     * @param {integer} [width] - The width of the layer in tiles. If not specified, it will default
      * to the map's width.
-     * @param {integer} height - The height of the layer in tiles. If not specified, it will default
+     * @param {integer} [height] - The height of the layer in tiles. If not specified, it will default
      * to the map's height.
-     * @param {integer} tileWidth - The width of the tiles the layer uses for calculations. If not
+     * @param {integer} [tileWidth] - The width of the tiles the layer uses for calculations. If not
      * specified, it will default to the map's tileWidth.
-     * @param {integer} tileHeight - The height of the tiles the layer uses for calculations. If not
+     * @param {integer} [tileHeight] - The height of the tiles the layer uses for calculations. If not
      * specified, it will default to the map's tileHeight.
      * @return {?Phaser.Tilemaps.DynamicTilemapLayer} Returns the new layer was created, or null if it failed.
      */


### PR DESCRIPTION
This PR:
* Updates the Documentation

Describe the changes below:
this fixes JsDoc for Phaser.Tilemaps.Tilemap#createBlankDynamicLayer 
x, y, width, height, tileWidth, tileHeight are all optional params

I also added x, y params to jsdoc as they were missing

