### PR TITLE
Fix issue with null config in Arcade PhysicsGroup constructor

### DIFF
--- a/src/physics/arcade/PhysicsGroup.js
+++ b/src/physics/arcade/PhysicsGroup.js
@@ -121,6 +121,14 @@ var PhysicsGroup = new Class({
                 singleConfig.removeCallback = this.removeCallbackHandler;
             });
         }
+        else
+        {
+            // config is not defined and children is not a plain object nor an array of plain objects
+            config = {
+                createCallback: this.createCallbackHandler,
+                removeCallback: this.removeCallbackHandler
+            }
+        }
 
         /**
          * The physics simulation.


### PR DESCRIPTION
# This PR

* Fixes a bug

# Describe the changes below:

This code was crashing:

```javascript
    const monsterGroup = this.physics.add.group(this.monsters);
```

with the following stacktrace:

![image](https://user-images.githubusercontent.com/6313316/47052777-29290600-d1aa-11e8-9f6c-53fadffc16fb.png)

It turns out the case were the config is null was not properly handled.

The execution reached this instruction without going through any of the if cases! So `config` was simply `undefined`, which leads to a crash.

![image](https://user-images.githubusercontent.com/6313316/47052812-5a093b00-d1aa-11e8-9801-d4db3505a899.png)
