### PR TITLE
Add CursorKeys type to Phaser.Input.Keyboard namespace

### DIFF
--- a/src/input/keyboard/KeyboardPlugin.js
+++ b/src/input/keyboard/KeyboardPlugin.js
@@ -276,7 +276,8 @@ var KeyboardPlugin = new Class({
 
     /**
      * @typedef {object} CursorKeys
-     *
+     * @memberOf Phaser.Input.Keyboard
+     * 
      * @property {Phaser.Input.Keyboard.Key} [up] - A Key object mapping to the UP arrow key.
      * @property {Phaser.Input.Keyboard.Key} [down] - A Key object mapping to the DOWN arrow key.
      * @property {Phaser.Input.Keyboard.Key} [left] - A Key object mapping to the LEFT arrow key.


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:
The CursorKeys type wasn't inside a namespace. This PR just add the Phaser.Input.Keyboard namespace to the CursorKeys type. 

Because it's only a type in the code documentation, it doesn't have any impacts on the Phaser source code but it fixes the TypeScript definition generated during tsgen execution.