### PR TITLE
Pick up animation data from Tiled 1.2+

### DIFF
--- a/src/tilemaps/parsers/tiled/ParseTilesets.js
+++ b/src/tilemaps/parsers/tiled/ParseTilesets.js
@@ -78,6 +78,16 @@ var ParseTilesets = function (json)
                                 tiles[tile.id].objectgroup.objects = parsedObjects2;
                             }
                         }
+
+                        // Copy animation data
+                        if(tile.animation) {
+                            if(tiles.hasOwnProperty(tile.id)){
+                                tiles[tile.id].animation = tile.animation;
+                            }
+                            else {
+                                tiles[tile.id] = { animation: tile.animation };
+                            }
+                        }
                     }
 
                     newSet.tileData = tiles;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Animation data was lost in the parser of Tiled 1.2+. I'm unaware what the objectgroup property is and if it can coexist with the animation property so I played safe. If it can't coexist the test in the if could be removed:

// Copy animation data
if(tile.animation) {
tiles[tile.id] = { animation: tile.animation };    
}