### PR TITLE
improve ts type hints for Phaser.Tilemaps.Types.StyleConfig

### DIFF
--- a/src/tilemaps/typedefs/StyleConfig.js
+++ b/src/tilemaps/typedefs/StyleConfig.js
@@ -2,7 +2,7 @@
  * @typedef {object} Phaser.Tilemaps.Types.StyleConfig
  * @since 3.0.0
  * 
- * @property {?number} [tileColor=blue] - Color to use for drawing a filled rectangle at non-colliding tile locations. If set to null, non-colliding tiles will not be drawn.
- * @property {?number} [collidingTileColor=orange] - Color to use for drawing a filled rectangle at colliding tile locations. If set to null, colliding tiles will not be drawn.
- * @property {?number} [faceColor=grey] - Color to use for drawing a line at interesting tile faces. If set to null, interesting tile faces will not be drawn.
+ * @property {?(Phaser.Display.Color|number|null)} [tileColor=blue] - Color to use for drawing a filled rectangle at non-colliding tile locations. If set to null, non-colliding tiles will not be drawn.
+ * @property {?(Phaser.Display.Color|number|null)} [collidingTileColor=orange] - Color to use for drawing a filled rectangle at colliding tile locations. If set to null, colliding tiles will not be drawn.
+ * @property {?(Phaser.Display.Color|number|null)} [faceColor=grey] - Color to use for drawing a line at interesting tile faces. If set to null, interesting tile faces will not be drawn.
  */


### PR DESCRIPTION
* Updates the Documentation

Describe the changes below:
Improves typehints for StyleConfig to allow for Phaser.Display.Color or null values.

Without these changes:

<img width="286" alt="Screenshot 2019-03-09 at 12 06 27" src="https://user-images.githubusercontent.com/181531/54070730-f7e9c900-4263-11e9-9070-f4f139c11f49.png">

