### PR TITLE
Fixed addKeys(string) whitespace issue

### DIFF
--- a/src/input/keyboard/KeyboardPlugin.js
+++ b/src/input/keyboard/KeyboardPlugin.js
@@ -345,7 +345,7 @@ var KeyboardPlugin = new Class({
             for (var i = 0; i < keys.length; i++)
             {
                 var currentKey = keys[i].trim();
-                if (currentKey) 
+                if (currentKey)
                 {
                     output[currentKey] = this.addKey(currentKey);
                 }

--- a/src/input/keyboard/KeyboardPlugin.js
+++ b/src/input/keyboard/KeyboardPlugin.js
@@ -344,8 +344,11 @@ var KeyboardPlugin = new Class({
 
             for (var i = 0; i < keys.length; i++)
             {
-                var current_key = keys[i].trim();
-                if (current_key) output[current_key] = this.addKey(current_key);
+                var currentKey = keys[i].trim();
+                if (currentKey) 
+                {
+                    output[currentKey] = this.addKey(currentKey);
+                }
             }
         }
         else

--- a/src/input/keyboard/KeyboardPlugin.js
+++ b/src/input/keyboard/KeyboardPlugin.js
@@ -344,7 +344,8 @@ var KeyboardPlugin = new Class({
 
             for (var i = 0; i < keys.length; i++)
             {
-                output[keys[i]] = this.addKey(keys[i]);
+                var current_key = keys[i].trim();
+                if (current_key) output[current_key] = this.addKey(current_key);
             }
         }
         else


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes an issue where `this.input.keyboard.addKeys("W, A, S, D");` would not run as expected because of the whitespace between commas and key values.

Describe the changes below:

Made a trivial addition - simply trimmed each key value to remove excess whitespaces before usage.