### PR TITLE
update type param for group factory and creator methods

### DIFF
--- a/src/gameobjects/group/GroupCreator.js
+++ b/src/gameobjects/group/GroupCreator.js
@@ -15,7 +15,7 @@ var Group = require('./Group');
  * @method Phaser.GameObjects.GameObjectCreator#group
  * @since 3.0.0
  *
- * @param {GroupConfig} config - The configuration object this Game Object will use to create itself.
+ * @param {GroupConfig|GroupCreateConfig} config - The configuration object this Game Object will use to create itself.
  *
  * @return {Phaser.GameObjects.Group} The Game Object that was created.
  */

--- a/src/gameobjects/group/GroupFactory.js
+++ b/src/gameobjects/group/GroupFactory.js
@@ -16,7 +16,7 @@ var GameObjectFactory = require('../GameObjectFactory');
  * @since 3.0.0
  *
  * @param {(Phaser.GameObjects.GameObject[]|GroupConfig|GroupConfig[])} [children] - Game Objects to add to this Group; or the `config` argument.
- * @param {GroupConfig} [config] - A Group Configuration object.
+ * @param {GroupConfig|GroupCreateConfig} [config] - A Group Configuration object.
  *
  * @return {Phaser.GameObjects.Group} The Game Object that was created.
  */


### PR DESCRIPTION
This PR:

* Updates the Documentation

Describe the changes below:

The `GroupCreator` and `GroupFactory` classes only accepted `GroupConfig` type config objects as parameters. However, the `Group` constructor accepts both `GroupConfig` and `GroupCreateConfig` parameter types.

This PR updates the config object types accepted by the `GroupCreator` and `GroupFactory` classes.

Thanks to @slothy in the Phaser slack channel for finding this.
