### PR TITLE
Wrong bounds/displayOrigin on BitmapText text change

### DIFF
--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -340,9 +340,9 @@ var BitmapText = new Class({
         {
             this._text = value.toString();
 
-            this.updateDisplayOrigin();
-
             this._dirty = true;
+
+            this.updateDisplayOrigin();
         }
 
         return this;


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:

updateDisplayOrigin needs current width and height, which are not recalculated if the _dirty is not set to true.

If the BitmapText with originX=1 is initialized with an empty string and then the text is changed, displayOriginX and displayOriginY remain at 0.