### PR TITLE
Fix JSDoc in Tilemap

### DIFF
--- a/src/tilemaps/components/RemoveTileAt.js
+++ b/src/tilemaps/components/RemoveTileAt.js
@@ -16,9 +16,8 @@ var CalculateFacesAt = require('./CalculateFacesAt');
  * @private
  * @since 3.0.0
  *
- * @param {(integer|Phaser.Tilemaps.Tile)} tile - The index of this tile to set or a Tile object.
- * @param {integer} tileX - [description]
- * @param {integer} tileY - [description]
+ * @param {integer} tileX - The x coordinate.
+ * @param {integer} tileY - The y coordinate.
  * @param {boolean} [replaceWithNull=true] - If true, this will replace the tile at the specified
  * location with null instead of a Tile with an index of -1.
  * @param {boolean} [recalculateFaces=true] - [description]

--- a/src/tilemaps/components/RemoveTileAtWorldXY.js
+++ b/src/tilemaps/components/RemoveTileAtWorldXY.js
@@ -16,7 +16,6 @@ var WorldToTileY = require('./WorldToTileY');
  * @private
  * @since 3.0.0
  *
- * @param {(integer|Phaser.Tilemaps.Tile)} tile - The index of this tile to set or a Tile object.
  * @param {number} worldX - [description]
  * @param {number} worldY - [description]
  * @param {boolean} [replaceWithNull=true] - If true, this will replace the tile at the specified

--- a/src/tilemaps/dynamiclayer/DynamicTilemapLayer.js
+++ b/src/tilemaps/dynamiclayer/DynamicTilemapLayer.js
@@ -732,7 +732,6 @@ var DynamicTilemapLayer = new Class({
      * @method Phaser.Tilemaps.DynamicTilemapLayer#removeTileAt
      * @since 3.0.0
      *
-     * @param {(integer|Phaser.Tilemaps.Tile)} tile - The index of this tile to set or a Tile object.
      * @param {integer} tileX - [description]
      * @param {integer} tileY - [description]
      * @param {boolean} [replaceWithNull=true] - If true, this will replace the tile at the specified
@@ -753,7 +752,6 @@ var DynamicTilemapLayer = new Class({
      * @method Phaser.Tilemaps.DynamicTilemapLayer#removeTileAtWorldXY
      * @since 3.0.0
      *
-     * @param {(integer|Phaser.Tilemaps.Tile)} tile - The index of this tile to set or a Tile object.
      * @param {number} worldX - [description]
      * @param {number} worldY - [description]
      * @param {boolean} [replaceWithNull=true] - If true, this will replace the tile at the specified


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:

Some functions: 

* `removeTileAt`
* `removeTileAtWorldXY` 

had unnecessary JSDoc parameters description: there is no `tile` parameter.