### PR TITLE
fix: Corrects the wrong JSdoc comments

### DIFF
--- a/src/gameobjects/particles/ParticleEmitterManager.js
+++ b/src/gameobjects/particles/ParticleEmitterManager.js
@@ -22,9 +22,9 @@ var Render = require('./ParticleManagerRender');
  * @constructor
  * @since 3.0.0
  *
- * @extends Phaser.GameObjects.Particles.Components.Depth
- * @extends Phaser.GameObjects.Particles.Components.Pipeline
- * @extends Phaser.GameObjects.Particles.Components.Visible
+ * @extends Phaser.GameObjects.Components.Depth
+ * @extends Phaser.GameObjects.Components.Pipeline
+ * @extends Phaser.GameObjects.Components.Visible
  *
  * @param {Phaser.Scene} scene - The Scene to which this Emitter Manager belongs.
  * @param {string} texture - The key of the Texture this Emitter Manager will use to render particles, as stored in the Texture Manager.


### PR DESCRIPTION
Wrong comments lead to a faulty Typescript Definition file missing
the depth attribute.

Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:

Depth property was missing in generated type script definition file. Correcting these paths fixes this error.