### PR TITLE
Pass `data` value to global plugins

### DIFF
--- a/src/boot/Config.js
+++ b/src/boot/Config.js
@@ -502,7 +502,7 @@ var Config = new Class({
          *
          * plugins: {
          *    global: [
-         *        { key: 'TestPlugin', plugin: TestPlugin, start: true },
+         *        { key: 'TestPlugin', plugin: TestPlugin, start: true, data: { msg: 'The plugin is alive' } },
          *    ],
          *    scene: [
          *        { key: 'WireFramePlugin', plugin: WireFramePlugin, systemKey: 'wireFramePlugin', sceneKey: 'wireframe' }

--- a/src/plugins/BasePlugin.js
+++ b/src/plugins/BasePlugin.js
@@ -80,6 +80,8 @@ var BasePlugin = new Class({
      *
      * @method Phaser.Plugins.BasePlugin#init
      * @since 3.8.0
+     *
+     * @param {?any} [data] - A value specified by the user, if any, from the `data` property of the plugin's configuration object (if started at game boot) or passed in the PluginManager's `install` method (if started manually).
      */
     init: function ()
     {

--- a/src/plugins/PluginCache.js
+++ b/src/plugins/PluginCache.js
@@ -61,10 +61,11 @@ PluginCache.register = function (key, plugin, mapping, custom)
  * @param {string} key - A reference used to get this plugin from the plugin cache.
  * @param {function} plugin - The plugin to be stored. Should be the core object, not instantiated.
  * @param {string} mapping - If this plugin is to be injected into the Scene Systems, this is the property key map used.
+ * @param {?any} data - A value to be passed to the plugin's `init` method.
  */
-PluginCache.registerCustom = function (key, plugin, mapping)
+PluginCache.registerCustom = function (key, plugin, mapping, data)
 {
-    customPlugins[key] = { plugin: plugin, mapping: mapping };
+    customPlugins[key] = { plugin: plugin, mapping: mapping, data: data };
 };
 
 /**

--- a/src/plugins/PluginManager.js
+++ b/src/plugins/PluginManager.js
@@ -146,6 +146,7 @@ var PluginManager = new Class({
         var plugin;
         var start;
         var mapping;
+        var data;
         var config = this.game.config;
 
         //  Any plugins to install?
@@ -158,16 +159,17 @@ var PluginManager = new Class({
         {
             entry = list[i];
 
-            // { key: 'TestPlugin', plugin: TestPlugin, start: true, mapping: 'test' }
+            // { key: 'TestPlugin', plugin: TestPlugin, start: true, mapping: 'test', data: { msg: 'The plugin is alive' } }
 
             key = GetFastValue(entry, 'key', null);
             plugin = GetFastValue(entry, 'plugin', null);
             start = GetFastValue(entry, 'start', false);
             mapping = GetFastValue(entry, 'mapping', null);
+            data = GetFastValue(entry, 'data', null);
 
             if (key && plugin)
             {
-                this.install(key, plugin, start, mapping);
+                this.install(key, plugin, start, mapping, data);
             }
         }
 
@@ -399,11 +401,13 @@ var PluginManager = new Class({
      * @param {function} plugin - The plugin code. This should be the non-instantiated version.
      * @param {boolean} [start=false] - Automatically start the plugin running? This is always `true` if you provide a mapping value.
      * @param {string} [mapping] - If this plugin is injected into the Phaser.Scene class, this is the property key to use.
+     * @param {any} [data] - A value passed to the plugin's `init` method.
      */
-    install: function (key, plugin, start, mapping)
+    install: function (key, plugin, start, mapping, data)
     {
         if (start === undefined) { start = false; }
         if (mapping === undefined) { mapping = null; }
+        if (data === undefined) { data = null; }
 
         if (typeof plugin !== 'function')
         {
@@ -424,12 +428,12 @@ var PluginManager = new Class({
 
         if (!this.game.isBooted)
         {
-            this._pendingGlobal.push({ key: key, plugin: plugin, start: start, mapping: mapping });
+            this._pendingGlobal.push({ key: key, plugin: plugin, start: start, mapping: mapping, data: data });
         }
         else
         {
             //  Add it to the plugin store
-            PluginCache.registerCustom(key, plugin, mapping);
+            PluginCache.registerCustom(key, plugin, mapping, data);
 
             if (start)
             {
@@ -568,12 +572,13 @@ var PluginManager = new Class({
                 key: runAs,
                 plugin: instance,
                 active: true,
-                mapping: entry.mapping
+                mapping: entry.mapping,
+                data: entry.data
             };
 
             this.plugins.push(entry);
 
-            instance.init();
+            instance.init(entry.data);
             instance.start();
         }
 


### PR DESCRIPTION
This PR

* Adds a new feature

When starting a global plugin when the game is created, use the `data` property of the entry in the plugins array.

When starting a global plugin manually, use the new argument to `plugins.install()`.

The plugin receives the data in its `init` method.
