### PR TITLE
JSDocs wrong Boolean on checkCollision description

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -644,7 +644,7 @@ var Body = new Class({
 
         /**
          * Whether this Body is checked for collisions and for which directions.
-         * You can set `checkCollision.none = false` to disable collision checks.
+         * You can set `checkCollision.none = true` to disable collision checks.
          *
          * @name Phaser.Physics.Arcade.Body#checkCollision
          * @type {ArcadeBodyCollision}


### PR DESCRIPTION
This PR (delete as applicable)
* Updates the Documentation

Describe the changes below:
L647 "checkCollision.none = false to disable collision checks" this is false way description, changed to "= true"
As of pull request: photonstorm/phaser3-docs#75
