### PR TITLE
[issue/4168] draw circular StaticBody as circle in drawDebug

### DIFF
--- a/src/physics/arcade/StaticBody.js
+++ b/src/physics/arcade/StaticBody.js
@@ -788,10 +788,21 @@ var StaticBody = new Class({
     {
         var pos = this.position;
 
+        var x = pos.x + this.halfWidth;
+        var y = pos.y + this.halfHeight;
+
         if (this.debugShowBody)
         {
             graphic.lineStyle(1, this.debugBodyColor, 1);
-            graphic.strokeRect(pos.x, pos.y, this.width, this.height);
+            if (this.isCircle)
+            {
+                graphic.strokeCircle(x, y, this.width / 2);
+            }
+            else
+            {
+                graphic.strokeRect(pos.x, pos.y, this.width, this.height);
+            }
+
         }
     },
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)
* Fixes a bug

Describe the changes below:
As described in #4168, circular staticbodies were not drawn in drawDebug as a circle.
I have test this in the example `public/src/physics/arcade/static group.js` by adding the following:
```
    group.children.entries.forEach(ball => {
        ball.body.setCircle(16);
    });
```
We can clearly see the fix working for the balls in the second screenshot below.
Before fix:
![image](https://user-images.githubusercontent.com/16080485/48635067-6827c280-e9c7-11e8-971b-87cc53928111.png)
After fix: 
![image](https://user-images.githubusercontent.com/16080485/48635130-9907f780-e9c7-11e8-92fb-841225a08663.png)

