### PR TITLE
Resizing of the SVG in the preload

### DIFF
--- a/src/loader/filetypes/SVGFile.js
+++ b/src/loader/filetypes/SVGFile.js
@@ -92,8 +92,8 @@ var SVGFile = new Class({
         {
             var xml = null;
             var parser = new DOMParser();
-            xml = parser.parseFromString( text , 'text/xml');
-            var svgXML = xml.getElementsByTagName('svg')[ 0 ];
+            xml = parser.parseFromString(text , 'text/xml');
+            var svgXML = xml.getElementsByTagName('svg')[0];
             
             // Si no tiene el atributo viewBox, le asigna el valor del alto y ancho predefinidos, para no tener problemas en el escalado.
             if (svgXML.getAttribute('viewBox'))

--- a/src/loader/filetypes/SVGFile.js
+++ b/src/loader/filetypes/SVGFile.js
@@ -83,7 +83,23 @@ var SVGFile = new Class({
     {
         this.state = CONST.FILE_PROCESSING;
 
-        var svg = [ this.xhrLoader.responseText ];
+          var rText = this.xhrLoader.responseText,
+            svg = [rText],
+            configWidth = this.xhrSettings.width,
+            configHeight = this.xhrSettings.height;
+
+        if (configWidth && configHeight) {
+            var xD = null,
+                parser = new DOMParser();
+            xD = parser.parseFromString(rText, "text/xml");
+            var svgXML = xD.getElementsByTagName("svg")[0];
+            gA = (a) => svgXML.getAttribute(a);
+            sA = (a, b) => svgXML.setAttribute(a, b);
+            gA('viewBox') ? '' : sA('viewBox', '0  0 ' + gA('width') + ' ' + gA('height'));
+            sA('width', configWidth);
+            sA('height', configHeight);
+            svg = [(new XMLSerializer()).serializeToString(svgXML)];
+            }
 
         try
         {

--- a/src/loader/filetypes/SVGFile.js
+++ b/src/loader/filetypes/SVGFile.js
@@ -83,23 +83,28 @@ var SVGFile = new Class({
     {
         this.state = CONST.FILE_PROCESSING;
 
-          var rText = this.xhrLoader.responseText,
-            svg = [rText],
-            configWidth = this.xhrSettings.width,
-            configHeight = this.xhrSettings.height;
+        var text = this.xhrLoader.responseText;
+        var svg = [ text ];
+        var width = this.xhrSettings.width;
+        var height = this.xhrSettings.height;
 
-        if (configWidth && configHeight) {
-            var xD = null,
-                parser = new DOMParser();
-            xD = parser.parseFromString(rText, "text/xml");
-            var svgXML = xD.getElementsByTagName("svg")[0];
-            gA = (a) => svgXML.getAttribute(a);
-            sA = (a, b) => svgXML.setAttribute(a, b);
-            gA('viewBox') ? '' : sA('viewBox', '0  0 ' + gA('width') + ' ' + gA('height'));
-            sA('width', configWidth);
-            sA('height', configHeight);
-            svg = [(new XMLSerializer()).serializeToString(svgXML)];
+        if (width && height)
+        {
+            var xml = null;
+            var parser = new DOMParser();
+            xml = parser.parseFromString( text , 'text/xml');
+            var svgXML = xml.getElementsByTagName('svg')[ 0 ];
+            
+            // Si no tiene el atributo viewBox, le asigna el valor del alto y ancho predefinidos, para no tener problemas en el escalado.
+            if (svgXML.getAttribute('viewBox'))
+            {
+                svgXML.setAttribute('viewBox', '0  0 ' + svgXML.getAttribute('width') + ' ' + svgXML.getAttribute('height'));
             }
+
+            svgXML.setAttribute('width', width);
+            svgXML.setAttribute('height', height);
+            svg = [ (new XMLSerializer()).serializeToString(svgXML) ];
+        }
 
         try
         {

--- a/src/loader/filetypes/SVGFile.js
+++ b/src/loader/filetypes/SVGFile.js
@@ -25,7 +25,7 @@ var IsPlainObject = require('../../utils/object/IsPlainObject');
  * A single SVG File suitable for loading by the Loader.
  *
  * These are created when you use the Phaser.Loader.LoaderPlugin#svg method and are not typically created directly.
- * 
+ *
  * For documentation about what all the arguments and configuration options mean please see Phaser.Loader.LoaderPlugin#svg.
  *
  * @class SVGFile
@@ -45,7 +45,7 @@ var SVGFile = new Class({
 
     initialize:
 
-    function SVGFile (loader, key, url, xhrSettings)
+    function SVGFile (loader, key, url, svgConfig, xhrSettings)
     {
         var extension = 'svg';
 
@@ -55,6 +55,7 @@ var SVGFile = new Class({
 
             key = GetFastValue(config, 'key');
             url = GetFastValue(config, 'url');
+            svgConfig = GetFastValue(config, 'svgConfig');
             xhrSettings = GetFastValue(config, 'xhrSettings');
             extension = GetFastValue(config, 'extension', extension);
         }
@@ -66,6 +67,7 @@ var SVGFile = new Class({
             responseType: 'text',
             key: key,
             url: url,
+            svgConfig: svgConfig,
             xhrSettings: xhrSettings
         };
 
@@ -85,17 +87,16 @@ var SVGFile = new Class({
 
         var text = this.xhrLoader.responseText;
         var svg = [ text ];
-        var width = this.xhrSettings.width;
-        var height = this.xhrSettings.height;
+        var width = this.svgConfig.width;
+        var height = this.svgConfig.height;
 
         if (width && height)
         {
             var xml = null;
             var parser = new DOMParser();
-            xml = parser.parseFromString(text , 'text/xml');
+            xml = parser.parseFromString(text, 'text/xml');
             var svgXML = xml.getElementsByTagName('svg')[0];
-            
-            // Si no tiene el atributo viewBox, le asigna el valor del alto y ancho predefinidos, para no tener problemas en el escalado.
+
             if (svgXML.getAttribute('viewBox'))
             {
                 svgXML.setAttribute('viewBox', '0  0 ' + svgXML.getAttribute('width') + ' ' + svgXML.getAttribute('height'));
@@ -173,7 +174,7 @@ var SVGFile = new Class({
  * Adds an SVG File, or array of SVG Files, to the current load queue.
  *
  * You can call this method from within your Scene's `preload`, along with any other files you wish to load:
- * 
+ *
  * ```javascript
  * function preload ()
  * {
@@ -195,7 +196,7 @@ var SVGFile = new Class({
  * then remove it from the Texture Manager first, before loading a new one.
  *
  * Instead of passing arguments you can pass a configuration object, such as:
- * 
+ *
  * ```javascript
  * this.load.svg({
  *     key: 'morty',
@@ -206,7 +207,7 @@ var SVGFile = new Class({
  * See the documentation for `Phaser.Loader.FileTypes.SVGFileConfig` for more details.
  *
  * Once the file has finished loading you can use it as a texture for a Game Object by referencing its key:
- * 
+ *
  * ```javascript
  * this.load.svg('morty', 'images/Morty.svg');
  * // and later in your game ...
@@ -255,3 +256,4 @@ FileTypesManager.register('svg', function (key, url, xhrSettings)
 });
 
 module.exports = SVGFile;
+


### PR DESCRIPTION
One of the main qualities of SVG images, is its scalability, not being able to use this, is to reduce it to be a bit more image. An SVG file has an XML format, so it can be modified with the DOM.
In order to collaborate, I have put the option to modify the parameters of the SVG and in this way make it adaptable.
The modification gives the option of being able to choose the size in the preload to which you want to have the image before rasterizing it; And so avoid the subsequent scaling that will not have the same quality.
You can see the example here: 
https://www.youtube.com/watch?v=Kd7pNjY-FLk
tested in version 3.11 It does not interfere with the original code.

Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation
* Adds a new feature
* Fixes a bug

Describe the changes below:

