### PR TITLE
fixed incorrect properties assignment in setTileScale method

### DIFF
--- a/src/gameobjects/tilesprite/TileSprite.js
+++ b/src/gameobjects/tilesprite/TileSprite.js
@@ -389,12 +389,12 @@ var TileSprite = new Class({
     {
         if (x !== undefined)
         {
-            this.tilePositionX = x;
+            this.tileScaleX = x;
         }
 
         if (y !== undefined)
         {
-            this.tilePositionY = y;
+            this.tileScaleY = y;
         }
 
         return this;


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

setTileScale method of the TileSprite game object now correctly set tileScale instead of tilePosition