### PR TITLE
Allow XHR status 0 as success too

### DIFF
--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -315,7 +315,10 @@ var File = new Class({
      */
     onLoad: function (xhr, event)
     {
-        var success = !(event.target && (event.target.status !== 200 && event.target.status !== 0));
+        var localFileOk = xhr.responseURL.indexOf('file://') == 0 &&
+            event.target.status === 0;
+
+        var success = !(event.target && event.target.status !== 200) || localFileOk;
 
         //  Handle HTTP status codes of 4xx and 5xx as errors, even if xhr.onerror was not called.
         if (xhr.readyState === 4 && xhr.status >= 400 && xhr.status <= 599)

--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -315,7 +315,7 @@ var File = new Class({
      */
     onLoad: function (xhr, event)
     {
-        var success = !(event.target && event.target.status !== 200);
+        var success = !(event.target && (event.target.status !== 200 && event.target.status !== 0));
 
         //  Handle HTTP status codes of 4xx and 5xx as errors, even if xhr.onerror was not called.
         if (xhr.readyState === 4 && xhr.status >= 400 && xhr.status <= 599)


### PR DESCRIPTION
This PR (delete as applicable)

* Adds a new feature
  * Allow opening games locally (without web server) when browser allows it
* Fixes a bug
  * This fixes #3464

Describe the changes below:

Normally only status 200 would be accepted as success, but 0 is returned when a file is loaded from the local filesystem (file://). This happens for example when opening the index.html of a (Phaser) game in a browser directly, or, as it turns out, when using Cordova on iOS.
