### PR TITLE
Added reverse animation feature (issue: #3837)

### DIFF
--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -538,7 +538,7 @@ var Animation = new Class({
 
         var frame = this.frames[startFrame];
 
-        if(startFrame === 0 && !component.forward)
+        if (startFrame === 0 && !component.forward)
         {
             frame = this.getLastFrame();
         }

--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -591,7 +591,7 @@ var Animation = new Class({
             {
                 //  Repeat (happens before complete)
 
-                if(component._reverse && component.forward)
+                if (component._reverse && component.forward)
                 {
                     component.forward = false;
                 }
@@ -615,6 +615,7 @@ var Animation = new Class({
      * Returns the animation last frame.
      *
      * @method Phaser.Animations.Animation#getLastFrame
+     * @since 3.12.0
      *
      * @return {Phaser.Animations.AnimationFrame} component - The Animation Last Frame.
      */
@@ -648,7 +649,7 @@ var Animation = new Class({
             }
             else if (component.repeatCounter > 0)
             {
-                if(component._reverse && !component.forward)
+                if (component._reverse && !component.forward)
                 {
                     component.currentFrame = this.getLastFrame();
                     this._updateAndGetNextTick(component, component.currentFrame);
@@ -675,6 +676,7 @@ var Animation = new Class({
      * Update Frame and Wait next tick
      *
      * @method Phaser.Animations.Animation#_updateAndGetNextTick
+     * @since 3.12.0
      *
      * @param {Phaser.Animations.AnimationFrame} frame - An Animation frame
      *

--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -536,7 +536,14 @@ var Animation = new Class({
             component._yoyo = this.yoyo;
         }
 
-        component.updateFrame(this.frames[startFrame]);
+        var frame = this.frames[startFrame];
+
+        if(startFrame === 0 && !component.forward)
+        {
+            frame = this.getLastFrame();
+        }
+
+        component.updateFrame(frame);
     },
 
     /**
@@ -603,6 +610,18 @@ var Animation = new Class({
     },
 
     /**
+     * Returns the animation last frame.
+     *
+     * @method Phaser.Animations.Animation#getLastFrame
+     *
+     * @return {Phaser.Animations.AnimationFrame} component - The Animation Last Frame.
+     */
+    getLastFrame: function ()
+    {
+        return this.frames[this.frames.length - 1];
+    },
+
+    /**
      * [description]
      *
      * @method Phaser.Animations.Animation#previousFrame
@@ -622,8 +641,18 @@ var Animation = new Class({
 
             if (component.repeatCounter > 0)
             {
-                //  Repeat (happens before complete)
-                this.repeatAnimation(component);
+                if(!component.forward)
+                {
+                    component.currentFrame = this.getLastFrame();
+
+                    component.updateFrame(component.currentFrame);
+                    this.getNextTick(component);
+                }
+                else
+                {
+                    //  Repeat (happens before complete)
+                    this.repeatAnimation(component);
+                }
             }
             else
             {
@@ -705,9 +734,7 @@ var Animation = new Class({
         {
             component.repeatCounter--;
 
-            component.forward = true;
-
-            component.updateFrame(component.currentFrame.nextFrame);
+            component.updateFrame(component.currentFrame[(component.forward) ? 'nextFrame' : 'prevFrame']);
 
             if (component.isPlaying)
             {

--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -585,16 +585,20 @@ var Animation = new Class({
             if (component._yoyo)
             {
                 component.forward = false;
-
-                component.updateFrame(frame.prevFrame);
-
-                //  Delay for the current frame
-                this.getNextTick(component);
+                this._updateAndGetNextTick(component, frame.prevFrame);
             }
             else if (component.repeatCounter > 0)
             {
                 //  Repeat (happens before complete)
-                this.repeatAnimation(component);
+
+                if(component._reverse && component.forward)
+                {
+                    component.forward = false;
+                }
+                else
+                {
+                    this.repeatAnimation(component);
+                }
             }
             else
             {
@@ -603,9 +607,7 @@ var Animation = new Class({
         }
         else
         {
-            component.updateFrame(frame.nextFrame);
-
-            this.getNextTick(component);
+            this._updateAndGetNextTick(component, frame.nextFrame);
         }
     },
 
@@ -639,18 +641,22 @@ var Animation = new Class({
         {
             //  We're at the start of the animation
 
-            if (component.repeatCounter > 0)
+            if (component._yoyo)
             {
-                if(!component.forward)
+                component.forward = true;
+                this._updateAndGetNextTick(component, frame.nextFrame);
+            }
+            else if (component.repeatCounter > 0)
+            {
+                if(component._reverse && !component.forward)
                 {
                     component.currentFrame = this.getLastFrame();
-
-                    component.updateFrame(component.currentFrame);
-                    this.getNextTick(component);
+                    this._updateAndGetNextTick(component, component.currentFrame);
                 }
                 else
                 {
                     //  Repeat (happens before complete)
+                    component.forward = true;
                     this.repeatAnimation(component);
                 }
             }
@@ -661,10 +667,22 @@ var Animation = new Class({
         }
         else
         {
-            component.updateFrame(frame.prevFrame);
-
-            this.getNextTick(component);
+            this._updateAndGetNextTick(component, frame.prevFrame);
         }
+    },
+
+    /**
+     * Update Frame and Wait next tick
+     *
+     * @method Phaser.Animations.Animation#_updateAndGetNextTick
+     *
+     * @param {Phaser.Animations.AnimationFrame} frame - An Animation frame
+     *
+     */
+    _updateAndGetNextTick: function (component, frame)
+    {
+        component.updateFrame(frame);
+        this.getNextTick(component);
     },
 
     /**

--- a/src/gameobjects/components/Animation.js
+++ b/src/gameobjects/components/Animation.js
@@ -208,7 +208,7 @@ var Animation = new Class({
         this._yoyo = false;
 
         /**
-         * Will the playhead move forwards (`true`) or in reverse (`false`)
+         * Will the playhead move forwards (`true`) or in reverse (`false`).
          *
          * @name Phaser.GameObjects.Components.Animation#forward
          * @type {boolean}
@@ -216,6 +216,16 @@ var Animation = new Class({
          * @since 3.0.0
          */
         this.forward = true;
+
+        /**
+         * An Internal trigger that's play the animation in reverse mode ('true') or not ('false'),
+         * needed because forward can be changed by yoyo feature.
+         *
+         * @name Phaser.GameObjects.Components.Animation#forward
+         * @type {boolean}
+         * @default false
+         */
+        this._reverse = false;
 
         /**
          * Internal time overflow accumulator.
@@ -497,6 +507,7 @@ var Animation = new Class({
         }
 
         this.forward = true;
+        this._reverse = false;
         return this._startAnimation(key, startFrame);
     },
 
@@ -523,6 +534,7 @@ var Animation = new Class({
         }
 
         this.forward = false;
+        this._reverse = true;
         return this._startAnimation(key, startFrame);
     },
 
@@ -575,6 +587,7 @@ var Animation = new Class({
     revert: function (key)
     {
         if (!this.isPlaying || this.currentAnim.key !== key) { return this.parent; }
+        this._reverse = !this._reverse;
         this.forward = !this.forward;
 
         return this.parent;

--- a/src/gameobjects/components/Animation.js
+++ b/src/gameobjects/components/Animation.js
@@ -496,6 +496,50 @@ var Animation = new Class({
             return this.parent;
         }
 
+        this.forward = true;
+        return this._startAnimation(key, startFrame);
+    },
+
+    /**
+     * Plays an Animation (in reverse mode) on the Game Object that owns this Animation Component.
+     *
+     * @method Phaser.GameObjects.Components.Animation#playReverse
+     * @fires Phaser.GameObjects.Components.Animation#onStartEvent
+     *
+     * @param {string} key - The string-based key of the animation to play, as defined previously in the Animation Manager.
+     * @param {boolean} [ignoreIfPlaying=false] - If an animation is already playing then ignore this call.
+     * @param {integer} [startFrame=0] - Optionally start the animation playing from this frame index.
+     *
+     * @return {Phaser.GameObjects.GameObject} The Game Object that owns this Animation Component.
+     */
+    playReverse: function (key, ignoreIfPlaying, startFrame)
+    {
+        if (ignoreIfPlaying === undefined) { ignoreIfPlaying = false; }
+        if (startFrame === undefined) { startFrame = 0; }
+
+        if (ignoreIfPlaying && this.isPlaying && this.currentAnim.key === key)
+        {
+            return this.parent;
+        }
+
+        this.forward = false;
+        return this._startAnimation(key, startFrame);
+    },
+
+    /**
+     * Load an Animation and fires 'onStartEvent' event,
+     * extracted from 'play' method
+     *
+     * @method Phaser.GameObjects.Components.Animation#_startAnimation
+     * @fires Phaser.GameObjects.Components.Animation#onStartEvent
+     *
+     * @param {string} key - The string-based key of the animation to play, as defined previously in the Animation Manager.
+     * @param {integer} [startFrame=0] - Optionally start the animation playing from this frame index.
+     *
+     * @return {Phaser.GameObjects.GameObject} The Game Object that owns this Animation Component.
+     */
+    _startAnimation: function (key, startFrame)
+    {
         this.load(key, startFrame);
 
         var anim = this.currentAnim;
@@ -505,8 +549,7 @@ var Animation = new Class({
         this.repeatCounter = (this._repeat === -1) ? Number.MAX_VALUE : this._repeat;
 
         anim.getFirstTick(this);
-
-        this.forward = true;
+        
         this.isPlaying = true;
         this.pendingRepeat = false;
 

--- a/src/gameobjects/components/Animation.js
+++ b/src/gameobjects/components/Animation.js
@@ -521,6 +521,23 @@ var Animation = new Class({
     },
 
     /**
+     * Revert an Animation that is already playing on the Game Object.
+     *
+     * @method Phaser.GameObjects.Components.Animation#revert
+     *
+     * @param {string} key - The string-based key of the animation to play, as defined previously in the Animation Manager.
+     *
+     * @return {Phaser.GameObjects.GameObject} The Game Object that owns this Animation Component.
+     */
+    revert: function (key)
+    {
+        if (!this.isPlaying || this.currentAnim.key !== key) { return this.parent; }
+        this.forward = !this.forward;
+
+        return this.parent;
+    },
+
+    /**
      * Returns a value between 0 and 1 indicating how far this animation is through, ignoring repeats and yoyos.
      * If the animation has a non-zero repeat defined, `getProgress` and `getTotalProgress` will be different
      * because `getProgress` doesn't include any repeats or repeat delays, whereas `getTotalProgress` does.

--- a/src/gameobjects/components/Animation.js
+++ b/src/gameobjects/components/Animation.js
@@ -224,6 +224,7 @@ var Animation = new Class({
          * @name Phaser.GameObjects.Components.Animation#forward
          * @type {boolean}
          * @default false
+         * @since 3.12.0
          */
         this._reverse = false;
 
@@ -516,6 +517,7 @@ var Animation = new Class({
      *
      * @method Phaser.GameObjects.Components.Animation#playReverse
      * @fires Phaser.GameObjects.Components.Animation#onStartEvent
+     * @since 3.12.0
      *
      * @param {string} key - The string-based key of the animation to play, as defined previously in the Animation Manager.
      * @param {boolean} [ignoreIfPlaying=false] - If an animation is already playing then ignore this call.
@@ -544,6 +546,7 @@ var Animation = new Class({
      *
      * @method Phaser.GameObjects.Components.Animation#_startAnimation
      * @fires Phaser.GameObjects.Components.Animation#onStartEvent
+     * @since 3.12.0
      *
      * @param {string} key - The string-based key of the animation to play, as defined previously in the Animation Manager.
      * @param {integer} [startFrame=0] - Optionally start the animation playing from this frame index.
@@ -561,7 +564,7 @@ var Animation = new Class({
         this.repeatCounter = (this._repeat === -1) ? Number.MAX_VALUE : this._repeat;
 
         anim.getFirstTick(this);
-        
+
         this.isPlaying = true;
         this.pendingRepeat = false;
 
@@ -576,15 +579,16 @@ var Animation = new Class({
     },
 
     /**
-     * Revert an Animation that is already playing on the Game Object.
+     * Reverse an Animation that is already playing on the Game Object.
      *
-     * @method Phaser.GameObjects.Components.Animation#revert
+     * @method Phaser.GameObjects.Components.Animation#reverse
+     * @since 3.12.0
      *
      * @param {string} key - The string-based key of the animation to play, as defined previously in the Animation Manager.
      *
      * @return {Phaser.GameObjects.GameObject} The Game Object that owns this Animation Component.
      */
-    revert: function (key)
+    reverse: function (key)
     {
         if (!this.isPlaying || this.currentAnim.key !== key) { return this.parent; }
         this._reverse = !this._reverse;


### PR DESCRIPTION
Added the 'revert' method, that reverts the execution of a animation at any time.
Added 'playReverse' method that runs the animation in reverse mode.

Extracted 'play' method to '_startAnimation' to reuse in 'playReverse'.
Created '_updateAndGetNextTick' method that remove redundance of code.

To test this feature use the pull request [#206](https://github.com/photonstorm/phaser3-examples/pull/206) (phaser3-example).
(Issue #3837 )

