### PR TITLE
fix reverse generateFrameNumbers

### DIFF
--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -390,7 +390,12 @@ var AnimationManager = new Class({
                 endFrame = texture.frameTotal;
             }
 
-            for (i = startFrame; i <= endFrame; i++)
+            var diff = (startFrame < endFrame) ? 1 : -1;
+
+            //  Adjust because we use i !== end in the for loop
+            endFrame += diff;
+
+            for (i = startFrame; i !== endFrame; i += diff)
             {
                 if (texture.has(i))
                 {


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

fixed `Phaser.Animations.AnimationManager#generateFrameNumbers` for reverse count (`start < end`). it's based on `Phaser.Animations.AnimationManager#generateFrameNames`.