### PR TITLE
Fix exiting full screen issue

### DIFF
--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -944,6 +944,8 @@ var ScaleManager = new Class({
         var zoom = this.zoom;
         var autoRound = this.autoRound;
         var resolution = 1;
+        
+        this.getParentBounds();
 
         if (this.scaleMode === CONST.SCALE_MODE.NONE)
         {


### PR DESCRIPTION
Fetch current parent size before taking action in updateScale

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

This PR references issue #4357 . The updateScale function is not always rescaling to the most up-to-date value of the parent element of the canvas. As a result, the canvas is still trying to scale to a fullscreen size, even after exiting via ESC. 

Though there are different ways to fix this bug, simply making sure the parent boundary information is up-to-date seems to be the core of the issue.

Let me know what you think. Thanks!
