### PR TITLE
Fixed animation playReverse with yoyo flag

### DIFF
--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -583,14 +583,7 @@ var Animation = new Class({
             //  Yoyo? (happens before repeat)
             if (component._yoyo)
             {
-                if (component._reverse !== false)
-                {
-                    this.completeAnimation(component);
-                    return;
-                }
-                
-                component.forward = false;
-                this._updateAndGetNextTick(component, frame.prevFrame);
+                this._handleYoyoFrame(component, false);
             }
             else if (component.repeatCounter > 0)
             {
@@ -614,6 +607,37 @@ var Animation = new Class({
         {
             this._updateAndGetNextTick(component, frame.nextFrame);
         }
+    },
+
+    /**
+     * Handle the yoyo functionality in nextFrame and previousFrame methods.
+     *
+     * @method Phaser.Animations.Animation#_handleYoyoFrame
+     * @since 3.12.0
+     *
+     * @param {Phaser.GameObjects.Components.Animation} component - The Animation Component to advance.
+     * @param {bool} isReverse - Is animation in reverse mode? (Default: false)
+     */
+    _handleYoyoFrame: function (component, isReverse)
+    {
+        if (!isReverse) { isReverse = false; }
+
+        if (component._reverse === !isReverse && component.repeatCounter > 0)
+        {
+            component.forward = isReverse;
+            this.repeatAnimation(component);
+            return;
+        }
+
+        if (component._reverse !== isReverse && component.repeatCounter === 0)
+        {
+            this.completeAnimation(component);
+            return;
+        }
+        
+        component.forward = isReverse;
+        var frame = isReverse ? component.currentFrame.nextFrame : component.currentFrame.prevFrame;
+        this._updateAndGetNextTick(component, frame);
     },
 
     /**
@@ -649,21 +673,14 @@ var Animation = new Class({
 
             if (component._yoyo)
             {
-                if (component._reverse !== true)
-                {
-                    this.completeAnimation(component);
-                    return;
-                }
-                
-                component.forward = true;
-                this._updateAndGetNextTick(component, frame.nextFrame);
+                this._handleYoyoFrame(component, true);
             }
             else if (component.repeatCounter > 0)
             {
                 if (component._reverse && !component.forward)
                 {
                     component.currentFrame = this.getLastFrame();
-                    this._updateAndGetNextTick(component, component.currentFrame);
+                    this.repeatAnimation(component);
                 }
                 else
                 {

--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -583,6 +583,12 @@ var Animation = new Class({
             //  Yoyo? (happens before repeat)
             if (component._yoyo)
             {
+                if (component._reverse !== false)
+                {
+                    this.completeAnimation(component);
+                    return;
+                }
+                
                 component.forward = false;
                 this._updateAndGetNextTick(component, frame.prevFrame);
             }
@@ -643,6 +649,12 @@ var Animation = new Class({
 
             if (component._yoyo)
             {
+                if (component._reverse !== true)
+                {
+                    this.completeAnimation(component);
+                    return;
+                }
+                
                 component.forward = true;
                 this._updateAndGetNextTick(component, frame.nextFrame);
             }


### PR DESCRIPTION
Fixed a bug found by @Ben-Millions (#3837) that after "playReverse" implementation, the yoyo flag run the animation infinitely.

Fixed playReverse repeat, now playReverse respect the repeat number.

I tested it with @Ben-Millions [sample ](https://codepen.io/ben-millions/pen/XPpmZW) and my sample in [phaser3 examples](https://labs.phaser.io/view.html?src=src\animation\reverse%20animation.js&v=dev).

