### PR TITLE
Fix Tiled obj property transfer onto spriteConfig

### DIFF
--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -543,7 +543,13 @@ var Tilemap = new Class({
 
             if (found)
             {
-                var config = Extend({}, spriteConfig, obj.properties);
+                var props = {}
+                for (var j=0; j < obj.properties.length; j++)
+                {
+                    props[obj.properties[j].name] = obj.properties[j].value
+                }
+
+                var config = Extend({}, spriteConfig, props);
 
                 config.x = obj.x;
                 config.y = obj.y;

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -543,10 +543,10 @@ var Tilemap = new Class({
 
             if (found)
             {
-                var props = {}
-                for (var j=0; j < obj.properties.length; j++)
+                var props = {};
+                for (var j = 0; j < obj.properties.length; j++)
                 {
-                    props[obj.properties[j].name] = obj.properties[j].value
+                    props[obj.properties[j].name] = obj.properties[j].value;
                 }
 
                 var config = Extend({}, spriteConfig, props);


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:

_Observed:_ 

Tiled properties are an array of objects (e.g. properties":[{"name":"ObjId","type":"int","value":335},{"name":"frame","type":"int","value":1256}]}) rather than a simple JSON object that the code currently assumed.

Because the function extends spriteConfig with the tiled object.properties object, spriteConfig gains a bunch of index properties ([0],[1],[2],) based on the array rather than the expected object keys and values. This prevents setting for .example frame for the spriteConfig from Tiled directly.

_Fix:_
Transfer tiled object properties onto spriteConfig correctly using the name and value properties on the object

