### PR TITLE
Modify resize() to change canvas style attribute too

### DIFF
--- a/src/renderer/canvas/CanvasRenderer.js
+++ b/src/renderer/canvas/CanvasRenderer.js
@@ -258,7 +258,7 @@ var CanvasRenderer = new Class({
             this.gameCanvas.style.width = (this.width / resolution) + 'px';
             this.gameCanvas.style.height = (this.height / resolution) + 'px';
         }
-        else 
+        else
         {
             this.gameCanvas.style.width = this.width + 'px';
             this.gameCanvas.style.height = this.height + 'px';

--- a/src/renderer/canvas/CanvasRenderer.js
+++ b/src/renderer/canvas/CanvasRenderer.js
@@ -258,6 +258,11 @@ var CanvasRenderer = new Class({
             this.gameCanvas.style.width = (this.width / resolution) + 'px';
             this.gameCanvas.style.height = (this.height / resolution) + 'px';
         }
+        else 
+        {
+            this.gameCanvas.style.width = this.width + 'px';
+            this.gameCanvas.style.height = this.height + 'px';
+        }
 
         //  Resizing a canvas will reset imageSmoothingEnabled (and probably other properties)
         if (this.scaleMode === ScaleModes.NEAREST)

--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -618,7 +618,7 @@ var WebGLRenderer = new Class({
             this.canvas.style.width = (this.width / resolution) + 'px';
             this.canvas.style.height = (this.height / resolution) + 'px';
         }
-        else 
+        else
         {
             this.canvas.style.width = this.width + 'px';
             this.canvas.style.height = this.height + 'px';

--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -618,6 +618,11 @@ var WebGLRenderer = new Class({
             this.canvas.style.width = (this.width / resolution) + 'px';
             this.canvas.style.height = (this.height / resolution) + 'px';
         }
+        else 
+        {
+            this.canvas.style.width = this.width + 'px';
+            this.canvas.style.height = this.height + 'px';
+        }
 
         gl.viewport(0, 0, this.width, this.height);
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

I modified resize() function WebGLRenderer and CanvasRenderer to solve issue #3928 .

Reason of that issue is original resize() function only change canvas size, not style's one.

This resize() change not only canvas size, but also canvas.style size.
