### PR TITLE
Reset Pointer.buttons to 0 on mouseup

### DIFF
--- a/src/input/Pointer.js
+++ b/src/input/Pointer.js
@@ -383,11 +383,7 @@ var Pointer = new Class({
      */
     up: function (event, time)
     {
-        if (event.buttons)
-        {
-            this.buttons = event.buttons;
-        }
-
+        this.buttons = event.buttons;
         this.event = event;
 
         //  Sets the local x/y properties


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
The leftButtonDown(), rightButtonDown(), etc functions currently don't return false after releasing the button on the mouse. There's a check in Pointer.up() for:

`if (event.buttons) { this.buttons = event.buttons; }`

However event.buttons is always 0 on mouseup, so this.buttons never gets reset to 0.
