### PR TITLE
Adding console warning to notify users of invalid frame config

### DIFF
--- a/src/textures/parsers/SpriteSheet.js
+++ b/src/textures/parsers/SpriteSheet.js
@@ -58,9 +58,9 @@ var SpriteSheet = function (texture, sourceIndex, x, y, width, height, config)
     var column = Math.floor((height - margin + spacing) / (frameHeight + spacing));
     var total = row * column;
 
-    if(total === 0)
+    if (total === 0)
     {
-        console.warn('TextureManager.SpriteSheet: Frame config produces zero frames. Check frameWidth and frameHeight.');
+        console.warn('SpriteSheet frame dimensions will result in zero frames.');
     }
 
     if (startFrame > total || startFrame < -total)

--- a/src/textures/parsers/SpriteSheet.js
+++ b/src/textures/parsers/SpriteSheet.js
@@ -58,6 +58,11 @@ var SpriteSheet = function (texture, sourceIndex, x, y, width, height, config)
     var column = Math.floor((height - margin + spacing) / (frameHeight + spacing));
     var total = row * column;
 
+    if(total === 0)
+    {
+        console.warn('TextureManager.SpriteSheet: Frame config produces zero frames. Check frameWidth and frameHeight.');
+    }
+
     if (startFrame > total || startFrame < -total)
     {
         startFrame = 0;


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:
It doesn't exactly fix a bug, but hopefully helps users discover their bugs. I have several times now set a frame height that was taller than my horizontal spritesheet. This results in zero frames and when you try to use the animation you get a console error that's pretty tough to track down:
![image](https://user-images.githubusercontent.com/8712960/42418908-3ab74d68-825f-11e8-8afd-4403fb888af9.png)

I added a console warning to notify users of this, in the hopes that they will waste less time than I have tracking down why their animation won't play. I also considered forcing the row or column to 1 when they're at zero so that users would see their animation and realize the settings were off, but I wasn't sure if there might be some valid use case to having zero frames, and didn't want to break anything. 
