### PR TITLE
generateTexture fix

### DIFF
--- a/src/gameobjects/graphics/Graphics.js
+++ b/src/gameobjects/graphics/Graphics.js
@@ -1494,6 +1494,7 @@ var Graphics = new Class({
         if (width === undefined) { width = sys.game.config.width; }
         if (height === undefined) { height = sys.game.config.height; }
 
+        Graphics.TargetCamera.setScene(this.scene);
         Graphics.TargetCamera.setViewport(0, 0, width, height);
         Graphics.TargetCamera.scrollX = this.x;
         Graphics.TargetCamera.scrollY = this.y;


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:

generateTexture sets viewport of Graphics TargetCamera, which eventually calls updateSystem(). If scene is not set, this.config and this.sceneManager are undefined, which leads to a crash inside updateSystem().
