### PR TITLE
Text style setStyle/setFont fix

### DIFF
--- a/src/gameobjects/text/TextStyle.js
+++ b/src/gameobjects/text/TextStyle.js
@@ -519,7 +519,7 @@ var TextStyle = new Class({
     setFont: function (font, updateText)
     {
         if (updateText === undefined) { updateText = true; }
-        
+
         var fontFamily = font;
         var fontSize = '';
         var fontStyle = '';
@@ -544,7 +544,7 @@ var TextStyle = new Class({
             this.fontFamily = fontFamily;
             this.fontSize = fontSize;
             this.fontStyle = fontStyle;
-            
+
             if (updateText)
             {
                 this.update(true);

--- a/src/gameobjects/text/TextStyle.js
+++ b/src/gameobjects/text/TextStyle.js
@@ -396,7 +396,7 @@ var TextStyle = new Class({
         {
             this.setFont(font, false);
         }
-		this._font = [ this.fontStyle, this.fontSize, this.fontFamily ].join(' ').trim();
+        this._font = [ this.fontStyle, this.fontSize, this.fontFamily ].join(' ').trim();
 
         //  Allow for 'fill' to be used in place of 'color'
         var fill = GetValue(style, 'fill', null);

--- a/src/gameobjects/text/TextStyle.js
+++ b/src/gameobjects/text/TextStyle.js
@@ -392,16 +392,11 @@ var TextStyle = new Class({
         //  Allow for 'font' override
         var font = GetValue(style, 'font', null);
 
-        if (font === null)
+        if (font !== null)
         {
-            this._font = [ this.fontStyle, this.fontSize, this.fontFamily ].join(' ').trim();
-        }
-        else
-        {
-            this._font = font;
-            
             this.setFont(font, false);
         }
+		this._font = [ this.fontStyle, this.fontSize, this.fontFamily ].join(' ').trim();
 
         //  Allow for 'fill' to be used in place of 'color'
         var fill = GetValue(style, 'fill', null);
@@ -539,12 +534,9 @@ var TextStyle = new Class({
         {
             var fontSplit = font.split(' ');
             var i = 0;
-            if (fontSplit.length > 2)
-            {
-                this.fontStyle = fontSplit[i++];
-            }
-            this.fontSize = fontSplit[i++] || this.fontSize;
-            this.fontFamily = fontSplit[i++] || this.fontFamily;
+            this.fontStyle = fontSplit.length > 2 ? fontSplit[i++] : '';
+            this.fontSize = fontSplit[i++] || '16px';
+            this.fontFamily = fontSplit[i++] || 'Courier';
         }
 
         if (fontFamily !== this.fontFamily || fontSize !== this.fontSize || fontStyle !== this.fontStyle)

--- a/src/gameobjects/text/TextStyle.js
+++ b/src/gameobjects/text/TextStyle.js
@@ -399,6 +399,8 @@ var TextStyle = new Class({
         else
         {
             this._font = font;
+            
+            this.setFont(font, false);
         }
 
         //  Allow for 'fill' to be used in place of 'color'
@@ -515,11 +517,14 @@ var TextStyle = new Class({
      * @since 3.0.0
      *
      * @param {(string|object)} font - The font family or font settings to set.
+     * @param {boolean} [updateText=true] - Whether to update the text immediately.
      *
      * @return {Phaser.GameObjects.Text} The parent Text object.
      */
-    setFont: function (font)
+    setFont: function (font, updateText)
     {
+        if (updateText === undefined) { updateText = true; }
+        
         var fontFamily = font;
         var fontSize = '';
         var fontStyle = '';
@@ -530,14 +535,28 @@ var TextStyle = new Class({
             fontSize = GetValue(font, 'fontSize', '16px');
             fontStyle = GetValue(font, 'fontStyle', '');
         }
+        else
+        {
+            var fontSplit = font.split(' ');
+            var i = 0;
+            if (fontSplit.length > 2)
+            {
+                this.fontStyle = fontSplit[i++];
+            }
+            this.fontSize = fontSplit[i++] || this.fontSize;
+            this.fontFamily = fontSplit[i++] || this.fontFamily;
+        }
 
         if (fontFamily !== this.fontFamily || fontSize !== this.fontSize || fontStyle !== this.fontStyle)
         {
             this.fontFamily = fontFamily;
             this.fontSize = fontSize;
             this.fontStyle = fontStyle;
-    
-            this.update(true);
+            
+            if (updateText)
+            {
+                this.update(true);
+            }
         }
 
         return this.parent;


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation
* Fixes a bug

Describe the changes below:

When using a font string instead of setting ``fontFamily``, ``fontSize``, and ``fontStyle`` in either setStyle or setFont, the fields  ``fontFamily``, ``fontSize``, and ``fontStyle`` wouldn't get set. This isn't a problem while creating the text object because TextStyle.update won't get called, which sets TextStyle._font to said fields. (``this._font = [ this.fontStyle, this.fontSize, this.fontFamily ].join(' ').trim();``)
