### PR TITLE
Major Optimization for Culling Tilemaps

### DIFF
--- a/src/tilemaps/components/CullTiles.js
+++ b/src/tilemaps/components/CullTiles.js
@@ -27,10 +27,10 @@ var CullTiles = function (layer, camera, outputArray)
 
     outputArray.length = 0;
     
-	var y = 0;
-	var x = 0;
-	var tile = null;
-	
+    var y = 0;
+    var x = 0;
+    var tile = null;
+    
     var tilemapLayer = layer.tilemapLayer;
 
     var tileW = Math.floor(layer.tileWidth * tilemapLayer.scaleX);

--- a/src/tilemaps/components/CullTiles.js
+++ b/src/tilemaps/components/CullTiles.js
@@ -42,49 +42,49 @@ var CullTiles = function (layer, camera, outputArray)
     var boundsRight = SnapCeil(camera.worldView.right, tileW) + (tilemapLayer.cullPaddingX * tileW);
     var boundsTop = SnapFloor(camera.worldView.y, tileH) - (tilemapLayer.cullPaddingY * tileH);
     var boundsBottom = SnapCeil(camera.worldView.bottom, tileH) + (tilemapLayer.cullPaddingY * tileH);
-	
-	// If skipping cull, loop through every tile in the map.
-	
-	if(tilemapLayer.skipCull)
-	{
-		for (var y = 0; y < mapHeight; y++)
-		{
-			for (var x = 0; x < mapWidth; x++)
-			{
-				var tile = mapData[y][x];
+    
+    // If skipping cull, loop through every tile in the map.
+    
+    if(tilemapLayer.skipCull)
+    {
+        for (var y = 0; y < mapHeight; y++)
+        {
+            for (var x = 0; x < mapWidth; x++)
+            {
+                var tile = mapData[y][x];
 
-				if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
-				{
-					continue;
-				}
+                if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
+                {
+                    continue;
+                }
 
-				outputArray.push(tile);
-			}
-		}
-	}
-	else
-	{
-		var drawLeft = Math.max(0, boundsLeft / layer.tileWidth);
-		var drawRight = Math.min(mapWidth, boundsRight / layer.tileWidth);
-		var drawTop = Math.max(0, boundsTop / layer.tileHeight);
-		var drawBottom = Math.min(mapHeight, boundsBottom / layer.tileHeight);
-		
-		for (var y = drawTop; y < drawBottom; y++)
-		{
-			for (var x = drawLeft; x < drawRight; x++)
-			{
-				var tile = mapData[y][x];
+                outputArray.push(tile);
+            }
+        }
+    }
+    else
+    {
+        var drawLeft = Math.max(0, boundsLeft / layer.tileWidth);
+        var drawRight = Math.min(mapWidth, boundsRight / layer.tileWidth);
+        var drawTop = Math.max(0, boundsTop / layer.tileHeight);
+        var drawBottom = Math.min(mapHeight, boundsBottom / layer.tileHeight);
+        
+        for (var y = drawTop; y < drawBottom; y++)
+        {
+            for (var x = drawLeft; x < drawRight; x++)
+            {
+                var tile = mapData[y][x];
 
-				if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
-				{
-					continue;
-				}
+                if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
+                {
+                    continue;
+                }
 
-				outputArray.push(tile);
-			}
-		}
-	}
-	
+                outputArray.push(tile);
+            }
+        }
+    }
+    
     tilemapLayer.tilesDrawn = outputArray.length;
     tilemapLayer.tilesTotal = mapWidth * mapHeight;
 

--- a/src/tilemaps/components/CullTiles.js
+++ b/src/tilemaps/components/CullTiles.js
@@ -26,19 +26,19 @@ var CullTiles = function (layer, camera, outputArray)
     if (outputArray === undefined) { outputArray = []; }
 
     outputArray.length = 0;
-    
+
     var y = 0;
     var x = 0;
     var tile = null;
-    
-    var tilemapLayer = layer.tilemapLayer;
 
