### PR TITLE
RenderTexture: Texture is always destroyed (canvas)

### DIFF
--- a/src/gameobjects/rendertexture/RenderTexture.js
+++ b/src/gameobjects/rendertexture/RenderTexture.js
@@ -829,7 +829,7 @@ var RenderTexture = new Class({
      */
     preDestroy: function ()
     {
-        if (this.canvas)
+        if (this.canvas && !this._saved)
         {
             CanvasPool.remove(this.canvas);
         }


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Forgot to check the flag for canvas renderer in the previous pull request.