### PR TITLE
Fix: Cannot read property 'index' of undefined at GetTileAt and RemoveTileAt

### DIFF
--- a/src/tilemaps/components/GetTileAt.js
+++ b/src/tilemaps/components/GetTileAt.js
@@ -27,7 +27,7 @@ var GetTileAt = function (tileX, tileY, nonNull, layer)
 
     if (IsInLayerBounds(tileX, tileY, layer))
     {
-        var tile = layer.data[tileY][tileX];
+        var tile = layer.data[tileY][tileX] || null;
         if (tile === null)
         {
             return null;

--- a/src/tilemaps/components/RemoveTileAt.js
+++ b/src/tilemaps/components/RemoveTileAt.js
@@ -30,7 +30,7 @@ var RemoveTileAt = function (tileX, tileY, replaceWithNull, recalculateFaces, la
     if (recalculateFaces === undefined) { recalculateFaces = true; }
     if (!IsInLayerBounds(tileX, tileY, layer)) { return null; }
 
-    var tile = layer.data[tileY][tileX];
+    var tile = layer.data[tileY][tileX] || null;
     if (tile === null)
     {
         return null;


### PR DESCRIPTION
Fixes a bug: `Cannot read property 'index' of undefined at GetTileAt`

A tile was undefined and the method failed because there were no case handling undefined.
I assumed that the behavior was the same as `tile === null`.