### PR TITLE
fix: GetValue not checking for the existence of '.' correctly

### DIFF
--- a/src/utils/object/GetValue.js
+++ b/src/utils/object/GetValue.js
@@ -30,7 +30,7 @@ var GetValue = function (source, key, defaultValue)
     {
         return source[key];
     }
-    else if (key.indexOf('.'))
+    else if (key.indexOf('.') !== -1)
     {
         var keys = key.split('.');
         var parent = source;


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

[`String.prototype.indexOf()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf) returns `-1` when the passed string is not found, which is truthy, so the branch was always executed regardless of its presence.