### PR TITLE
Fix 'collide' events triggered by overlap only

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1464,9 +1464,12 @@ var World = new Class({
 
         if (result)
         {
-            if (overlapOnly && (body1.onOverlap || body2.onOverlap))
+            if (overlapOnly)
             {
-                this.emit('overlap', body1.gameObject, body2.gameObject, body1, body2);
+                if (body1.onOverlap || body2.onOverlap)
+                {
+                    this.emit('overlap', body1.gameObject, body2.gameObject, body1, body2);
+                }
             }
             else
             {


### PR DESCRIPTION
This PR

* Fixes a bug

If you had an Arcade Body with onCollide=true and onOverlap=false it could receive a 'collide' event in response to an overlap.

