### PR TITLE
fixed - cameraFilter bitmask doesn't work for values < 0

### DIFF
--- a/src/gameobjects/domelement/DOMElementCSSRenderer.js
+++ b/src/gameobjects/domelement/DOMElementCSSRenderer.js
@@ -25,7 +25,7 @@ var DOMElementCSSRenderer = function (renderer, src, interpolationPercentage, ca
 {
     var node = src.node;
 
-    if (!node || GameObject.RENDER_MASK !== src.renderFlags || (src.cameraFilter > 0 && (src.cameraFilter & camera.id)))
+    if (!node || GameObject.RENDER_MASK !== src.renderFlags || (src.cameraFilter !== 0 && (src.cameraFilter & camera.id)))
     {
         if (node)
         {


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

The `cameraFilter` bitmask is only checked if its value is more than 0. A full bitmask is equal to -1, so I've changed the check to specifically check for !== 0.

I discovered this when coming up with a way of easily only showing something on one camera - `foo.cameraFilter = ~camera.id`, which for a camera id of 1 returns -2.