### PR TITLE
Use defaultStrokeWidth in Arcade.Body#drawDebug()

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1386,7 +1386,7 @@ var Body = new Class({
 
         if (this.debugShowBody)
         {
-            graphic.lineStyle(1, this.debugBodyColor);
+            graphic.lineStyle(graphic.defaultStrokeWidth, this.debugBodyColor);
 
             if (this.isCircle)
             {
@@ -1400,7 +1400,7 @@ var Body = new Class({
 
         if (this.debugShowVelocity)
         {
-            graphic.lineStyle(1, this.world.defaults.velocityDebugColor, 1);
+            graphic.lineStyle(graphic.defaultStrokeWidth, this.world.defaults.velocityDebugColor, 1);
             graphic.lineBetween(x, y, x + this.velocity.x / 2, y + this.velocity.y / 2);
         }
     },


### PR DESCRIPTION
This PR

* Adds a new feature

This lets you modify `this.physics.world.debugGraphic.defaultStrokeWidth` to alter the debug display.