### PR TITLE
Fix for from/to in PathFollower.js

### DIFF
--- a/src/gameobjects/pathfollower/PathFollower.js
+++ b/src/gameobjects/pathfollower/PathFollower.js
@@ -244,8 +244,8 @@ var PathFollower = new Class({
         }
 
         //  Override in case they've been specified in the config
-        config.from = 0;
-        config.to = 1;
+        config.from = config.from || 0;
+        config.to = config.to || 1;
 
         //  Can also read extra values out of the config:
 


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:
Fixed path follower from/to value. It was overwritten by default.
