### PR TITLE
fix tileLayer.setCollisionFromCollisionGroup() to work with multiple tilesets

### DIFF
--- a/src/tilemaps/Tile.js
+++ b/src/tilemaps/Tile.js
@@ -335,7 +335,14 @@ var Tile = new Class({
      */
     getCollisionGroup: function ()
     {
-        return this.tileset ? this.tileset.getTileCollisionGroup(this.index) : null;
+        if (!this.tileset) { return null; }
+        
+        var collisionGroupArray = [];
+        for (var tilesetIndex = 0; tilesetIndex < this.tileset.length; tilesetIndex++)
+        {
+            collisionGroupArray.push(this.tileset[tilesetIndex].getTileCollisionGroup(this.index));
+        }
+        return collisionGroupArray;
     },
 
     /**

--- a/src/tilemaps/components/SetCollisionFromCollisionGroup.js
+++ b/src/tilemaps/components/SetCollisionFromCollisionGroup.js
@@ -36,11 +36,20 @@ var SetCollisionFromCollisionGroup = function (collides, recalculateFaces, layer
 
             var collisionGroup = tile.getCollisionGroup();
 
-            // It's possible in Tiled to have a collision group without any shapes, e.g. create a
-            // shape and then delete the shape.
-            if (collisionGroup && collisionGroup.objects && collisionGroup.objects.length > 0)
+            if (collisionGroup && collisionGroup.length > 0)
             {
-                SetTileCollision(tile, collides);
+
+                for (var collisionGroupIndex = 0; collisionGroupIndex < collisionGroup.length; collisionGroupIndex++)
+                // collisionGroup.forEach(function (_collisionGroup)
+                {
+                    // It's possible in Tiled to have a collision group without any shapes, e.g. create a
+                    // shape and then delete the shape.
+                    if (collisionGroup[collisionGroupIndex] && collisionGroup[collisionGroupIndex].objects && collisionGroup[collisionGroupIndex].objects.length > 0)
+                    {
+                        SetTileCollision(tile, collides);
+                    }
+                }
+
             }
         }
     }


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Fixes [#4095](https://github.com/photonstorm/phaser/issues/4095) by looping over all tilesets of a tile to get the CollisionGroups required for SetCollisionFromCollisionGroup().

Tile.getCollisionGroup() returns an array for each tileset.
SetCollisionFromCollisionGroup() iterates through this array.

Please let me know if there are implications of doing this which I don't understand since I'm pretty new to the Phaser code.

