### PR TITLE
Add isPaused() methods to ScenePlugin, SceneManager

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -912,6 +912,28 @@ var SceneManager = new Class({
     },
 
     /**
+     * Determines whether a Scene is paused.
+     *
+     * @method Phaser.Scenes.SceneManager#isPaused
+     * @since 3.17.0
+     *
+     * @param {string} key - The Scene to check.
+     *
+     * @return {boolean} Whether the Scene is paused.
+     */
+    isPaused: function (key)
+    {
+        var scene = this.getScene(key);
+
+        if (scene)
+        {
+            return scene.sys.isPaused();
+        }
+
+        return null;
+    },
+
+    /**
      * Determines whether a Scene is visible.
      *
      * @method Phaser.Scenes.SceneManager#isVisible

--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -890,14 +890,14 @@ var SceneManager = new Class({
     },
 
     /**
-     * Determines whether a Scene is active.
+     * Determines whether a Scene is running.
      *
      * @method Phaser.Scenes.SceneManager#isActive
      * @since 3.0.0
      *
      * @param {string} key - The Scene to check.
      *
-     * @return {boolean} Whether the Scene is active.
+     * @return {boolean} Whether the Scene is running.
      */
     isActive: function (key)
     {

--- a/src/scene/ScenePlugin.js
+++ b/src/scene/ScenePlugin.js
@@ -677,14 +677,14 @@ var ScenePlugin = new Class({
     },
 
     /**
-     * Checks if the given Scene is active or not?
+     * Checks if the given Scene is running or not?
      *
      * @method Phaser.Scenes.ScenePlugin#isActive
      * @since 3.0.0
      *
      * @param {string} [key] - The Scene to check.
      *
-     * @return {boolean} Whether the Scene is active.
+     * @return {boolean} Whether the Scene is running.
      */
     isActive: function (key)
     {

--- a/src/scene/ScenePlugin.js
+++ b/src/scene/ScenePlugin.js
@@ -694,6 +694,23 @@ var ScenePlugin = new Class({
     },
 
     /**
+     * Checks if the given Scene is paused or not?
+     *
+     * @method Phaser.Scenes.ScenePlugin#isPaused
+     * @since 3.17.0
+     *
+     * @param {string} [key] - The Scene to check.
+     *
+     * @return {boolean} Whether the Scene is paused.
+     */
+    isPaused: function (key)
+    {
+        if (key === undefined) { key = this.key; }
+
+        return this.manager.isPaused(key);
+    },
+
+    /**
      * Checks if the given Scene is visible or not?
      *
      * @method Phaser.Scenes.ScenePlugin#isVisible

--- a/src/scene/Systems.js
+++ b/src/scene/Systems.js
@@ -539,12 +539,12 @@ var Systems = new Class({
     },
 
     /**
-     * Is this Scene active?
+     * Is this Scene running?
      *
      * @method Phaser.Scenes.Systems#isActive
      * @since 3.0.0
      *
-     * @return {boolean} `true` if this Scene is active, otherwise `false`.
+     * @return {boolean} `true` if this Scene is running, otherwise `false`.
      */
     isActive: function ()
     {


### PR DESCRIPTION
This PR

* Updates the Documentation
* Adds a new feature

Describe the changes below:

Lets you do

    this.scene.isPaused()
    this.scene.isPaused('KEY')

instead of

    this.scene.sys.isPaused()
    this.scene.get('KEY').sys.isPaused()

I also changed the descriptions of the `isActive()` methods to try to clarify that they are testing the scene's `status` (RUNNING) and not its `active` flag.