### PR TITLE
remove invalid canvas reference

### DIFF
--- a/src/renderer/webgl/WebGLPipeline.js
+++ b/src/renderer/webgl/WebGLPipeline.js
@@ -72,15 +72,6 @@ var WebGLPipeline = new Class({
         this.game = config.game;
 
         /**
-         * The canvas which this WebGL Pipeline renders to.
-         *
-         * @name Phaser.Renderer.WebGL.WebGLPipeline#view
-         * @type {HTMLCanvasElement}
-         * @since 3.0.0
-         */
-        this.view = config.game.canvas;
-
-        /**
          * Used to store the current game resolution
          *
          * @name Phaser.Renderer.WebGL.WebGLPipeline#resolution


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation
* Fixes a bug

Describe the changes below:

With the following code, using Typescript

```typescript
export default class Main extends Phaser.Scene {
    preload(): void {
        (this.game.renderer as any as Phaser.Renderer.WebGL.WebGLRenderer).
            addPipeline('foo', new Phaser.Renderer.WebGL.Pipelines.TextureTintPipeline(this.game));
    }
}
```

Fails with the error:

```
Uncaught TypeError: Cannot read property 'canvas' of undefined
    at TextureTintPipeline.WebGLPipeline (WebGLPipeline.js:81)
    at new TextureTintPipeline (TextureTintPipeline.js:56)
```

It looks like the WebGLPipeline class attempts to create a reference to the HTML canvas element. This does not exist on WebGLRenderer. Further, it looks like `this.view` isn't referenced anywhere at any rate. If it is, please let me know. The alternate option is have WebGLRenderer have a property referencing the HTMLCanvas element.