### PR TITLE
Tiled editor changed syntax of json export

### DIFF
--- a/src/tilemaps/Tileset.js
+++ b/src/tilemaps/Tileset.js
@@ -214,9 +214,11 @@ var Tileset = new Class({
     {
         if (!this.containsTileIndex(tileIndex)) { return null; }
 
-        if(!this.tileIndexMap){
+        if (!this.tileIndexMap)
+        {
             this.tileIndexMap = {};
-            for(var i = 0; i < this.tileData.length; i++){
+            for (var i = 0; i < this.tileData.length; i++)
+            {
                 this.tileIndexMap[this.tileData[i]['id']] = this.tileData[i];
             }
         }

--- a/src/tilemaps/Tileset.js
+++ b/src/tilemaps/Tileset.js
@@ -214,7 +214,14 @@ var Tileset = new Class({
     {
         if (!this.containsTileIndex(tileIndex)) { return null; }
 
-        return this.tileData[tileIndex - this.firstgid];
+        if(!this.tileIndexMap){
+            this.tileIndexMap = {};
+            for(var i = 0; i < this.tileData.length; i++){
+                this.tileIndexMap[this.tileData[i]['id']] = this.tileData[i];
+            }
+        }
+
+        return this.tileIndexMap[tileIndex - this.firstgid];
     },
 
     /**


### PR DESCRIPTION
Tiled editor changed syntax of json export, see 
http://www.html5gamedevs.com/topic/38729-unexpected-tiles-properties-syntax-in-the-latest-tiled/?tab=comments#comment-220919
this fix enables phaser 3 to read the new file format.

This PR fixes a bug

Description of changes:
Inside json export files generated by Tiled (https://www.mapeditor.org/) the data structure of element tilesets[i].tiles has changed from map to array. This fix recreates the map structure so that phaser can find the tiledata for a given tile index.