### PR TITLE
Add __BASE texture entry in SpriteSheetFromAtlas parser

### DIFF
--- a/src/textures/parsers/SpriteSheetFromAtlas.js
+++ b/src/textures/parsers/SpriteSheetFromAtlas.js
@@ -40,9 +40,9 @@ var SpriteSheetFromAtlas = function (texture, frame, config)
         throw new Error('TextureManager.SpriteSheetFromAtlas: Invalid frameWidth given.');
     }
 
-    //  Add in a __BASE entry (for the entire atlas)
-    // var source = texture.source[sourceIndex];
-    // texture.add('__BASE', sourceIndex, 0, 0, source.width, source.height);
+    //  Add in a __BASE entry (for the entire atlas frame)
+    var source = texture.source[0];
+    texture.add('__BASE', 0, 0, 0, source.width, source.height);
 
     var startFrame = GetFastValue(config, 'startFrame', 0);
     var endFrame = GetFastValue(config, 'endFrame', -1);


### PR DESCRIPTION

This PR
* Fixes a bug

Describe the changes below:
Spritesheets created with the SpriteSheetFromAtlas parser don't have a __BASE texture entry at the moment, inconsistent with normal sprite sheets. This PR fixes the problem by providing the texture-atlas frame that the spritesheet is created from as a __BASE texture.
