### PR TITLE
add typedef for SpriteConfig and allowed GameObject#update signature override

### DIFF
--- a/src/gameobjects/GameObject.js
+++ b/src/gameobjects/GameObject.js
@@ -126,7 +126,7 @@ var GameObject = new Class({
          * A bitmask that controls if this Game Object is drawn by a Camera or not.
          * Not usually set directly, instead call `Camera.ignore`, however you can
          * set this property directly using the Camera.id property:
-         * 
+         *
          * @example
          * this.cameraFilter |= camera.id
          *
@@ -234,12 +234,12 @@ var GameObject = new Class({
 
     /**
      * Allows you to store a key value pair within this Game Objects Data Manager.
-     * 
+     *
      * If the Game Object has not been enabled for data (via `setDataEnabled`) then it will be enabled
      * before setting the value.
-     * 
+     *
      * If the key doesn't already exist in the Data Manager then it is created.
-     * 
+     *
      * ```javascript
      * sprite.setData('name', 'Red Gem Stone');
      * ```
@@ -251,13 +251,13 @@ var GameObject = new Class({
      * ```
      *
      * To get a value back again you can call `getData`:
-     * 
+     *
      * ```javascript
      * sprite.getData('gold');
      * ```
-     * 
+     *
      * Or you can access the value directly via the `values` property, where it works like any other variable:
-     * 
+     *
      * ```javascript
      * sprite.data.values.gold += 50;
      * ```
@@ -295,19 +295,19 @@ var GameObject = new Class({
      * Retrieves the value for the given key in this Game Objects Data Manager, or undefined if it doesn't exist.
      *
      * You can also access values via the `values` object. For example, if you had a key called `gold` you can do either:
-     * 
+     *
      * ```javascript
      * sprite.getData('gold');
      * ```
      *
      * Or access the value directly:
-     * 
+     *
      * ```javascript
      * sprite.data.values.gold;
      * ```
      *
      * You can also pass in an array of keys, in which case an array of values will be returned:
-     * 
+     *
      * ```javascript
      * sprite.getData([ 'gold', 'armor', 'health' ]);
      * ```
@@ -416,6 +416,8 @@ var GameObject = new Class({
      *
      * @method Phaser.GameObjects.GameObject#update
      * @since 3.0.0
+     *
+     * @param {...*} [args] - args
      */
     update: function ()
     {
@@ -440,7 +442,7 @@ var GameObject = new Class({
      *
      * @method Phaser.GameObjects.GameObject#willRender
      * @since 3.0.0
-     * 
+     *
      * @param {Phaser.Cameras.Scene2D.Camera} camera - The Camera to check against this Game Object.
      *
      * @return {boolean} True if the Game Object should be rendered, otherwise false.

--- a/src/gameobjects/sprite/SpriteCreator.js
+++ b/src/gameobjects/sprite/SpriteCreator.js
@@ -15,7 +15,7 @@ var Sprite = require('./Sprite');
  * @extends GameObjectConfig
  *
  * @property {string} [key] - The key of the Texture this Game Object will use to render with, as stored in the Texture Manager.
- * @property {number|string} [frame] - An optional frame from the Texture this Game Object is rendering with.
+ * @property {(number|string)} [frame] - An optional frame from the Texture this Game Object is rendering with.
  */
 
 /**

--- a/src/gameobjects/sprite/SpriteCreator.js
+++ b/src/gameobjects/sprite/SpriteCreator.js
@@ -11,6 +11,14 @@ var GetAdvancedValue = require('../../utils/object/GetAdvancedValue');
 var Sprite = require('./Sprite');
 
 /**
+ * @typedef {object} SpriteConfig
+ * @extends GameObjectConfig
+ *
+ * @property {string} [key] - The key of the Texture this Game Object will use to render with, as stored in the Texture Manager.
+ * @property {number|string} [frame] - An optional frame from the Texture this Game Object is rendering with.
+ */
+
+/**
  * Creates a new Sprite Game Object and returns it.
  *
  * Note: This method will only be available if the Sprite Game Object has been built into Phaser.
@@ -18,7 +26,7 @@ var Sprite = require('./Sprite');
  * @method Phaser.GameObjects.GameObjectCreator#sprite
  * @since 3.0.0
  *
- * @param {object} config - The configuration object this Game Object will use to create itself.
+ * @param {SpriteConfig} config - The configuration object this Game Object will use to create itself.
  * @param {boolean} [addToScene] - Add this Game Object to the Scene after creating it? If set this argument overrides the `add` property in the config object.
  *
  * @return {Phaser.GameObjects.Sprite} The Game Object that was created.

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -508,7 +508,7 @@ var Tilemap = new Class({
      * @param {(integer|string)} id - Either the id (object), gid (tile object) or name (object or
      * tile object) from Tiled. Ids are unique in Tiled, but a gid is shared by all tile objects
      * with the same graphic. The same name can be used on multiple objects.
-     * @param {object} spriteConfig - The config object to pass into the Sprite creator (i.e.
+     * @param {SpriteConfig} spriteConfig - The config object to pass into the Sprite creator (i.e.
      * scene.make.sprite).
      * @param {Phaser.Scene} [scene=the scene the map is within] - The Scene to create the Sprites within.
      *
@@ -599,7 +599,7 @@ var Tilemap = new Class({
      * @param {(integer|array)} replacements - The tile index, or array of indexes, to change a converted
      * tile to. Set to `null` to leave the tiles unchanged. If an array is given, it is assumed to be a
      * one-to-one mapping with the indexes array.
-     * @param {object} spriteConfig - The config object to pass into the Sprite creator (i.e.
+     * @param {SpriteConfig} spriteConfig - The config object to pass into the Sprite creator (i.e.
      * scene.make.sprite).
      * @param {Phaser.Scene} [scene=scene the map is within] - The Scene to create the Sprites within.
      * @param {Phaser.Cameras.Scene2D.Camera} [camera=main camera] - The Camera to use when determining the world XY

--- a/src/tilemaps/components/CreateFromTiles.js
+++ b/src/tilemaps/components/CreateFromTiles.js
@@ -23,7 +23,7 @@ var ReplaceByIndex = require('./ReplaceByIndex');
  * @param {(integer|array)} replacements - The tile index, or array of indexes, to change a converted
  * tile to. Set to `null` to leave the tiles unchanged. If an array is given, it is assumed to be a
  * one-to-one mapping with the indexes array.
- * @param {object} spriteConfig - The config object to pass into the Sprite creator (i.e.
+ * @param {SpriteConfig} spriteConfig - The config object to pass into the Sprite creator (i.e.
  * scene.make.sprite).
  * @param {Phaser.Scene} [scene=scene the map is within] - The Scene to create the Sprites within.
  * @param {Phaser.Cameras.Scene2D.Camera} [camera=main camera] - The Camera to use when determining the world XY

--- a/src/tilemaps/dynamiclayer/DynamicTilemapLayer.js
+++ b/src/tilemaps/dynamiclayer/DynamicTilemapLayer.js
@@ -134,7 +134,7 @@ var DynamicTilemapLayer = new Class({
         /**
          * You can control if the Cameras should cull tiles before rendering them or not.
          * By default the camera will try to cull the tiles in this layer, to avoid over-drawing to the renderer.
-         * 
+         *
          * However, there are some instances when you may wish to disable this, and toggling this flag allows
          * you to do so. Also see `setSkipCull` for a chainable method that does the same thing.
          *
@@ -166,7 +166,7 @@ var DynamicTilemapLayer = new Class({
 
         /**
          * The amount of extra tiles to add into the cull rectangle when calculating its horizontal size.
-         * 
+         *
          * See the method `setCullPadding` for more details.
          *
          * @name Phaser.Tilemaps.DynamicTilemapLayer#cullPaddingX
@@ -178,7 +178,7 @@ var DynamicTilemapLayer = new Class({
 
         /**
          * The amount of extra tiles to add into the cull rectangle when calculating its vertical size.
-         * 
+         *
          * See the method `setCullPadding` for more details.
          *
          * @name Phaser.Tilemaps.DynamicTilemapLayer#cullPaddingY
@@ -190,15 +190,15 @@ var DynamicTilemapLayer = new Class({
 
         /**
          * The callback that is invoked when the tiles are culled.
-         * 
+         *
          * By default it will call `TilemapComponents.CullTiles` but you can override this to call any function you like.
-         * 
+         *
          * It will be sent 3 arguments:
-         * 
+         *
          * 1) The Phaser.Tilemaps.LayerData object for this Layer
          * 2) The Camera that is culling the layer. You can check its `dirty` property to see if it has changed since the last cull.
          * 3) A reference to the `culledTiles` array, which should be used to store the tiles you want rendered.
-         * 
+         *
          * See the `TilemapComponents.CullTiles` source code for details on implementing your own culling system.
          *
          * @name Phaser.Tilemaps.DynamicTilemapLayer#cullCallback
@@ -270,7 +270,7 @@ var DynamicTilemapLayer = new Class({
      * @param {(integer|array)} replacements - The tile index, or array of indexes, to change a converted
      * tile to. Set to `null` to leave the tiles unchanged. If an array is given, it is assumed to be a
      * one-to-one mapping with the indexes array.
-     * @param {object} spriteConfig - The config object to pass into the Sprite creator (i.e.
+     * @param {SpriteConfig} spriteConfig - The config object to pass into the Sprite creator (i.e.
      * scene.make.sprite).
      * @param {Phaser.Scene} [scene=scene the map is within] - The Scene to create the Sprites within.
      * @param {Phaser.Cameras.Scene2D.Camera} [camera=main camera] - The Camera to use when determining the world XY
@@ -822,9 +822,9 @@ var DynamicTilemapLayer = new Class({
     /**
      * You can control if the Cameras should cull tiles before rendering them or not.
      * By default the camera will try to cull the tiles in this layer, to avoid over-drawing to the renderer.
-     * 
+     *
      * However, there are some instances when you may wish to disable this.
-     * 
+     *
      * @method Phaser.Tilemaps.DynamicTilemapLayer#setSkipCull
      * @since 3.11.0
      *
@@ -842,12 +842,12 @@ var DynamicTilemapLayer = new Class({
     },
 
     /**
-     * When a Camera culls the tiles in this layer it does so using its view into the world, building up a 
+     * When a Camera culls the tiles in this layer it does so using its view into the world, building up a
      * rectangle inside which the tiles must exist or they will be culled. Sometimes you may need to expand the size
      * of this 'cull rectangle', especially if you plan on rotating the Camera viewing the layer. Do so
      * by providing the padding values. The values given are in tiles, not pixels. So if the tile width was 32px
      * and you set `paddingX` to be 4, it would add 32px x 4 to the cull rectangle (adjusted for scale)
-     * 
+     *
      * @method Phaser.Tilemaps.DynamicTilemapLayer#setCullPadding
      * @since 3.11.0
      *

--- a/src/tilemaps/staticlayer/StaticTilemapLayer.js
+++ b/src/tilemaps/staticlayer/StaticTilemapLayer.js
@@ -237,7 +237,7 @@ var StaticTilemapLayer = new Class({
                 var row;
                 var col;
                 var texCoords;
-   
+
                 var vertexBuffer = this.vertexBuffer;
                 var bufferData = this.bufferData;
                 var voffset = -1;
@@ -433,7 +433,7 @@ var StaticTilemapLayer = new Class({
      * @param {(integer|array)} replacements - The tile index, or array of indexes, to change a converted
      * tile to. Set to `null` to leave the tiles unchanged. If an array is given, it is assumed to be a
      * one-to-one mapping with the indexes array.
-     * @param {object} spriteConfig - The config object to pass into the Sprite creator (i.e.
+     * @param {SpriteConfig} spriteConfig - The config object to pass into the Sprite creator (i.e.
      * scene.make.sprite).
      * @param {Phaser.Scene} [scene=scene the map is within] - The Scene to create the Sprites within.
      * @param {Phaser.Cameras.Scene2D.Camera} [camera=main camera] - The Camera to use when determining the world XY


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:

- Added typedef for SpriteConfig (extends GameObjectConfig)
- Added rest parameter param to GameObject#update so TypeScript users can override the function signature

(Also vscode removed some random whitespaces in jsdocs)