### PR TITLE
Setting HTML5AudioSound's volume and mute is now working.

### DIFF
--- a/src/sound/html5/HTML5AudioSound.js
+++ b/src/sound/html5/HTML5AudioSound.js
@@ -634,6 +634,7 @@ var HTML5AudioSound = new Class({
             {
                 return;
             }
+            this.updateMute();
 
             this.emit('mute', this, value);
         }
@@ -686,6 +687,7 @@ var HTML5AudioSound = new Class({
             {
                 return;
             }
+            this.updateVolume();
 
             this.emit('volume', this, value);
         }


### PR DESCRIPTION
This PR:

* Fixes a bug

Describe the changes below:

Hi!
There is a problem with setting volume and mute for HTML5AudioSound. Currently we can update those values only by manager, but setting rate and detune of the sound is working as intended. Example:
[click](https://labs.phaser.io/view.html?src=src\audio\HTML5%20Audio\Volume%20Mute%20Rate%20Detune.js)

We can fix this issue by using the same update methods that are being used by the manager, but directly inside setters.

I hope I didn't miss anything and this is indeed just a bug, not an intended behaviour.

Cheers!