-    var tileW = Math.floor(layer.tileWidth * tilemapLayer.scaleX);
-    var tileH = Math.floor(layer.tileHeight * tilemapLayer.scaleY);
+    var tilemapLayer = layer.tilemapLayer;
 
     var mapData = layer.data;
     var mapWidth = layer.width;
     var mapHeight = layer.height;
+
+    var tileW = Math.floor(layer.tileWidth * tilemapLayer.scaleX);
+    var tileH = Math.floor(layer.tileHeight * tilemapLayer.scaleY);
 
     //  Camera world view bounds, snapped for tile size
 
@@ -46,46 +46,25 @@ var CullTiles = function (layer, camera, outputArray)
     var boundsRight = SnapCeil(camera.worldView.right, tileW) + (tilemapLayer.cullPaddingX * tileW);
     var boundsTop = SnapFloor(camera.worldView.y, tileH) - (tilemapLayer.cullPaddingY * tileH);
     var boundsBottom = SnapCeil(camera.worldView.bottom, tileH) + (tilemapLayer.cullPaddingY * tileH);
+
+    var skipCull = tilemapLayer.skipCull;
+    var drawLeft = skipCull ? 0 : Math.max(0, boundsLeft / layer.tileWidth);
+    var drawRight = skipCull ? mapWidth : Math.min(mapWidth, boundsRight / layer.tileWidth);
+    var drawTop = skipCull ? 0 : Math.max(0, boundsTop / layer.tileHeight);
+    var drawBottom = skipCull ? mapHeight : Math.min(mapHeight, boundsBottom / layer.tileHeight);
     
-    // If skipping cull, loop through every tile in the map.
-    
-    if(tilemapLayer.skipCull)
+    for (y = drawTop; y < drawBottom; y++)
     {
-        for (y = 0; y < mapHeight; y++)
+        for (x = drawLeft; x < drawRight; x++)
         {
-            for (x = 0; x < mapWidth; x++)
+            tile = mapData[y][x];
+
+            if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
             {
-                tile = mapData[y][x];
-
-                if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
-                {
-                    continue;
-                }
-
-                outputArray.push(tile);
+                continue;
             }
-        }
-    }
-    else
-    {
-        var drawLeft = Math.max(0, boundsLeft / layer.tileWidth);
-        var drawRight = Math.min(mapWidth, boundsRight / layer.tileWidth);
-        var drawTop = Math.max(0, boundsTop / layer.tileHeight);
-        var drawBottom = Math.min(mapHeight, boundsBottom / layer.tileHeight);
-        
-        for (y = drawTop; y < drawBottom; y++)
-        {
-            for (x = drawLeft; x < drawRight; x++)
-            {
-                tile = mapData[y][x];
 
-                if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
-                {
-                    continue;
-                }
-
-                outputArray.push(tile);
-            }
+            outputArray.push(tile);
         }
     }
     

--- a/src/tilemaps/components/CullTiles.js
+++ b/src/tilemaps/components/CullTiles.js
@@ -27,6 +27,10 @@ var CullTiles = function (layer, camera, outputArray)
 
     outputArray.length = 0;
     
+	var y = 0;
+	var x = 0;
+	var tile = null;
+	
     var tilemapLayer = layer.tilemapLayer;
 
     var tileW = Math.floor(layer.tileWidth * tilemapLayer.scaleX);
