### PR TITLE
Added this.scale property to Scene

### DIFF
--- a/src/scene/Scene.js
+++ b/src/scene/Scene.js
@@ -255,6 +255,16 @@ var Scene = new Class({
              */
             this.facebook;
         }
+
+        /**
+         * A reference to the global Scale Manager.
+         * This property will only be available if defined in the Scene Injection Map.
+         *
+         * @name Phaser.Scene#scale
+         * @type {Phaser.Scale.ScaleManager}
+         * @since 3.16.1
+         */
+        this.scale;
     },
 
     /**


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:
Purely a doc fix, noticed in the latest typedefs that this property was unavailable yet logging out this.scale within a scene showed it existed. It's existence is also referenced by Phaser.Scene.Systems#scale description.