### PR TITLE
Add setMaxSpeed() function.

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -421,6 +421,17 @@ var Body = new Class({
         this.maxVelocity = new Vector2(10000, 10000);
 
         /**
+         * The Body's maximum speed.
+         * 
+         * This limits Body's scalar value of speed. Always positive value.
+         * 
+         * Negative value means that there is no limitation on speed.
+         * 
+         *  
+         */
+        this.maxSpeed = -1;
+
+        /**
          * If this Body is `immovable` and in motion, this the proportion of this Body's movement received by the riding body on each axis, relative to 1.
          * The default value (1, 0) moves the riding body horizontally in equal proportion and vertically not at all.
          *
@@ -1515,6 +1526,22 @@ var Body = new Class({
     setMaxVelocity: function (x, y)
     {
         this.maxVelocity.set(x, y);
+
+        return this;
+    },
+
+    /**
+     * Sets the Body's maximum speed(Scalar value).
+     * 
+     * @method Phaser.Physics.Arcade.Body#setMaxSpeed
+     * @since 3.13.0
+     * 
+     * @param {number} s - The max speed value, in pixels per second. 
+     * 
+     * @return {Phaser.Physics.Arcade.Body} This Body Object.
+     */
+    setMaxSpeed: function (s){
+        this.maxSpeed = s;
 
         return this;
     },

--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -427,7 +427,9 @@ var Body = new Class({
          * 
          * Negative value means that there is no limitation on speed.
          * 
-         *  
+         * @name Phaser.Physics.Arcade.Body#maxSpeed
+         * @type {number}
+         * @since 3.13.0 
          */
         this.maxSpeed = -1;
 

--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -423,7 +423,7 @@ var Body = new Class({
         /**
          * The Body's maximum speed.
          * 
-         * This limits Body's scalar value of speed. Always positive value.
+         * This limits Body's scalar value of speed. Always has positive value.
          * 
          * Negative value means that there is no limitation on speed.
          * 
@@ -1533,7 +1533,7 @@ var Body = new Class({
     },
 
     /**
-     * Sets the Body's maximum speed(Scalar value).
+     * Sets the maximum scalar value of Body's velocity.
      * 
      * @method Phaser.Physics.Arcade.Body#setMaxSpeed
      * @since 3.13.0

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1270,6 +1270,8 @@ var World = new Class({
         var maxY = body.maxVelocity.y;
 
         var speed = body.speed;
+        var maxSpeed = body.maxSpeed;
+        var newSpeed = 0;
         var allowDrag = body.allowDrag;
         var useDamping = body.useDamping;
 
@@ -1354,7 +1356,16 @@ var World = new Class({
         velocityX = Clamp(velocityX, -maxX, maxX);
         velocityY = Clamp(velocityY, -maxY, maxY);
 
-        body.velocity.set(velocityX, velocityY);
+        newSpeed = Math.sqrt(velocityX * velocityX + velocityY * velocityY);
+        if(maxSpeed >= 0 && FuzzyGreaterThan(newSpeed, maxSpeed, 0.001))
+        {
+            body.velocity.set(velocityX / newSpeed * maxSpeed, velocityY / newSpeed * maxSpeed);
+        }
+        else
+        {
+            body.velocity.set(velocityX, velocityY);
+        }
+        
     },
 
     /**


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

I added setMaxSpeed() function requested on #4000 issue.

This function limits vector length of arcade physics body's velocity. I implemented it by checking vector length of new velocity value when Physics.Arcade.World  computes velocity.

if it has maxSpeed value and new vector length is greater than max speed value, it decrease new velocity's X and Y value to fit max speed. formula used for this is based on trigonometric function so change of vector's direction from change of value is applied as normally.

