### PR TITLE
2d Camera startFollow should respect useBounds

### DIFF
--- a/src/cameras/2d/Camera.js
+++ b/src/cameras/2d/Camera.js
@@ -885,8 +885,8 @@ var Camera = new Class({
         this.scrollY = fy - originY;
         
         if (this.useBounds) {
-            this.scrollX = this.clampX(scrollX);
-            this.scrollY = this.clampY(scrollY);
+            this.scrollX = this.clampX(this.scrollX);
+            this.scrollY = this.clampY(this.scrollY);
         }
 
         return this;

--- a/src/cameras/2d/Camera.js
+++ b/src/cameras/2d/Camera.js
@@ -881,12 +881,12 @@ var Camera = new Class({
 
         this.midPoint.set(fx, fy);
 
-        var scrollX = fx - originX;
-        var scrollY = fy - originY;
+        this.scrollX = fx - originX;
+        this.scrollY = fy - originY;
         
         if (this.useBounds) {
-            this.clampX(scrollX);
-            this.clampY(scrollY);
+            this.scrollX = this.clampX(scrollX);
+            this.scrollY = this.clampY(scrollY);
         }
 
         return this;

--- a/src/cameras/2d/Camera.js
+++ b/src/cameras/2d/Camera.js
@@ -881,8 +881,13 @@ var Camera = new Class({
 
         this.midPoint.set(fx, fy);
 
-        this.scrollX = fx - originX;
-        this.scrollY = fy - originY;
+        var scrollX = fx - originX;
+        var scrollY = fy - originY;
+        
+        if (this.useBounds) {
+            this.clampX(scrollX);
+            this.clampY(scrollY);
+        }
 
         return this;
     },


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

It was possible for the 2d camera's `startFollow` method to set the `scrollX` and `scrollY` values out of the camera's bounds, even when `useBounds` was set to true.

This PR ensures that `useBounds` is respected by the `startFollow` method when setting the `scrollX` and `scrollY` values. 

Question - should this check also happen when setting the `midpoint` with the `fx` and `fy` values?