### PR TITLE
Fix a bug that tween delay doesn't applied after one loop of timeline(issue #3841)

### DIFF
--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -710,14 +710,15 @@ var Tween = new Class({
 
                 tweenData.state = TWEEN_CONST.PLAYING_FORWARD;
             }
-            else if (tweenData.delay > 0)
-            {
-                tweenData.elapsed = tweenData.delay;
-                tweenData.state = TWEEN_CONST.DELAY;
-            }
             else
             {
                 tweenData.state = TWEEN_CONST.PENDING_RENDER;
+            }
+
+            if (tweenData.delay > 0)
+            {
+                tweenData.elapsed = tweenData.delay;
+                tweenData.state = TWEEN_CONST.DELAY;
             }
         }
     },


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* ~~Updates the Documentation~~
* ~~Adds a new feature~~
* Fixes a bug

Describe the changes below:

Fix a bug described in issue #3841 .

After one loop of timeline, function callstack seems like to:

Timeline.nextState() => Timeline.resetTweens() => Timeline.resetTweens() => Tween.play() => Tween.resetTweenData().

And that function doesn't init the tweenData's delay if resetFromLoop is true. So I fixed it and it seems to be worked well.