### PR TITLE
Fixed an issue where module exports are not named correct for CanvasInterpolation and CanvasPool

### DIFF
--- a/src/display/canvas/index.js
+++ b/src/display/canvas/index.js
@@ -10,8 +10,8 @@
 
 module.exports = {
 
-    Interpolation: require('./CanvasInterpolation'),
-    Pool: require('./CanvasPool'),
+    CanvasInterpolation: require('./CanvasInterpolation'),
+    CanvasPool: require('./CanvasPool'),
     Smoothing: require('./Smoothing'),
     TouchAction: require('./TouchAction'),
     UserSelect: require('./UserSelect')


### PR DESCRIPTION
* Fixes a bug #3946

Fixed an issue where `TypeError: undefined is not an object` was thrown in TypeScript as soon as you tried to access a function of CanvasInterpolation or CanvasPool.