### PR TITLE
Adds invertAlpha flag to GeometryMask

### DIFF
--- a/src/display/mask/GeometryMask.js
+++ b/src/display/mask/GeometryMask.js
@@ -9,9 +9,9 @@ var Class = require('../../utils/Class');
 /**
  * @classdesc
  * A Geometry Mask can be applied to a Game Object to hide any pixels of it which don't intersect a visible pixel from the geometry mask. The mask is essentially a clipping path which can only make a masked pixel fully visible or fully invisible without changing its alpha (opacity).
- * 
+ *
  * A Geometry Mask uses a Graphics Game Object to determine which pixels of the masked Game Object(s) should be clipped. For any given point of a masked Game Object's texture, the pixel will only be displayed if the Graphics Game Object of the Geometry Mask has a visible pixel at the same position. The color and alpha of the pixel from the Geometry Mask do not matter.
- * 
+ *
  * The Geometry Mask's location matches the location of its Graphics object, not the location of the masked objects. Moving or transforming the underlying Graphics object will change the mask (and affect the visibility of any masked objects), whereas moving or transforming a masked object will not affect the mask. You can think of the Geometry Mask (or rather, of the its Graphics object) as an invisible curtain placed in front of all masked objects which has its own visual properties and, naturally, respects the camera's visual properties, but isn't affected by and doesn't follow the masked objects by itself.
  *
  * @class GeometryMask
@@ -36,6 +36,16 @@ var GeometryMask = new Class({
          * @since 3.0.0
          */
         this.geometryMask = graphicsGeometry;
+
+        /**
+         * Similiar to the BitmapMasks invertAlpha setting this to true will then hide all pixels
+         * drawn to the Geometry Mask.
+         *
+         * @name Phaser.Display.Masks.GeometryMask#invertAlpha
+         * @type {boolean}
+         * @since 3.16.0
+         */
+        this.invertAlpha = false;
     },
 
     /**
@@ -82,7 +92,16 @@ var GeometryMask = new Class({
 
         // Use stencil buffer to affect next rendering object
         gl.colorMask(true, true, true, true);
-        gl.stencilFunc(gl.EQUAL, 1, 1);
+
+        if (this.invertAlpha)
+        {
+            gl.stencilFunc(gl.NOTEQUAL, 1, 1);
+        }
+        else
+        {
+            gl.stencilFunc(gl.EQUAL, 1, 1);
+        }
+
         gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
     },
 
@@ -140,7 +159,7 @@ var GeometryMask = new Class({
 
     /**
      * Destroys this GeometryMask and nulls any references it holds.
-     * 
+     *
      * Note that if a Game Object is currently using this mask it will _not_ automatically detect you have destroyed it,
      * so be sure to call `clearMask` on any Game Object using it, before destroying it.
      *


### PR DESCRIPTION
Similiar to the invertAlpha flag on Bitmap Mask this flag if set to true
will esentially invert the function of the stencil buffer: non drawn
shapes will become invisible and drawn shapes will be visible.

Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)
* Adds a new feature

Describe the changes below:

As said in the commit message this flag will invert the function of the stencil buffer when used on the GeometryMask. Its nice when you want to show only a small rectangle for example. 