### PR TITLE
Make Texture.add() firstFrame check more explicit (Fix issue #4088)

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -154,7 +154,7 @@ var Texture = new Class({
         //  This is used to ensure we don't spam the display with entire
         //  atlases of sprite sheets, but instead just the first frame of them
         //  should the dev incorrectly specify the frame index
-        if (this.frameTotal === 1)
+        if (this.firstFrame === '__BASE')
         {
             this.firstFrame = name;
         }


### PR DESCRIPTION
Fixes issue #4088 where a SpriteSheet created from a trimmed texture atlas frame returns the second frame when the first frame is requested.

This PR
* Fixes a bug

Describe the changes below:
-Made simple change to `Texture.add()` that will prevent the second frame from being selected as the `firstFrame` in the event that __BASE texture does not exist.
