### PR TITLE
Add lineSpacing option to RetroFont Config

### DIFF
--- a/src/gameobjects/bitmaptext/ParseRetroFont.js
+++ b/src/gameobjects/bitmaptext/ParseRetroFont.js
@@ -36,6 +36,7 @@ var ParseRetroFont = function (scene, config)
     var offsetY = GetValue(config, 'offset.y', 0);
     var spacingX = GetValue(config, 'spacing.x', 0);
     var spacingY = GetValue(config, 'spacing.y', 0);
+    var lineSpacing = GetValue(config, 'lineSpacing', 0);
 
     var charsPerRow = GetValue(config, 'charsPerRow', null);
 
@@ -56,7 +57,7 @@ var ParseRetroFont = function (scene, config)
         retroFont: true,
         font: key,
         size: w,
-        lineHeight: h,
+        lineHeight: h + lineSpacing,
         chars: {}
     };
 

--- a/src/gameobjects/bitmaptext/RetroFont.js
+++ b/src/gameobjects/bitmaptext/RetroFont.js
@@ -19,6 +19,7 @@ var Extend = require('../../utils/object/Extend');
  * @property {number} charsPerRow - The number of characters per row in the font set. If not given charsPerRow will be the image width / characterWidth.
  * @property {number} spacing.x - If the characters in the font set have horizontal spacing between them set the required amount here.
  * @property {number} spacing.y - If the characters in the font set have vertical spacing between them set the required amount here.
+ * @property {number} lineSpacing - The amount of vertical space to add to the line height of the font.
 */
 
 /**


### PR DESCRIPTION
This PR:
* Updates the Documentation
* Adds a new feature

Describe the changes below:
#3890 
Allows specifying extra spacing for retro font line height
Add lineSpacing option to RetroFont Config
Add lineSpacing to line height when parseing RetroFont Config
