### PR TITLE
animation{event}-key was not firing on the Animation event emitter

### DIFF
--- a/src/animations/Animation.js
+++ b/src/animations/Animation.js
@@ -808,6 +808,8 @@ var Animation = new Class({
 
                 this.emit('repeat', this, frame);
 
+                component.currentAnim.emit('animationrepeat-' + this.key, this, frame, component.repeatCounter, parent);
+
                 parent.emit('animationrepeat-' + this.key, this, frame, component.repeatCounter, parent);
 
                 parent.emit('animationrepeat', this, frame, component.repeatCounter, parent);

--- a/src/gameobjects/components/Animation.js
+++ b/src/gameobjects/components/Animation.js
@@ -676,6 +676,8 @@ var Animation = new Class({
 
         anim.emit('start', anim, frame);
 
+        anim.emit('animationstart-' + key, anim, frame, gameObject);
+
         gameObject.emit('animationstart-' + key, anim, frame, gameObject);
 
         gameObject.emit('animationstart', anim, frame, gameObject);
@@ -872,6 +874,8 @@ var Animation = new Class({
 
         anim.emit('restart', anim, frame);
 
+        anim.emit('animationrestart-' + anim.key, anim, frame, gameObject);
+
         gameObject.emit('animationrestart-' + anim.key, anim, frame, gameObject);
 
         gameObject.emit('animationrestart', anim, frame, gameObject);
@@ -905,6 +909,8 @@ var Animation = new Class({
         if (anim)
         {
             anim.emit('complete', anim, frame);
+
+            anim.emit('animationcomplete-' + anim.key, anim, frame, gameObject);
 
             gameObject.emit('animationcomplete-' + anim.key, anim, frame, gameObject);
     
@@ -1119,6 +1125,8 @@ var Animation = new Class({
             }
 
             var anim = this.currentAnim;
+
+            anim.emit('animationupdate-' + anim.key, anim, animationFrame, gameObject);
 
             gameObject.emit('animationupdate-' + anim.key, anim, animationFrame, gameObject);
 


### PR DESCRIPTION
fixes this issue: 
```javascript
var config = {
    type: Phaser.AUTO,
    parent: 'phaser-example',
    width: 800,
    height: 600,
    scene: {
        preload: preload,
        create: create
    }
};

var game = new Phaser.Game(config);

function preload ()
{
    this.load.spritesheet('boom', 'assets/sprites/explosion.png', { frameWidth: 64, frameHeight: 64, endFrame: 23 });
}

function create ()
{
    var config = {
        key: 'explode',
        frames: this.anims.generateFrameNumbers('boom', { frames: [ 0, 1, 2, 1, 2, 3, 4, 0, 1, 2 ] }),
        frameRate: 20,
        repeat: -1
    };

    this.anims.create(config);

    //DOES NOT WORK
    let animation = this.anims.get("boom").on('animationupdate-explode', ()=> {
        console.log("play sound or something")
    }); 

    let booomie = this.add.sprite(400, 300, 'boom').play('explode');

    //WORKS FINE
    boomie.on("boom").on('animationupdate-explode', ()=> {
        console.log("play sound or something222")
    }); 
}

```
https://labs.phaser.io/edit.html?src=src/animation/generate%20frames.js (reproducible if you can get it running on latest dev release)