### PR TITLE
updated typedef comments

### DIFF
--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -238,7 +238,7 @@ var AnimationManager = new Class({
      * @property {string} [suffix=''] - [description]
      * @property {integer} [zeroPad=0] - [description]
      * @property {AnimationFrameConfig[]} [outputArray=[]] - [description]
-     * @property {boolean} [frames=false] - [description]
+     * @property {boolean|number[]} [frames=false] - [description]
      */
 
     /**
@@ -323,7 +323,7 @@ var AnimationManager = new Class({
      * @property {integer} [end=-1] - [description]
      * @property {boolean} [first=false] - [description]
      * @property {AnimationFrameConfig[]} [outputArray=[]] - [description]
-     * @property {boolean} [frames=false] - [description]
+     * @property {boolean|number[]} [frames=false] - [description]
      */
 
     /**

--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -238,7 +238,7 @@ var AnimationManager = new Class({
      * @property {string} [suffix=''] - [description]
      * @property {integer} [zeroPad=0] - [description]
      * @property {AnimationFrameConfig[]} [outputArray=[]] - [description]
-     * @property {boolean|number[]} [frames=false] - [description]
+     * @property {boolean|integer[]} [frames=false] - [description]
      */
 
     /**
@@ -323,7 +323,7 @@ var AnimationManager = new Class({
      * @property {integer} [end=-1] - [description]
      * @property {boolean} [first=false] - [description]
      * @property {AnimationFrameConfig[]} [outputArray=[]] - [description]
-     * @property {boolean|number[]} [frames=false] - [description]
+     * @property {boolean|integer[]} [frames=false] - [description]
      */
 
     /**


### PR DESCRIPTION
GenerateFrameNumbersConfig & GenerateFrameNamesConfig take a number[]. Unsure why it takes a boolean.

e.g : ` frames: this.anims.generateFrameNumbers('boom', { frames: [ 0, 1, 2, 1, 2, 3, 4, 0, 1, 2 ] }),`