### PR TITLE
Fix `collisionEnd` triggering many times in Phaser's Matter.js copy

### DIFF
--- a/src/physics/matter-js/lib/collision/Pairs.js
+++ b/src/physics/matter-js/lib/collision/Pairs.js
@@ -94,7 +94,7 @@ var Common = require('../core/Common');
         // deactivate previously active pairs that are now inactive
         for (i = 0; i < pairsList.length; i++) {
             pair = pairsList[i];
-            if (!pair.confirmedActive) {
+            if (pair.isActive && !pair.confirmedActive) {
                 Pair.setActive(pair, false, timestamp);
                 collisionEnd.push(pair);
             }


### PR DESCRIPTION
The Matter copy in Phaser is missing this upstream [bug fix](https://github.com/liabru/matter-js/commit/4e04043fe0daf7deec681ab49f244d3867f75062#diff-7e3ecd3fdc11e74015231affd3d1416c) that prevents `collisionEnd` from triggering many times when it should only trigger once. (Oddly enough, the matter copy in Phaser has code that is more recent than that commit, it's just missing that line modification. Here's a [diff](https://www.diffchecker.com/Co4cz215) to verify that.)

Here's a [codesandbox](https://codesandbox.io/s/zrlw9jw59m?expanddevtools=1) with the bug demonstrated. It logs to the console (and displays on screen) when collisionStart, collisionActive and collisionEnd happen. I've verified that this PR fixes the issue locally.