### PR TITLE
Tween inside Timeline fix

### DIFF
--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -901,8 +901,16 @@ var Tween = new Class({
         {
             if (this.state === TWEEN_CONST.PAUSED || this.state === TWEEN_CONST.PENDING_ADD)
             {
-                this.parent._destroy.push(this);
-                this.parent._toProcess++;
+                if (this.parentIsTimeline)
+                {
+                    this.parent.manager._destroy.push(this);
+                    this.parent.manager._toProcess++;
+                }
+                else
+                {
+                    this.parent._destroy.push(this);
+                    this.parent._toProcess++;
+                }
             }
 
             this.state = TWEEN_CONST.PENDING_REMOVE;


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

The stop method in Tween assumed, that tween's parent was TweenManager. If the Tween has been added to the Timeline, that was not true and the stop method crashed.