### PR TITLE
Fixed dataManager redefining previously (re)set property

### DIFF
--- a/src/data/DataManager.js
+++ b/src/data/DataManager.js
@@ -306,6 +306,8 @@ var DataManager = new Class({
             Object.defineProperty(this.values, key, {
 
                 enumerable: true,
+                
+                configurable: true,
 
                 get: function ()
                 {


### PR DESCRIPTION
This PR 
* Fixes a bug

Describe the changes below:
Added Configurable:true to Object.defineProperty in dataManager to fix #3803
