### PR TITLE
Correct types for ArcadeImage#body, ArcadeSprite#body

### DIFF
--- a/src/physics/arcade/ArcadeImage.js
+++ b/src/physics/arcade/ArcadeImage.js
@@ -80,6 +80,16 @@ var ArcadeImage = new Class({
     function ArcadeImage (scene, x, y, texture, frame)
     {
         Image.call(this, scene, x, y, texture, frame);
+
+        /**
+         * This Game Object's Physics Body.
+         *
+         * @name Phaser.Physics.Arcade.Image#body
+         * @type {?(Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody)}
+         * @default null
+         * @since 3.0.0
+         */
+        this.body = null;
     }
 
 });

--- a/src/physics/arcade/ArcadeSprite.js
+++ b/src/physics/arcade/ArcadeSprite.js
@@ -85,10 +85,10 @@ var ArcadeSprite = new Class({
         Sprite.call(this, scene, x, y, texture, frame);
 
         /**
-         * If this Game Object is enabled for physics then this property will contain a reference to a Physics Body.
+         * This Game Object's Physics Body.
          *
          * @name Phaser.Physics.Arcade.Sprite#body
-         * @type {?Phaser.Physics.Arcade.Body}
+         * @type {?(Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody)}
          * @default null
          * @since 3.0.0
          */


### PR DESCRIPTION
This PR

* Updates the Documentation

ArcadeImage didn't declare its own [body](https://photonstorm.github.io/phaser3-docs/Phaser.Physics.Arcade.Image.html#body__anchor) property and I was getting errors trying to use it:

> Property 'velocity' does not exist on type 'object | Body | Body'. Property 'velocity' does not exist on type 'object'

I guess the `<object>` type for GameObject#body should either be removed or changed to `<any>`.