### PR TITLE
Allow matter js bodies to render their debug graphics individually

### DIFF
--- a/src/physics/matter-js/World.js
+++ b/src/physics/matter-js/World.js
@@ -728,7 +728,7 @@ var World = new Class({
         {
             if (!bodies[i].render.visible)
             {
-                return;
+                continue;
             }
 
             // Handle drawing both single bodies and compound bodies. If compound, draw both the


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR

* Fixes a bug

Describe the changes below:

This small change allows the debug graphics to be turned off and on individually for matter js bodies. Before this commit, if a body has their `render.visible` value set to false, it stops all subsequent debug graphics from rendering.
