### PR TITLE
Don't set gl.clearColor when no clearBeforeRender

### DIFF
--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -1636,11 +1636,9 @@ var WebGLRenderer = new Class({
         var color = this.config.backgroundColor;
         var pipelines = this.pipelines;
 
-        // Bind custom framebuffer here
-        gl.clearColor(color.redGL, color.greenGL, color.blueGL, color.alphaGL);
-
         if (this.config.clearBeforeRender)
         {
+            gl.clearColor(color.redGL, color.greenGL, color.blueGL, color.alphaGL);
             gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
         }
 


### PR DESCRIPTION
Unless I'm missing something, the `gl.clearColor` command is unnecessary when you have `this.config.clearBeforeRender` set to `false`. This simply moves that into the config check to eliminate an unused command in those situations.
