### PR TITLE
Add forgotten keycode and letters

### DIFF
--- a/src/input/keyboard/keys/KeyCodes.js
+++ b/src/input/keyboard/keys/KeyCodes.js
@@ -6,7 +6,7 @@
 
 /**
  * Keyboard Codes.
- * 
+ *
  * @name Phaser.Input.Keyboard.KeyCodes
  * @enum {integer}
  * @memberof Phaser.Input.Keyboard
@@ -464,8 +464,32 @@ var KeyCodes = {
     /**
      * @name Phaser.Input.Keyboard.KeyCodes.CLOSED_BRACKET
      */
-    CLOSED_BRACKET: 221
+    CLOSED_BRACKET: 221,
 
+    /**
+     * @name Phaser.Input.Keyboard.KeyCodes.SEMICOLON_FIREFOX
+     */
+    SEMICOLON_FIREFOX: 59,
+
+    /**
+     * @name Phaser.Input.Keyboard.KeyCodes.COLON
+     */
+    COLON: 58,
+
+    /**
+     * @name Phaser.Input.Keyboard.KeyCodes.COMMA_FIREFOX
+     */
+    COMMA_FIREFOX: 62,
+
+    /**
+     * @name Phaser.Input.Keyboard.KeyCodes.BRACKET_RIGHT_FIREFOX
+     */
+    BRACKET_RIGHT_FIREFOX: 174,
+
+    /**
+     * @name Phaser.Input.Keyboard.KeyCodes.BRACKET_LEFT_FIREFOX
+     */
+    BRACKET_LEFT_FIREFOX: 175
 };
 
 module.exports = KeyCodes;

--- a/src/input/keyboard/keys/KeyCodes.js
+++ b/src/input/keyboard/keys/KeyCodes.js
@@ -477,6 +477,11 @@ var KeyCodes = {
     COLON: 58,
 
     /**
+     * @name Phaser.Input.Keyboard.KeyCodes.COMMA_FIREFOX_WINDOWS
+     */
+    COMMA_FIREFOX_WINDOWS: 60,
+
+    /**
      * @name Phaser.Input.Keyboard.KeyCodes.COMMA_FIREFOX
      */
     COMMA_FIREFOX: 62,


### PR DESCRIPTION
 This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Some key Codes were forgotten. most of this happened in firefox browser. They included some alphabet letters in Persian and Arabic. The key codes are as follow:

* SEMICOLON_FIREFOX: 59
* COLON: 58
* COMMA_FIREFOX_WINDOWS: 60
* COMMA_FIREFOX: 62
* BRACKET_RIGHT_FIREFOX: 174
* BRACKET_LEFT_FIREFOX: 175