### PR TITLE
Fix null game.context after WebGLRenderer init

### DIFF
--- a/src/boot/CreateRenderer.js
+++ b/src/boot/CreateRenderer.js
@@ -97,9 +97,6 @@ var CreateRenderer = function (game)
         if (config.renderType === CONST.WEBGL)
         {
             game.renderer = new WebGLRenderer(game);
-
-            //  The WebGL Renderer sets this value during its init, not on construction
-            game.context = null;
         }
         else
         {
@@ -116,9 +113,6 @@ var CreateRenderer = function (game)
         config.renderType = CONST.WEBGL;
 
         game.renderer = new WebGLRenderer(game);
-
-        //  The WebGL Renderer sets this value during its init, not on construction
-        game.context = null;
     }
 
     if (!typeof WEBGL_RENDERER && typeof CANVAS_RENDERER)


### PR DESCRIPTION
This PR

* Fixes a bug

`game.context` was always null even after `game.renderer.gl` was created.

I guess WebGLRenderer#init() used to be run later, but now it's run immediately during construction.