### PR TITLE
Improved trim handling for Spritesheets created from trimmed Texture Atlas Frames

### DIFF
--- a/src/textures/parsers/SpriteSheetFromAtlas.js
+++ b/src/textures/parsers/SpriteSheetFromAtlas.js
@@ -117,26 +117,32 @@ var SpriteSheetFromAtlas = function (texture, frame, config)
             {
                 var destX = (leftRow) ? leftPad : 0;
                 var destY = (topRow) ? topPad : 0;
-                var destWidth = frameWidth;
-                var destHeight = frameHeight;
+
+                var trimWidth = 0;
+                var trimHeight = 0;
 
                 if (leftRow)
                 {
-                    destWidth = leftWidth;
+                    trimWidth += (frameWidth - leftWidth);
                 }
-                else if (rightRow)
+
+                if (rightRow)
                 {
-                    destWidth = rightWidth;
+                    trimWidth += (frameWidth - rightWidth);
                 }
 
                 if (topRow)
                 {
-                    destHeight = topHeight;
+                    trimHeight += (frameHeight - topHeight);
                 }
-                else if (bottomRow)
+
+                if (bottomRow)
                 {
-                    destHeight = bottomHeight;
+                    trimHeight += (frameHeight - bottomHeight);
                 }
+
+                var destWidth = frameWidth - trimWidth;
+                var destHeight = frameHeight - trimHeight;
 
                 sheetFrame.cutWidth = destWidth;
                 sheetFrame.cutHeight = destHeight;
@@ -152,7 +158,7 @@ var SpriteSheetFromAtlas = function (texture, frame, config)
             }
             else if (rightRow)
             {
-                frameX += rightRow;
+                frameX += rightWidth;
             }
             else
             {


### PR DESCRIPTION
This PR
* Fixes a bug

Describe the changes below:
Fixes issue #4096 by modifying the calculation method for spritesheet frame sizes in `Parsers.SpriteSheetFromAtlas()`.
Previously the calculation method did not handle the case where `topRow && bottomRow` or `leftRow && rightRow` for a single frame, causing problems when a spritesheet was single-row or single-column. One more corner case covered, eh?

Also fixed an apparent typo on line 155 where the `rightRow` bool was being added to `frameX` instead of the correct `rightWidth` value. (Trivial)