### PR TITLE
Replace DistanceBetween with DistanceSquared in closest() and furthest() functions (ArcadePhysics.js)

### DIFF
--- a/src/physics/arcade/ArcadePhysics.js
+++ b/src/physics/arcade/ArcadePhysics.js
@@ -7,6 +7,7 @@
 var Class = require('../../utils/Class');
 var DegToRad = require('../../math/DegToRad');
 var DistanceBetween = require('../../math/distance/DistanceBetween');
+var DistanceSquared = require('../../math/distance/DistanceSquared');
 var Factory = require('./Factory');
 var GetFastValue = require('../../utils/object/GetFastValue');
 var Merge = require('../../utils/object/Merge');
@@ -310,7 +311,7 @@ var ArcadePhysics = new Class({
         for (var i = bodies.length - 1; i >= 0; i--)
         {
             var target = bodies[i];
-            var distance = DistanceBetween(x, y, target.x, target.y);
+            var distance = DistanceSquared(x, y, target.x, target.y);
 
             if (distance < min)
             {
@@ -344,7 +345,7 @@ var ArcadePhysics = new Class({
         for (var i = bodies.length - 1; i >= 0; i--)
         {
             var target = bodies[i];
-            var distance = DistanceBetween(x, y, target.x, target.y);
+            var distance = DistanceSquared(x, y, target.x, target.y);
 
             if (distance > max)
             {


### PR DESCRIPTION
This PR contains just a minor performance change

Describe the changes below:
In `closest` and `furthest` functions (`ArcadePhysics.js`), distances are calculated with `DistanceBetween` using a square root, but the same result can be obtained without this operation, using `DistanceSquared`.
