### PR TITLE
Updated @param notation that cause issues generating docs

### DIFF
--- a/src/gameobjects/group/GroupFactory.js
+++ b/src/gameobjects/group/GroupFactory.js
@@ -15,7 +15,7 @@ var GameObjectFactory = require('../GameObjectFactory');
  * @method Phaser.GameObjects.GameObjectFactory#group
  * @since 3.0.0
  *
- * @param {(Phaser.GameObjects.GameObject[]|GroupConfig||GroupConfig[])} [children] - Game Objects to add to this Group; or the `config` argument.
+ * @param {(Phaser.GameObjects.GameObject[]|GroupConfig|GroupConfig[])} [children] - Game Objects to add to this Group; or the `config` argument.
  * @param {GroupConfig} [config] - A Group Configuration object.
  *
  * @return {Phaser.GameObjects.Group} The Game Object that was created.


### PR DESCRIPTION
there was a double pipe - now there isn't

Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)
 
* Fixes a bug

Describe the changes below:

removes a bug for when running JSDoc / Typescript generating documentation.