### PR TITLE
Fix Phaser.GameObjects.Shape#setStrokeStyle JSDoc

### DIFF
--- a/src/gameobjects/shape/Shape.js
+++ b/src/gameobjects/shape/Shape.js
@@ -231,6 +231,7 @@ var Shape = new Class({
      * @method Phaser.GameObjects.Shape#setStrokeStyle
      * @since 3.13.0
      * 
+     * @param {number} [lineWidth] - The width of line to stroke with. If not provided or undefined the Shape will not be stroked.
      * @param {number} [color] - The color used to stroke this shape. If not provided the Shape will not be stroked.
      * @param {number} [alpha=1] - The alpha value used when stroking this shape, if a stroke color is given.
      *


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation
* Fixes a bug

Describe the changes below:

This should fix TypeScript definitions, that at the moment lead to an unexpected behavior (cause color is passed instead of a line width).

At the moment definition looks like this:
```setStrokeStyle(color?: number, alpha?: number): this;```

and hopefully will look like this:
```setStrokeStyle(lineWidth?: number, color?: number, alpha?: number): this;```

At the moment inside IDE:
<img width="679" alt="image" src="https://user-images.githubusercontent.com/2737310/46910754-70b15700-cf4a-11e8-8a51-bf8a16bcb5d2.png">
