### PR TITLE
Fix TS definition of Set#iterate, callbackScope is an optional param

### DIFF
--- a/src/structs/Set.js
+++ b/src/structs/Set.js
@@ -179,7 +179,7 @@ var Set = new Class({
      * @genericUse {Phaser.Structs.Set.<T>} - [$return]
      *
      * @param {EachSetCallback} callback - The callback to be invoked and passed each value this Set contains.
-     * @param {*} callbackScope - The scope of the callback.
+     * @param {*} [callbackScope] - The scope of the callback.
      *
      * @return {Phaser.Structs.Set} This Set object.
      */
@@ -224,7 +224,7 @@ var Set = new Class({
      * @genericUse {Phaser.Structs.Set.<T>} - [$return]
      *
      * @param {EachSetCallback} callback - The callback to be invoked and passed each value this Set contains.
-     * @param {*} callbackScope - The scope of the callback.
+     * @param {*} [callbackScope] - The scope of the callback.
      *
      * @return {Phaser.Structs.Set} This Set object.
      */


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:

Fixes TS definition of Set#iterate to `callbackScope` as optional.

