### PR TITLE
Mark optional params as optional in jsdoc

### DIFF
--- a/src/scene/ScenePlugin.js
+++ b/src/scene/ScenePlugin.js
@@ -608,7 +608,7 @@ var ScenePlugin = new Class({
      * @method Phaser.Scenes.ScenePlugin#stop
      * @since 3.0.0
      *
-     * @param {string} key - The Scene to stop.
+     * @param {string} [key] - The Scene to stop.
      *
      * @return {Phaser.Scenes.ScenePlugin} This ScenePlugin object.
      */
@@ -678,7 +678,7 @@ var ScenePlugin = new Class({
      * @method Phaser.Scenes.ScenePlugin#isSleeping
      * @since 3.0.0
      *
-     * @param {string} key - The Scene to check.
+     * @param {string} [key] - The Scene to check.
      *
      * @return {boolean} Whether the Scene is sleeping.
      */
@@ -695,7 +695,7 @@ var ScenePlugin = new Class({
      * @method Phaser.Scenes.ScenePlugin#isActive
      * @since 3.0.0
      *
-     * @param {string} key - The Scene to check.
+     * @param {string} [key] - The Scene to check.
      *
      * @return {boolean} Whether the Scene is active.
      */
@@ -712,7 +712,7 @@ var ScenePlugin = new Class({
      * @method Phaser.Scenes.ScenePlugin#isVisible
      * @since 3.0.0
      *
-     * @param {string} key - The Scene to check.
+     * @param {string} [key] - The Scene to check.
      *
      * @return {boolean} Whether the Scene is visible.
      */
@@ -810,7 +810,7 @@ var ScenePlugin = new Class({
      * @method Phaser.Scenes.ScenePlugin#remove
      * @since 3.2.0
      *
-     * @param {(string|Phaser.Scene)} key - The Scene to be removed.
+     * @param {(string|Phaser.Scene)} [key] - The Scene to be removed.
      *
      * @return {Phaser.Scenes.SceneManager} This SceneManager.
      */
@@ -829,7 +829,7 @@ var ScenePlugin = new Class({
      * @method Phaser.Scenes.ScenePlugin#moveUp
      * @since 3.0.0
      *
-     * @param {string} key - The Scene to move.
+     * @param {string} [key] - The Scene to move.
      *
      * @return {Phaser.Scenes.ScenePlugin} This ScenePlugin object.
      */
@@ -848,7 +848,7 @@ var ScenePlugin = new Class({
      * @method Phaser.Scenes.ScenePlugin#moveDown
      * @since 3.0.0
      *
-     * @param {string} key - The Scene to move.
+     * @param {string} [key] - The Scene to move.
      *
      * @return {Phaser.Scenes.ScenePlugin} This ScenePlugin object.
      */
@@ -869,7 +869,7 @@ var ScenePlugin = new Class({
      * @method Phaser.Scenes.ScenePlugin#bringToTop
      * @since 3.0.0
      *
-     * @param {string} key - The Scene to move.
+     * @param {string} [key] - The Scene to move.
      *
      * @return {Phaser.Scenes.ScenePlugin} This ScenePlugin object.
      */
@@ -890,7 +890,7 @@ var ScenePlugin = new Class({
      * @method Phaser.Scenes.ScenePlugin#sendToBack
      * @since 3.0.0
      *
-     * @param {string} key - The Scene to move.
+     * @param {string} [key] - The Scene to move.
      *
      * @return {Phaser.Scenes.ScenePlugin} This ScenePlugin object.
      */


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:
Some methods in ScenePlugin accept a key parameter, but the JSDoc annotations didn't reflect that this parameter is optional. It does now.
