### PR TITLE
fix minor typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ You can then run `webpack` to create a development build in the `build` folder w
 * `dropZone` - If `true` the Interactive Object will be set to be a drop zone for draggable objects.
 * `useHandCursor` - If `true` the Interactive Object will set the `pointer` hand cursor when a pointer is over it. This is a short-cut for setting `cursor: 'pointer'`.
 * `cursor` - The CSS string to be used when the cursor is over this Interactive Object.
-* `pixelPerfect` - If `true` the a pixel perfect function will be set for the hit area callback. Only works with texture based Game Objects.
+* `pixelPerfect` - If `true` the pixel perfect function will be set for the hit area callback. Only works with texture based Game Objects.
 * `alphaTolerance` - If `pixelPerfect` is set, this is the alpha tolerance threshold value used in the callback.
 
 ### Input - Keyboard Manager Updates


### PR DESCRIPTION
* Updates the Documentation


Describe the changes below:
changed one typo from "the a" to "the" in readme.  Pointing out the minor typo
