### PR TITLE
Empty params reset to current texture size

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1089,8 +1089,8 @@ var Body = new Class({
 
         var gameObject = this.gameObject;
 
-        if(width === undefined) { width = gameObject.frame.data.sourceSize.w; }
-        if(height === undefined) { height = gameObject.frame.data.sourceSize.h; }
+        if (width === undefined) { width = gameObject.frame.data.sourceSize.w; }
+        if (height === undefined) { height = gameObject.frame.data.sourceSize.h; }
         
         this.sourceWidth = width;
         this.sourceHeight = height;

--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1072,6 +1072,7 @@ var Body = new Class({
     /**
      * Sizes and positions this Body's boundary, as a rectangle.
      * Modifies the Body's `offset` if `center` is true (the default).
+     * Resets the width and height to match current frame, if no width and height provided.
      *
      * @method Phaser.Physics.Arcade.Body#setSize
      * @since 3.0.0
@@ -1088,6 +1089,9 @@ var Body = new Class({
 
         var gameObject = this.gameObject;
 
+        if(width === undefined) { width = gameObject.frame.data.sourceSize.w; }
+        if(height === undefined) { height = gameObject.frame.data.sourceSize.h; }
+        
         this.sourceWidth = width;
         this.sourceHeight = height;
 

--- a/src/physics/arcade/StaticBody.js
+++ b/src/physics/arcade/StaticBody.js
@@ -486,7 +486,8 @@ var StaticBody = new Class({
     },
 
     /**
-     * [description]
+     * Sets the size of the body.
+     * Resets the body to match the current frame if no width or height is provided.
      *
      * @method Phaser.Physics.Arcade.StaticBody#setSize
      * @since 3.0.0
@@ -500,6 +501,8 @@ var StaticBody = new Class({
      */
     setSize: function (width, height, offsetX, offsetY)
     {
+        if (width === undefined) { width = this.gameObject.frame.data.sourceSize.w; }
+        if (height === undefined) { height = this.gameObject.frame.data.sourceSize.h; }
         if (offsetX === undefined) { offsetX = this.offset.x; }
         if (offsetY === undefined) { offsetY = this.offset.y; }
 


### PR DESCRIPTION
This PR adds a new feature: Update a physics body (arcade) to match the existing frame of a texture using empty values on setSize();

This applies to instances where you are modifying frames during gameplay and need the physics body to match the new frame.