### PR TITLE
Emit previous value with DataManager's `changedata` event

### DIFF
--- a/src/data/DataManager.js
+++ b/src/data/DataManager.js
@@ -318,10 +318,11 @@ var DataManager = new Class({
                 {
                     if (!_this._frozen)
                     {
+                        var previousValue = list[key];
                         list[key] = value;
 
-                        events.emit('changedata', parent, key, value);
-                        events.emit('changedata_' + key, parent, value);
+                        events.emit('changedata', parent, key, value, previousValue);
+                        events.emit('changedata_' + key, parent, value, previousValue);
                     }
                 }
 


### PR DESCRIPTION
This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

This updates the payload for `DataManager`'s `changedata` event to include the previous value for convenience. Previously it was not possible to access the previous value once set without caching in userland.