### PR TITLE
Fix WebGLRenderer to apply transparent bg in config

### DIFF
--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -556,7 +556,7 @@ var WebGLRenderer = new Class({
 
         gl.enable(gl.BLEND);
 
-        gl.clearColor(clearColor.redGL, clearColor.greenGL, clearColor.blueGL, 1);
+        gl.clearColor(clearColor.redGL, clearColor.greenGL, clearColor.blueGL, clearColor.alphaGL);
 
         // Initialize all textures to null
         for (var index = 0; index < this.currentTextures.length; ++index)
@@ -1795,7 +1795,7 @@ var WebGLRenderer = new Class({
         {
             var clearColor = this.config.backgroundColor;
 
-            gl.clearColor(clearColor.redGL, clearColor.greenGL, clearColor.blueGL, 1);
+            gl.clearColor(clearColor.redGL, clearColor.greenGL, clearColor.blueGL, clearColor.alphaGL);
 
             gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
         }


### PR DESCRIPTION
This PR 
* Fixes a bug

When configured as `Phaser.Boot.Config.transparent = true`, canvas's bg is still colored on WebGLRenderer.  But on running by CanvasRenderer, it is applied correctly.

So I fixed WebGLRenderer to clear color as transparent on `transparent` is `true`.