### PR TITLE
Update AudioFile.js

### DIFF
--- a/src/loader/filetypes/AudioFile.js
+++ b/src/loader/filetypes/AudioFile.js
@@ -97,7 +97,7 @@ var AudioFile = new Class({
             function (e)
             {
                 // eslint-disable-next-line no-console
-                console.error('Error decoding audio: ' + this.key + ' - ', e.message);
+                console.error('Error decoding audio: ' + this.key + ' - ', e ? e.message : null);
 
                 _this.onProcessError();
             }


### PR DESCRIPTION
This PR Fixes a bug.

Describe the changes below:

When variable `e` is undefined or null then whole game won't start. In my case some bigger mp3 file on safari cannot load (which is another issue) and javascript breaks because of that. This is a small change which at least allows the error to be shown and the game to be started anyway.