### PR TITLE
Fixed Issue #4271

### DIFF
--- a/plugins/fbinstant/src/Leaderboard.js
+++ b/plugins/fbinstant/src/Leaderboard.js
@@ -248,7 +248,7 @@ var Leaderboard = new Class({
 
         var _this = this;
 
-        this.ref.getEntriesAsync().then(function (entries)
+        this.ref.getEntriesAsync(count, offset).then(function (entries)
         {
             _this.scores = [];
 


### PR DESCRIPTION

* Fixes a bug

Fixes the Leaderboard.getScores method which didn't take its arguments into account. See issue #4271 
