### PR TITLE
Fix getCenter methods returning wrong value for scaled layers

### DIFF
--- a/src/tilemaps/Tile.js
+++ b/src/tilemaps/Tile.js
@@ -470,7 +470,7 @@ var Tile = new Class({
      */
     getCenterX: function (camera)
     {
-        return this.getLeft(camera) + this.width / 2;
+        return (this.getLeft(camera) + this.getRight(camera)) / 2;
     },
 
     /**
@@ -486,7 +486,7 @@ var Tile = new Class({
      */
     getCenterY: function (camera)
     {
-        return this.getTop(camera) + this.height / 2;
+        return (this.getTop(camera) + this.getBottom(camera)) / 2;
     },
 
     /**


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation
* Adds a new feature
* Fixes a bug

Describe the changes below:
Tile class methods getCenterX and getCenterY now returning correct values with scaled layers.
Fix the issue #3845.
