### PR TITLE
Adds Polygon.Perimeter and Polygon.GetPoints

### DIFF
--- a/src/geom/polygon/GetPoints.js
+++ b/src/geom/polygon/GetPoints.js
@@ -1,0 +1,71 @@
+/**
+ * @author       Richard Davey <rich@photonstorm.com>
+ * @copyright    2018 Photon Storm Ltd.
+ * @license      {@link https://github.com/photonstorm/phaser/blob/master/license.txt|MIT License}
+ */
+
+var Length = require('../line/Length');
+var Line = require('../line/Line');
+var Perimeter = require('./Perimeter');
+
+/**
+ * Returns an array of Point objects containing the coordinates of the points around the perimeter of the Polygon,
+ * based on the given quantity or stepRate values.
+ *
+ * @function Phaser.Geom.Polygon.GetPoints
+ * @since 3.12.0
+ *
+ * @param {Phaser.Geom.Polygon} polygon - The Polygon to get the points from.
+ * @param {integer} quantity - The amount of points to return. If a falsey value the quantity will be derived from the `stepRate` instead.
+ * @param {number} [stepRate] - Sets the quantity by getting the perimeter of the Polygon and dividing it by the stepRate.
+ * @param {array} [output] - An array to insert the points in to. If not provided a new array will be created.
+ *
+ * @return {Phaser.Geom.Point[]} An array of Point objects pertaining to the points around the perimeter of the Polygon.
+ */
+var GetPoints = function (polygon, quantity, stepRate, out)
+{
+    if (out === undefined) { out = []; }
+
+    var points = polygon.points;
+    var perimeter = Perimeter(polygon);
+
+    //  If quantity is a falsey value (false, null, 0, undefined, etc) then we calculate it based on the stepRate instead.
+    if (!quantity)
+    {
+        quantity = perimeter / stepRate;
+    }
+
+    for (var i = 0; i < quantity; i++)
+    {
+        var position = perimeter * (i / quantity);
+        var accumulatedPerimeter = 0;
+
+        for (var j = 0; j < points.length; j++)
+        {
+            var pointA = points[j];
+            var pointB = points[(j + 1) % points.length];
+            var line = new Line(
+                pointA.x,
+                pointA.y,
+                pointB.x,
+                pointB.y
+            );
+            var length = Length(line);
+
+            if (position < accumulatedPerimeter || position > accumulatedPerimeter + length)
+            {
+                accumulatedPerimeter += length;
+                continue;
+            }
+
+            var point = line.getPoint((position - accumulatedPerimeter) / length);
+            out.push(point);
+
+            break;
+        }
+    }
+
+    return out;
+};
+
+module.exports = GetPoints;

--- a/src/geom/polygon/Perimeter.js
+++ b/src/geom/polygon/Perimeter.js
@@ -1,0 +1,42 @@
+/**
+ * @author       Richard Davey <rich@photonstorm.com>
+ * @copyright    2018 Photon Storm Ltd.
+ * @license      {@link https://github.com/photonstorm/phaser/blob/master/license.txt|MIT License}
+ */
+
+var Length = require('../line/Length');
+var Line = require('../line/Line');
+
+/**
+ * Returns the perimeter of the given Polygon.
+ *
+ * @function Phaser.Geom.Polygon.Perimeter
+ * @since 3.12.0
+ *
+ * @param {Phaser.Geom.Polygon} polygon - The Polygon to get the perimeter of.
+ *
+ * @return {number} The perimeter of the Polygon.
+ */
+var Perimeter = function (polygon)
+{
+    var points = polygon.points;
+    var perimeter = 0;
+
+    for (var i = 0; i < points.length; i++)
+    {
+        var pointA = points[i];
+        var pointB = points[(i + 1) % points.length];
+        var line = new Line(
+            pointA.x,
+            pointA.y,
+            pointB.x,
+            pointB.y
+        );
+
+        perimeter += Length(line);
+    }
+
+    return perimeter;
+};
+
+module.exports = Perimeter;

--- a/src/geom/polygon/Polygon.js
+++ b/src/geom/polygon/Polygon.js
@@ -6,6 +6,7 @@
 
 var Class = require('../../utils/Class');
 var Contains = require('./Contains');
+var GetPoints = require('./GetPoints');
 
 /**
  * @classdesc
@@ -171,6 +172,11 @@ var Polygon = new Class({
         this.area = -sum * 0.5;
 
         return this.area;
+    },
+
+    getPoints: function (quantity, step, output)
+    {
+        return GetPoints(this, quantity, step, output);
     }
 
 });

--- a/src/geom/polygon/index.js
+++ b/src/geom/polygon/index.js
@@ -11,5 +11,6 @@ Polygon.Contains = require('./Contains');
 Polygon.ContainsPoint = require('./ContainsPoint');
 Polygon.GetAABB = require('./GetAABB');
 Polygon.GetNumberArray = require('./GetNumberArray');
+Polygon.Perimeter = require('./Perimeter');
 
 module.exports = Polygon;

--- a/src/geom/polygon/index.js
+++ b/src/geom/polygon/index.js
@@ -11,6 +11,7 @@ Polygon.Contains = require('./Contains');
 Polygon.ContainsPoint = require('./ContainsPoint');
 Polygon.GetAABB = require('./GetAABB');
 Polygon.GetNumberArray = require('./GetNumberArray');
+Polygon.GetPoints = require('./GetPoints');
 Polygon.Perimeter = require('./Perimeter');
 
 module.exports = Polygon;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

This adds `Perimeter` and `GetPoints` methods to `Polygon`.