@@ -47,11 +51,11 @@ var CullTiles = function (layer, camera, outputArray)
     
     if(tilemapLayer.skipCull)
     {
-        for (var y = 0; y < mapHeight; y++)
+        for (y = 0; y < mapHeight; y++)
         {
-            for (var x = 0; x < mapWidth; x++)
+            for (x = 0; x < mapWidth; x++)
             {
-                var tile = mapData[y][x];
+                tile = mapData[y][x];
 
                 if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
                 {
@@ -69,11 +73,11 @@ var CullTiles = function (layer, camera, outputArray)
         var drawTop = Math.max(0, boundsTop / layer.tileHeight);
         var drawBottom = Math.min(mapHeight, boundsBottom / layer.tileHeight);
         
-        for (var y = drawTop; y < drawBottom; y++)
+        for (y = drawTop; y < drawBottom; y++)
         {
-            for (var x = drawLeft; x < drawRight; x++)
+            for (x = drawLeft; x < drawRight; x++)
             {
-                var tile = mapData[y][x];
+                tile = mapData[y][x];
 
                 if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
                 {

--- a/src/tilemaps/components/CullTiles.js
+++ b/src/tilemaps/components/CullTiles.js
@@ -28,7 +28,6 @@ var CullTiles = function (layer, camera, outputArray)
     outputArray.length = 0;
     
     var tilemapLayer = layer.tilemapLayer;
-    var skipCull = tilemapLayer.skipCull;
 
     var tileW = Math.floor(layer.tileWidth * tilemapLayer.scaleX);
     var tileH = Math.floor(layer.tileHeight * tilemapLayer.scaleY);
@@ -43,28 +42,49 @@ var CullTiles = function (layer, camera, outputArray)
     var boundsRight = SnapCeil(camera.worldView.right, tileW) + (tilemapLayer.cullPaddingX * tileW);
     var boundsTop = SnapFloor(camera.worldView.y, tileH) - (tilemapLayer.cullPaddingY * tileH);
     var boundsBottom = SnapCeil(camera.worldView.bottom, tileH) + (tilemapLayer.cullPaddingY * tileH);
+	
+	// If skipping cull, loop through every tile in the map.
+	
+	if(tilemapLayer.skipCull)
+	{
+		for (var y = 0; y < mapHeight; y++)
+		{
+			for (var x = 0; x < mapWidth; x++)
+			{
+				var tile = mapData[y][x];
 
-    for (var y = 0; y < mapHeight; y++)
-    {
-        for (var x = 0; x < mapWidth; x++)
-        {
-            var tile = mapData[y][x];
+				if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
+				{
+					continue;
+				}
 
-            if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
-            {
-                continue;
-            }
+				outputArray.push(tile);
+			}
+		}
+	}
+	else
+	{
+		var drawLeft = Math.max(0, boundsLeft / layer.tileWidth);
+		var drawRight = Math.min(mapWidth, boundsRight / layer.tileWidth);
+		var drawTop = Math.max(0, boundsTop / layer.tileHeight);
+		var drawBottom = Math.min(mapHeight, boundsBottom / layer.tileHeight);
+		
+		for (var y = drawTop; y < drawBottom; y++)
+		{
+			for (var x = drawLeft; x < drawRight; x++)
+			{
+				var tile = mapData[y][x];
 
-            var tilePixelX = (tile.pixelX + tilemapLayer.x) * tilemapLayer.scaleX;
-            var tilePixelY = (tile.pixelY + tilemapLayer.y) * tilemapLayer.scaleY;
+				if (!tile || tile.index === -1 || !tile.visible || tile.alpha === 0)
+				{
+					continue;
+				}
 
-            if (skipCull || (tilePixelX >= boundsLeft && tilePixelX + tileW <= boundsRight && tilePixelY >= boundsTop && tilePixelY + tileH <= boundsBottom))
-            {
-                outputArray.push(tile);
-            }
-        }
-    }
-
+				outputArray.push(tile);
+			}
+		}
+	}
+	
     tilemapLayer.tilesDrawn = outputArray.length;
     tilemapLayer.tilesTotal = mapWidth * mapHeight;
 


### PR DESCRIPTION
This PR

* Optimizes an existing feature.

Describe the changes below:

Refine the loop to only scan through the drawn boundaries that are being tested against (except when skipping cull). This eliminates a huge bottleneck / lookup time from the original loop each frame.

The update should affect tilemaps exponentially based on their size (and # of layers). It reduced my culling time to 1/70th for 1000x1000 tilemaps, and by about 1/20th on 250x250 tilemaps. It also reduced my requestAnimationFrame time from over 16ms per frame to ~1ms for the larger map.
