### PR TITLE
Array of dead particles is now being filled up with dead particles.

### DIFF
--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -2111,7 +2111,7 @@ var ParticleEmitter = new Class({
                 }
             }
 
-            this.dead.concat(rip);
+            this.dead = this.dead.concat(rip);
 
             StableSort.inplace(particles, this.indexSortCallback);
         }


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:

Hi!
Currently, when using particle emitters, dead particles pool is not functioning properly, here is the example:
[click](https://codepen.io/anon/pen/PygvGW?editors=0010)

It is caused by not catching value that `this.dead.concat(rip);` is returning.

Best regards.

