### PR TITLE
Correct jsdoc for Class utilities

### DIFF
--- a/src/utils/Class.js
+++ b/src/utils/Class.js
@@ -66,6 +66,15 @@ function hasNonConfigurable (obj, k)
     return false;
 }
 
+/**
+ * Extends the given `myClass` object's prototype with the properties of `definition`.
+ *
+ * @function Phaser.Class.extend
+ * @param {Object} ctor The constructor object to mix into.
+ * @param {Object} definition A dictionary of functions for the class.
+ * @param {boolean} isClassDescriptor Is the definition a class descriptor?
+ * @param {Object} [extend] The parent constructor object.
+ */
 function extend (ctor, definition, isClassDescriptor, extend)
 {
     for (var k in definition)
@@ -108,6 +117,13 @@ function extend (ctor, definition, isClassDescriptor, extend)
     }
 }
 
+/**
+ * Applies the given `mixins` to the prototype of `myClass`.
+ *
+ * @function Phaser.Class.mixin
+ * @param {Object} myClass The constructor object to mix into.
+ * @param {Object|Array<Object>} mixins The mixins to apply to the constructor.
+ */
 function mixin (myClass, mixins)
 {
     if (!mixins)
@@ -136,7 +152,7 @@ function mixin (myClass, mixins)
  * You can also use `Extends` and `Mixins` to provide subclassing
  * and inheritance.
  *
- * @class  Class
+ * @class Phaser.Class
  * @constructor
  * @param {Object} definition a dictionary of functions for the class
  * @example


### PR DESCRIPTION
This PR

* Updates the Documentation

I noticed that the `Class` utilities are missing from the typescript definitions. However, when I create a custom GameObject I want to use the `mixin` function to mix Components.

I use this pattern:

```ts
export class MyGameObject
    extends Phaser.GameObjects.GameObject
    implements Phaser.GameObjects.Components.Alpha
{
    // Alpha interface
    clearAlpha: () => this;
    setAlpha: (topLeft?: number, topRight?: number, bottomLeft?: number, bottomRight?: number) => this;
    alpha: number;
    alphaTopLeft: number;
    alphaTopRight: number;
    alphaBottomLeft: number;
    alphaBottomRight: number;
}

Phaser.Class.mixin(MyGameObject, [
    (Phaser.GameObjects.Components as any).Alpha,
]);
```

This PR is to address the fact that `Phaser.Class` doesn't exist in the typings.

It is also unfortunate that I to have to repeat the Alpha interface to mix it, and also unfortunate that because the Components are listed as interfaces I have to do the `any` cast at the bottom. I may tackle this in a later PR.

I was unable to confirm if this fixes the definition files or not because when I tried to generate them locally in my clone of `phaser3-docs` I got very different output than what is in the repo (in fact, I got invalid output). Not sure what is going on there, but hopefully this is correct.