### PR TITLE
Fix game object memory leak

### DIFF
--- a/src/gameobjects/GameObject.js
+++ b/src/gameobjects/GameObject.js
@@ -560,6 +560,8 @@ var GameObject = new Class({
 
         //  Tell the Scene to re-sort the children
         sys.queueDepthSort();
+        
+        this.scene.sys.events.off('shutdown', this.destroy, this);
 
         this.active = false;
         this.visible = false;


### PR DESCRIPTION
When calling `destroy` directly on a game object, the `shutdown` event for this game object on the scene never gets turned off, thus leading to a memory leak. I wasn't 100% sure if this is where/how this should be done, but it seems to be working for us in our testing.