### PR TITLE
Change JSDoc @type from any to Phaser.FacebookInstantGamesPlugin

### DIFF
--- a/src/scene/Systems.js
+++ b/src/scene/Systems.js
@@ -58,7 +58,7 @@ var Systems = new Class({
              * The Facebook Instant Games Plugin.
              *
              * @name Phaser.Scenes.Systems#facebook
-             * @type {any}
+             * @type {Phaser.FacebookInstantGamesPlugin}
              * @since 3.12.0
              */
             this.facebook;


### PR DESCRIPTION
This PR changes the JSDoc `@type` for facebook instant games plugin on `Phaser.Scene` from `any` to `Phaser.FacebookInstantGamesPlugin` to match the definition on `Phaser.Game`.

