### PR TITLE
Wrong filling rectangle for camera with background

### DIFF
--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -1568,7 +1568,7 @@ var WebGLRenderer = new Class({
             this.pushScissor(cx, cy, cw, ch);
 
             TextureTintPipeline.drawFillRect(
-                0, 0, cw + cx, ch + cy,
+                cx, cy, cw , ch,
                 Utils.getTintFromFloats(color.redGL, color.greenGL, color.blueGL, 1),
                 color.alphaGL
             );


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
After some changes related to scissor the camera background is displaced.
Bug can be reproduced in https://labs.phaser.io/view.html?src=src\camera\minimap%20camera.js from 3.12.0 version.

