### PR TITLE
Declared dataset as object for internet explorer 10

### DIFF
--- a/src/loader/filetypes/HTML5AudioFile.js
+++ b/src/loader/filetypes/HTML5AudioFile.js
@@ -148,7 +148,7 @@ var HTML5AudioFile = new Class({
         for (var i = 0; i < instances; i++)
         {
             var audio = new Audio();
-
+            audio.dataset = {};
             audio.dataset.name = this.key + ('0' + i).slice(-2);
             audio.dataset.used = 'false';
 


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:

Internet explorer 10 crashed when trying to access the dataset property of the audio object.


