### PR TITLE
Add support for setting float array uniforms in the WebGLPipeline / WebGLRenderer

### DIFF
--- a/src/renderer/webgl/WebGLPipeline.js
+++ b/src/renderer/webgl/WebGLPipeline.js
@@ -546,7 +546,7 @@ var WebGLPipeline = new Class({
     /**
      * Set a uniform value of the current pipeline program.
      *
-     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat1
+     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat1v
      * @since 3.2.0
      *
      * @param {string} name - [description]
@@ -564,7 +564,7 @@ var WebGLPipeline = new Class({
     /**
      * Set a uniform value of the current pipeline program.
      *
-     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat2
+     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat2v
      * @since 3.2.0
      *
      * @param {string} name - [description]
@@ -582,7 +582,7 @@ var WebGLPipeline = new Class({
     /**
      * Set a uniform value of the current pipeline program.
      *
-     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat3
+     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat3v
      * @since 3.2.0
      *
      * @param {string} name - [description]
@@ -600,7 +600,7 @@ var WebGLPipeline = new Class({
     /**
      * Set a uniform value of the current pipeline program.
      *
-     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat4
+     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat4v
      * @since 3.2.0
      *
      * @param {string} name - Name of the uniform

--- a/src/renderer/webgl/WebGLPipeline.js
+++ b/src/renderer/webgl/WebGLPipeline.js
@@ -10,12 +10,12 @@ var Utils = require('./Utils');
 
 /**
  * @classdesc
- * WebGLPipeline is a class that describes the way elements will be rendererd 
- * in WebGL, specially focused on batching vertices (batching is not provided). 
- * Pipelines are mostly used for describing 2D rendering passes but it's 
- * flexible enough to be used for any type of rendering including 3D. 
+ * WebGLPipeline is a class that describes the way elements will be rendererd
+ * in WebGL, specially focused on batching vertices (batching is not provided).
+ * Pipelines are mostly used for describing 2D rendering passes but it's
+ * flexible enough to be used for any type of rendering including 3D.
  * Internally WebGLPipeline will handle things like compiling shaders,
- * creating vertex buffers, assigning primitive topology and binding 
+ * creating vertex buffers, assigning primitive topology and binding
  * vertex attributes.
  *
  * The config properties are:
@@ -30,7 +30,7 @@ var Utils = require('./Utils');
  * - vertexSize: The size of a single vertex in bytes.
  * - vertices: An optional buffer of vertices
  * - attributes: An array describing the vertex attributes
- *  
+ *
  * The vertex attributes properties are:
  * - name : String - Name of the attribute in the vertex shader
  * - size : integer - How many components describe the attribute. For ex: vec3 = size of 3, float = size of 1
@@ -240,7 +240,7 @@ var WebGLPipeline = new Class({
 
     /**
      * Called when the Game has fully booted and the Renderer has finished setting up.
-     * 
+     *
      * By this stage all Game level systems are now in place and you can perform any final
      * tasks that the pipeline may need that relied on game systems such as the Texture Manager.
      *
@@ -539,6 +539,78 @@ var WebGLPipeline = new Class({
     setFloat4: function (name, x, y, z, w)
     {
         this.renderer.setFloat4(this.program, name, x, y, z, w);
+
+        return this;
+    },
+
+    /**
+     * Set a uniform value of the current pipeline program.
+     *
+     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat1
+     * @since 3.2.0
+     *
+     * @param {string} name - [description]
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLPipeline} [description]
+     */
+    setFloat1v: function (name, arr)
+    {
+        this.renderer.setFloat1v(this.program, name, arr);
+
+        return this;
+    },
+
+    /**
+     * Set a uniform value of the current pipeline program.
+     *
+     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat2
+     * @since 3.2.0
+     *
+     * @param {string} name - [description]
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLPipeline} [description]
+     */
+    setFloat2v: function (name, arr)
+    {
+        this.renderer.setFloat2v(this.program, name, arr);
+
+        return this;
+    },
+
+    /**
+     * Set a uniform value of the current pipeline program.
+     *
+     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat3
+     * @since 3.2.0
+     *
+     * @param {string} name - [description]
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLPipeline} [description]
+     */
+    setFloat3v: function (name, arr)
+    {
+        this.renderer.setFloat3v(this.program, name, arr);
+
+        return this;
+    },
+
+    /**
+     * Set a uniform value of the current pipeline program.
+     *
+     * @method Phaser.Renderer.WebGL.WebGLPipeline#setFloat4
+     * @since 3.2.0
+     *
+     * @param {string} name - Name of the uniform
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLPipeline} [description]
+     */
+    setFloat4v: function (name, arr)
+    {
+        this.renderer.setFloat4v(this.program, name, arr);
 
         return this;
     },

--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -1869,90 +1869,6 @@ var WebGLRenderer = new Class({
      *
      * @param {WebGLProgram} program - [description]
      * @param {string} name - [description]
-     * @param {array} arr - [description]
-     *
-     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
-     */
-    setFloat1v: function (program, name, arr)
-    {
-        this.setProgram(program);
-
-        this.gl.uniform1fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
-
-        return this;
-    },
-
-    /**
-     * [description]
-     *
-     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat2
-     * @since 3.0.0
-     *
-     * @param {WebGLProgram} program - [description]
-     * @param {string} name - [description]
-     * @param {array} arr - [description]
-     *
-     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
-     */
-    setFloat2v: function (program, name, arr)
-    {
-        this.setProgram(program);
-
-        this.gl.uniform2fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
-
-        return this;
-    },
-
-    /**
-     * [description]
-     *
-     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat3
-     * @since 3.0.0
-     *
-     * @param {WebGLProgram} program - [description]
-     * @param {string} name - [description]
-     * @param {array} arr - [description]
-     *
-     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
-     */
-    setFloat3v: function (program, name, arr)
-    {
-        this.setProgram(program);
-
-        this.gl.uniform3fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
-
-        return this;
-    },
-
-    /**
-     * Sets uniform of a WebGLProgram
-     *
-     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat4
-     * @since 3.0.0
-     *
-     * @param {WebGLProgram} program - Target program
-     * @param {string} name - Name of the uniform
-     * @param {array} arr - [description]
-     *
-     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
-     */
-    setFloat4v: function (program, name, arr)
-    {
-        this.setProgram(program);
-
-        this.gl.uniform4fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
-
-        return this;
-    },
-
-    /**
-     * [description]
-     *
-     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat1
-     * @since 3.0.0
-     *
-     * @param {WebGLProgram} program - [description]
-     * @param {string} name - [description]
      * @param {number} x - [description]
      *
      * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
@@ -2031,6 +1947,91 @@ var WebGLRenderer = new Class({
         this.setProgram(program);
 
         this.gl.uniform4f(this.gl.getUniformLocation(program, name), x, y, z, w);
+
+        return this;
+    },
+
+    /**
+     * [description]
+     *
+     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat1v
+     * @since 3.0.0
+     *
+     * @param {WebGLProgram} program - [description]
+     * @param {string} name - [description]
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
+     */
+    setFloat1v: function (program, name, arr)
+    {
+        this.setProgram(program);
+
+        this.gl.uniform1fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
+
+        return this;
+    },
+
+    /**
+     * [description]
+     *
+     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat2v
+     * @since 3.0.0
+     *
+     * @param {WebGLProgram} program - [description]
+     * @param {string} name - [description]
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
+     */
+    setFloat2v: function (program, name, arr)
+    {
+        this.setProgram(program);
+
+        this.gl.uniform2fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
+
+        return this;
+    },
+
+    /**
+     * [description]
+     *
+     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat3v
+     * @since 3.0.0
+     *
+     * @param {WebGLProgram} program - [description]
+     * @param {string} name - [description]
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
+     */
+    setFloat3v: function (program, name, arr)
+    {
+        this.setProgram(program);
+
+        this.gl.uniform3fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
+
+        return this;
+    },
+
+    /**
+     * Sets uniform of a WebGLProgram
+     *
+     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat4v
+     * @since 3.0.0
+     *
+     * @param {WebGLProgram} program - Target program
+     * @param {string} name - Name of the uniform
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
+     */
+
+    setFloat4v: function (program, name, arr)
+    {
+        this.setProgram(program);
+
+        this.gl.uniform4fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
 
         return this;
     },

--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -40,7 +40,7 @@ var TextureTintPipeline = require('./pipelines/TextureTintPipeline');
  * any context change that happens for WebGL rendering inside of Phaser. This means
  * if raw webgl functions are called outside the WebGLRenderer of the Phaser WebGL
  * rendering ecosystem they might pollute the current WebGLRenderingContext state producing
- * unexpected behavior. It's recommended that WebGL interaction is done through 
+ * unexpected behavior. It's recommended that WebGL interaction is done through
  * WebGLRenderer and/or WebGLPipeline.
  *
  * @class WebGLRenderer
@@ -535,13 +535,13 @@ var WebGLRenderer = new Class({
         this.compression.ETC1 = gl.getExtension(extString + 'etc1') || gl.getExtension(wkExtString + 'etc1');
         this.compression.PVRTC = gl.getExtension(extString + 'pvrtc') || gl.getExtension(wkExtString + 'pvrtc');
         this.compression.S3TC = gl.getExtension(extString + 's3tc') || gl.getExtension(wkExtString + 's3tc');
-        
+
         this.supportedExtensions = exts;
 
         // Setup initial WebGL state
         gl.disable(gl.DEPTH_TEST);
         gl.disable(gl.CULL_FACE);
-        
+
         // gl.disable(gl.SCISSOR_TEST);
 
         gl.enable(gl.BLEND);
@@ -626,7 +626,7 @@ var WebGLRenderer = new Class({
         {
             pipelines[pipelineName].resize(width, height, resolution);
         }
-        
+
         this.drawingBufferHeight = gl.drawingBufferHeight;
 
         this.defaultCamera.setSize(width, height);
@@ -817,7 +817,7 @@ var WebGLRenderer = new Class({
         var scissorStack = this.scissorStack;
 
         var scissor = [ x, y, w, h ];
-        
+
         scissorStack.push(scissor);
 
         this.setScissor(x, y, w, h);
@@ -868,7 +868,7 @@ var WebGLRenderer = new Class({
         var scissorStack = this.scissorStack;
 
         var scissor = scissorStack.pop();
-       
+
         this.setScissor(scissor[0], scissor[1], scissor[2], scissor[3]);
 
         this.currentScissor = scissor;
@@ -1015,7 +1015,7 @@ var WebGLRenderer = new Class({
      * @method Phaser.Renderer.WebGL.WebGLRenderer#setBlankTexture
      * @private
      * @since 3.12.0
-     * 
+     *
      * @param {boolean} [force=false] - Force a blank texture set, regardless of what's already bound?
      *
      * @return {Phaser.Renderer.WebGL.WebGLRenderer} This WebGL Renderer.
@@ -1031,7 +1031,7 @@ var WebGLRenderer = new Class({
     },
 
     /**
-     * Binds a texture at a texture unit. If a texture is already 
+     * Binds a texture at a texture unit. If a texture is already
      * bound to that unit it will force a flush on the current pipeline.
      *
      * @method Phaser.Renderer.WebGL.WebGLRenderer#setTexture2D
@@ -1300,7 +1300,7 @@ var WebGLRenderer = new Class({
      *
      * @param {integer} width - Width in pixels of the framebuffer
      * @param {integer} height - Height in pixels of the framebuffer
-     * @param {WebGLTexture} renderTexture - The color texture to where the color pixels are written 
+     * @param {WebGLTexture} renderTexture - The color texture to where the color pixels are written
      * @param {boolean} addDepthStencilBuffer - Indicates if the current framebuffer support depth and stencil buffers
      *
      * @return {WebGLFramebuffer} Raw WebGLFramebuffer
@@ -1547,9 +1547,9 @@ var WebGLRenderer = new Class({
             this.setFramebuffer(camera.framebuffer);
 
             var gl = this.gl;
-        
+
             gl.clearColor(0, 0, 0, 0);
-    
+
             gl.clear(gl.COLOR_BUFFER_BIT);
 
             TextureTintPipeline.projOrtho(cx, cw + cx, cy, ch + cy, -1000, 1000);
@@ -1611,7 +1611,7 @@ var WebGLRenderer = new Class({
             var getTint = Utils.getTintAppendFloatAlpha;
 
             var pipeline = (camera.pipeline) ? camera.pipeline : TextureTintPipeline;
-       
+
             pipeline.batchTexture(
                 camera,
                 camera.glTexture,
@@ -1857,6 +1857,90 @@ var WebGLRenderer = new Class({
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, glFilter);
 
         this.setTexture2D(null, 0);
+
+        return this;
+    },
+
+    /**
+     * [description]
+     *
+     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat1
+     * @since 3.0.0
+     *
+     * @param {WebGLProgram} program - [description]
+     * @param {string} name - [description]
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
+     */
+    setFloat1v: function (program, name, arr)
+    {
+        this.setProgram(program);
+
+        this.gl.uniform1fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
+
+        return this;
+    },
+
+    /**
+     * [description]
+     *
+     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat2
+     * @since 3.0.0
+     *
+     * @param {WebGLProgram} program - [description]
+     * @param {string} name - [description]
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
+     */
+    setFloat2v: function (program, name, arr)
+    {
+        this.setProgram(program);
+
+        this.gl.uniform2fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
+
+        return this;
+    },
+
+    /**
+     * [description]
+     *
+     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat3
+     * @since 3.0.0
+     *
+     * @param {WebGLProgram} program - [description]
+     * @param {string} name - [description]
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
+     */
+    setFloat3v: function (program, name, arr)
+    {
+        this.setProgram(program);
+
+        this.gl.uniform3fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
+
+        return this;
+    },
+
+    /**
+     * Sets uniform of a WebGLProgram
+     *
+     * @method Phaser.Renderer.WebGL.WebGLRenderer#setFloat4
+     * @since 3.0.0
+     *
+     * @param {WebGLProgram} program - Target program
+     * @param {string} name - Name of the uniform
+     * @param {array} arr - [description]
+     *
+     * @return {Phaser.Renderer.WebGL.WebGLRenderer} [description]
+     */
+    setFloat4v: function (program, name, arr)
+    {
+        this.setProgram(program);
+
+        this.gl.uniform4fv(this.gl.getUniformLocation(program, name), new Float32Array(arr));
 
         return this;
     },


### PR DESCRIPTION
This PR
* Adds a new feature

Describe the changes below:

Added support for setting float array uniforms. There are 4 new methods on both the WebGLRenderer and WebGLPipeline

* setFloat1v
* setFloat2v
* setFloat3v
* setFloat4v

P.S.
My editor decided to remove some trailing spaces in the files I edited. According to the contribution guide we don't like trailing spaces anyways, so I left the changes in :) If you would like me to revert those lines back to how they were for any reason please let me know and I can take care of that.

