### PR TITLE
Update `Tile.properties` type to `any`

### DIFF
--- a/src/tilemaps/Tile.js
+++ b/src/tilemaps/Tile.js
@@ -151,7 +151,7 @@ var Tile = new Class({
          * Tile specific properties. These usually come from Tiled.
          *
          * @name Phaser.Tilemaps.Tile#properties
-         * @type {object}
+         * @type {any}
          * @since 3.0.0
          */
         this.properties = {};


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation
* Fixes a bug

Describe the changes below:

Update `Tile.properties` type from ` object` to `any` so we can access any un-declared property without TypeScript throwing an error.

Solve issue https://github.com/photonstorm/phaser/issues/4356