### PR TITLE
Add force orientation support

### DIFF
--- a/src/core/Config.js
+++ b/src/core/Config.js
@@ -77,6 +77,11 @@ var Config = new Class({
         this.scaleMode = GetValue(config, 'scaleMode', 0);
 
         /**
+         * @const {boolean} Phaser.Core.Config#forceOrientation - Toggle force orientation for the Scale Manager. The default is false, which means closed.
+         */
+        this.forceOrientation = GetValue(config, 'forceOrientation', false);
+
+        /**
          * @const {boolean} Phaser.Core.Config#expandParent - Is the Scale Manager allowed to adjust the CSS height property of the parent to be 100%?
          */
         this.expandParent = GetValue(config, 'expandParent', true);

--- a/src/input/InputManager.js
+++ b/src/input/InputManager.js
@@ -1634,8 +1634,8 @@ var InputManager = new Class({
         p1.y = p0.y;
 
         //  Translate coordinates
-        var x = this.scaleManager.transformX(pageX);
-        var y = this.scaleManager.transformY(pageY);
+        var x = this.scaleManager.getAxisX(pageX, pageY);
+        var y = this.scaleManager.getAxisY(pageX, pageY);
 
         var a = pointer.smoothFactor;
 

--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -189,6 +189,8 @@ var ScaleManager = new Class({
          */
         this.parentSize = new Size();
 
+        this.parentOriginalSize = new Size();
+
         /**
          * The Game Size component.
          * 
@@ -669,23 +671,28 @@ var ScaleManager = new Class({
         }
 
         var resolution = this.resolution;
+        var newOriginalWidth = DOMRect.width * resolution;
+        var newOriginalHeight = DOMRect.height * resolution;
 
-        var newWidth;
-        var newHeight;
+        const isParentResized = this.parentOriginalSize.width !== newOriginalWidth || this.parentOriginalSize.height !== newOriginalHeight;
+        this.parentOriginalSize.setSize(newOriginalWidth, newOriginalHeight);
 
-        if (this.shouldRotate)
+        if (isParentResized)
         {
-            newWidth = DOMRect.height * resolution;
-            newHeight = DOMRect.width * resolution;
-        }
-        else
-        {
-            newWidth = DOMRect.width * resolution;
-            newHeight = DOMRect.height * resolution;
-        }
+            var newWidth;
+            var newHeight;
 
-        if (parentSize.width !== newWidth || parentSize.height !== newHeight)
-        {
+            if (this.shouldRotate)
+            {
+                newWidth = newOriginalHeight;
+                newHeight = newOriginalWidth;
+            }
+            else
+            {
+                newWidth = newOriginalWidth;
+                newHeight = newOriginalHeight;
+            }
+
             parentSize.setSize(newWidth, newHeight);
 
             return true;
@@ -1695,6 +1702,40 @@ var ScaleManager = new Class({
     },
 
     /**
+     * Is the screen's width smaller than / equal to its height?
+     *
+     * @name Phaser.Scale.ScaleManager#isScreenPortrait
+     * @type {boolean}
+     * @readonly
+     * @since 3.17.0
+     */
+    isScreenPortrait: {
+
+        get: function ()
+        {
+            return document.documentElement.clientWidth <= document.documentElement.clientHeight;
+        }
+
+    },
+
+    /**
+     * Is the screen's width bigger than its height?
+     *
+     * @name Phaser.Scale.ScaleManager#isScreenLandscape
+     * @type {boolean}
+     * @readonly
+     * @since 3.17.0
+     */
+    isScreenLandscape: {
+
+        get: function ()
+        {
+            return document.documentElement.clientWidth >= document.documentElement.clientHeight;
+        }
+
+    },
+
+    /**
      * Are the game dimensions portrait? (i.e. taller than they are wide)
      * 
      * This is different to the device itself being in a portrait orientation.
@@ -1744,7 +1785,7 @@ var ScaleManager = new Class({
 
         get: function ()
         {
-            var isOrientationNotMatched = this.isLandscape !== this.isGameLandscape;
+            var isOrientationNotMatched = this.isScreenLandscape !== this.isGameLandscape;
             return this.forceOrientation && isOrientationNotMatched;
         }
 

--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -481,7 +481,7 @@ var ScaleManager = new Class({
     {
         //  Get the parent element, if any
         this.getParent(config);
-        
+
         //  Get the size of the parent element
         //  This can often set a height of zero (especially for un-styled divs)
         this.getParentBounds();
@@ -657,8 +657,20 @@ var ScaleManager = new Class({
         }
 
         var resolution = this.resolution;
-        var newWidth = DOMRect.width * resolution;
-        var newHeight = DOMRect.height * resolution;
+
+        var newWidth;
+        var newHeight;
+
+        if (this.shouldRotate)
+        {
+            newWidth = DOMRect.height * resolution;
+            newHeight = DOMRect.width * resolution;
+        }
+        else
+        {
+            newWidth = DOMRect.width * resolution;
+            newHeight = DOMRect.height * resolution;
+        }
 
         if (parentSize.width !== newWidth || parentSize.height !== newHeight)
         {
@@ -922,6 +934,9 @@ var ScaleManager = new Class({
     
                 this.emit(Events.ORIENTATION_CHANGE, newOrientation);
             }
+
+            //  Update the parentSize because of orientationchange will influence it
+            this.getParentBounds();
         }
     },
 
@@ -1060,24 +1075,55 @@ var ScaleManager = new Class({
 
         var style = canvas.style;
 
-        var bounds = canvas.getBoundingClientRect();
+        var offsetX;
+        var offsetY;
 
-        // var width = parseInt(canvas.style.width, 10) || canvas.width;
-        // var height = parseInt(canvas.style.height, 10) || canvas.height;
-
-        var width = bounds.width;
-        var height = bounds.height;
-
-        var offsetX = Math.floor((this.parentSize.width - width) / 2);
-        var offsetY = Math.floor((this.parentSize.height - height) / 2);
-
-        if (autoCenter === CONST.CENTER.CENTER_HORIZONTALLY)
+        if (this.shouldRotate)
         {
-            offsetY = 0;
+            style.transformOrigin = '0 0 0';
+            style.transform = 'rotate(90deg)';
+
+            var bounds = canvas.getBoundingClientRect();
+            var width = bounds.height;
+            var height = bounds.width;
+
+            var baseOffsetX = 0;
+            var baseOffsetY = this.parentSize.height;
+            var _offsetX = Math.floor((this.parentSize.width - width) / 2);
+            var _offsetY = Math.floor((this.parentSize.height - height) / 2);
+
+            if (autoCenter === CONST.CENTER.CENTER_HORIZONTALLY)
+            {
+                _offsetY = 0;
+            }
+            else if (autoCenter === CONST.CENTER.CENTER_VERTICALLY)
+            {
+                _offsetX = 0;
+            }
+
+            offsetX = baseOffsetY - _offsetY;
+            offsetY = baseOffsetX + _offsetX;
         }
-        else if (autoCenter === CONST.CENTER.CENTER_VERTICALLY)
+        else
         {
-            offsetX = 0;
+            style.transformOrigin = '0 0 0';
+            style.transform = 'rotate(0deg)';
+
+            var bounds = canvas.getBoundingClientRect();
+            var width = bounds.width;
+            var height = bounds.height;
+
+            offsetX = Math.floor((this.parentSize.width - width) / 2);
+            offsetY = Math.floor((this.parentSize.height - height) / 2);
+
+            if (autoCenter === CONST.CENTER.CENTER_HORIZONTALLY)
+            {
+                offsetY = 0;
+            }
+            else if (autoCenter === CONST.CENTER.CENTER_VERTICALLY)
+            {
+                offsetX = 0;
+            }
         }
 
         style.marginLeft = offsetX + 'px';
@@ -1680,7 +1726,7 @@ var ScaleManager = new Class({
      * @name Phaser.Scale.ScaleManager#shouldRotate
      * @type {boolean}
      * @readonly
-     * @since 3.16.2
+     * @since 3.17.0
      */
     shouldRotate: {
 

--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -888,9 +888,9 @@ var ScaleManager = new Class({
      */
     refresh: function ()
     {
+        this.updateOrientation();
         this.updateScale();
         this.updateBounds();
-        this.updateOrientation();
 
         this.displayScale.set(this.baseSize.width / this.canvasBounds.width, this.baseSize.height / this.canvasBounds.height);
 
@@ -1672,6 +1672,23 @@ var ScaleManager = new Class({
             return (this.width > this.height);
         }
     
+    },
+
+    /**
+     * Did the canvas need rotation?
+     *
+     * @name Phaser.Scale.ScaleManager#shouldRotate
+     * @type {boolean}
+     * @readonly
+     * @since 3.16.2
+     */
+    shouldRotate: {
+
+        get: function ()
+        {
+            return (this.isLandscape !== this.isGameLandscape);
+        }
+
     }
 
 });

--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -1748,7 +1748,7 @@ var ScaleManager = new Class({
 
         get: function ()
         {
-            return (this.height > this.width);
+            return (this.game.config.height > this.game.config.width);
         }
     
     },
@@ -1767,7 +1767,7 @@ var ScaleManager = new Class({
 
         get: function ()
         {
-            return (this.width > this.height);
+            return (this.game.config.width >= this.game.config.height);
         }
     
     },

--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -490,6 +490,27 @@ var ScaleManager = new Class({
      */
     parseConfig: function (config)
     {
+        var width = config.width;
+        var height = config.height;
+        var resolution = config.resolution;
+        var zoom = config.zoom;
+        var autoRound = config.autoRound;
+
+        //  This is fixed at 1 on purpose.
+        //  Changing it will break all user input.
+        //  Wait for another release to solve this issue.
+        this.resolution = 1;
+
+        this.scaleMode = config.scaleMode;
+
+        this.forceOrientation = config.forceOrientation;;
+
+        this.autoRound = autoRound;
+
+        this.autoCenter = config.autoCenter;
+
+        this.resizeInterval = config.resizeInterval;
+
         //  Get the parent element, if any
         this.getParent(config);
 
@@ -497,13 +518,6 @@ var ScaleManager = new Class({
         //  This can often set a height of zero (especially for un-styled divs)
         this.getParentBounds();
 
-        var width = config.width;
-        var height = config.height;
-        var scaleMode = config.scaleMode;
-        var resolution = config.resolution;
-        var zoom = config.zoom;
-        var forceOrientation = config.forceOrientation;
-        var autoRound = config.autoRound;
 
         //  If width = '100%', or similar value
         if (typeof width === 'string')
@@ -536,21 +550,6 @@ var ScaleManager = new Class({
 
             height = Math.floor(parentHeight * parentScaleY);
         }
-
-        //  This is fixed at 1 on purpose.
-        //  Changing it will break all user input.
-        //  Wait for another release to solve this issue.
-        this.resolution = 1;
-
-        this.scaleMode = scaleMode;
-
-        this.forceOrientation = forceOrientation;
-
-        this.autoRound = autoRound;
-
-        this.autoCenter = config.autoCenter;
-
-        this.resizeInterval = config.resizeInterval;
 
         if (autoRound)
         {

--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -777,7 +777,7 @@ var ScaleManager = new Class({
 
         this.updateBounds();
 
-        this.displayScale.set(width / this.canvasBounds.width, height / this.canvasBounds.height);
+        this.updateDisplayScale();
 
         this.emit(Events.RESIZE, this.gameSize, this.baseSize, this.displaySize, this.resolution);
 
@@ -859,7 +859,7 @@ var ScaleManager = new Class({
 
         this.updateBounds();
 
-        this.displayScale.set(width / this.canvasBounds.width, height / this.canvasBounds.height);
+        this.updateDisplayScale();
 
         this.emit(Events.RESIZE, this.gameSize, this.baseSize, this.displaySize, this.resolution);
 
@@ -921,8 +921,7 @@ var ScaleManager = new Class({
         this.updateOrientation();
         this.updateScale();
         this.updateBounds();
-
-        this.displayScale.set(this.baseSize.width / this.canvasBounds.width, this.baseSize.height / this.canvasBounds.height);
+        this.updateDisplayScale();
 
         this.emit(Events.RESIZE, this.gameSize, this.baseSize, this.displaySize, this.resolution);
 
@@ -1047,6 +1046,17 @@ var ScaleManager = new Class({
     },
 
     /**
+     * Internal method that manages updating the displayScale.
+     *
+     * @method Phaser.Scale.ScaleManager#updateDisplayScale
+     * @since 3.17.0
+     */
+    updateDisplayScale: function ()
+    {
+        this.displayScale.set(this.baseSize.width / this.displaySize.width, this.baseSize.height / this.displaySize.height);
+    },
+
+    /**
      * Calculates and returns the largest possible zoom factor, based on the current
      * parent and game sizes. If the parent has no dimensions (i.e. an unstyled div),
      * or is smaller than the un-zoomed game, then this will return a value of 1 (no zoom)
@@ -1167,33 +1177,50 @@ var ScaleManager = new Class({
     },
 
     /**
-     * Transforms the pageX value into the scaled coordinate space of the Scale Manager.
+     * Get x-axis value in the scaled coordinate space of the Scale Manager according pageX and pageY.
      *
-     * @method Phaser.Scale.ScaleManager#transformX
-     * @since 3.16.0
+     * @method Phaser.Scale.ScaleManager#getX
+     * @since 3.17.0
      *
      * @param {number} pageX - The DOM pageX value.
+     * @param {number} pageY - The DOM pageY value.
      *
-     * @return {number} The translated value.
+     * @return {number} The x-axis value.
      */
-    transformX: function (pageX)
+    getAxisX: function (pageX, pageY)
     {
-        return (pageX - this.canvasBounds.left) * this.displayScale.x;
+        if (this.shouldRotate)
+        {
+            return (pageY - this.canvasBounds.top) * this.displayScale.y;
+        }
+        else
+        {
+            return (pageX - this.canvasBounds.left) * this.displayScale.x;
+        }
+
     },
 
     /**
-     * Transforms the pageY value into the scaled coordinate space of the Scale Manager.
+     * Get y-axis value in the scaled coordinate space of the Scale Manager according pageX and pageY.
      *
-     * @method Phaser.Scale.ScaleManager#transformY
+     * @method Phaser.Scale.ScaleManager#getY
      * @since 3.16.0
      *
+     * @param {number} pageX - The DOM pageX value.
      * @param {number} pageY - The DOM pageY value.
      *
-     * @return {number} The translated value.
+     * @return {number} The y-axis value.
      */
-    transformY: function (pageY)
+    getAxisY: function (pageX, pageY)
     {
-        return (pageY - this.canvasBounds.top) * this.displayScale.y;
+        if (this.shouldRotate)
+        {
+            return (this.displaySize.height - (pageX - this.canvasBounds.left)) * this.displayScale.x;
+        }
+        else
+        {
+            return (pageY - this.canvasBounds.top) * this.displayScale.y;
+        }
     },
 
     /**

--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -234,6 +234,15 @@ var ScaleManager = new Class({
         this.scaleMode = CONST.SCALE_MODE.NONE;
 
         /**
+         * Toggle for force orientation.
+         *
+         * @name Phaser.Scale.ScaleManager#forceOrientation
+         * @type {boolean}
+         * @since 3.17.0
+         */
+        this.forceOrientation = false;
+
+        /**
          * The canvas resolution.
          * 
          * This is hard-coded to a value of 1 in the 3.16 release of Phaser and will be enabled at a later date.
@@ -491,6 +500,7 @@ var ScaleManager = new Class({
         var scaleMode = config.scaleMode;
         var resolution = config.resolution;
         var zoom = config.zoom;
+        var forceOrientation = config.forceOrientation;
         var autoRound = config.autoRound;
 
         //  If width = '100%', or similar value
@@ -531,6 +541,8 @@ var ScaleManager = new Class({
         this.resolution = 1;
 
         this.scaleMode = scaleMode;
+
+        this.forceOrientation = forceOrientation;
 
         this.autoRound = autoRound;
 
@@ -1732,7 +1744,8 @@ var ScaleManager = new Class({
 
         get: function ()
         {
-            return (this.isLandscape !== this.isGameLandscape);
+            var isOrientationNotMatched = this.isLandscape !== this.isGameLandscape;
+            return this.forceOrientation && isOrientationNotMatched;
         }
 
     }


### PR DESCRIPTION
> I am not sure that whether all users need this feature. But, in my situation, I surely need this. So, I took the liberty of writing this PR.

Back to Phaser 2, we have a feature call force orientation, which is described at [here](https://photonstorm.github.io/phaser-ce/Phaser.ScaleManager.html#forceOrientation). I think Phaser 3 should have this feature, too.

## Why we need force orientation?

When a game is running in general browser (for example, not in Cordava), and it should be displayed in Landscape Direction. But, when the user locks his / her phone in Portrait Direction, the game will be displayed like this following current policy of ScaleManager:

<img src="https://user-images.githubusercontent.com/12194646/54862382-e5e44c00-4d74-11e9-83bf-5acdd6b447ad.png" width="200">

Above condition isn't what we want, apparently.

If user want to play this game in a better layout, he / she should disable orientation lock of phone, and rotate the phone is physical world, then the game should be displayed like this:

<img src="https://user-images.githubusercontent.com/12194646/54862385-f0064a80-4d74-11e9-874e-c76a61859f45.png" width="400">

That's what I want to say: **In order to play a game which is in Landscape Direction and display it in better layout, user have to disable orientation lock in Phone's OS and rotate Phone by themselves**.

## What is the policy should be?

### When Phone's orientation lock is enabled

For a game should be displayed in Landscape Direction - [online demo](https://dodrio.github.io/phaser3-game-landscape-example/index.html):

<img src="https://user-images.githubusercontent.com/12194646/54862391-f98fb280-4d74-11e9-9825-495855043253.png" width="200">
<img src="https://user-images.githubusercontent.com/12194646/54862389-f72d5880-4d74-11e9-8f75-5420dff716a1.png" width="400">

For a game should be displayed in Partrait Direction - [online demo](https://dodrio.github.io/phaser3-game-portrait-example/index.html):

<img src="https://user-images.githubusercontent.com/12194646/54862393-fdbbd000-4d74-11e9-9344-54657c093ce3.png" width="200">
<img src="https://user-images.githubusercontent.com/12194646/54862397-07ddce80-4d75-11e9-9d18-e4e8bc3b9a65.png" width="400">

## Why not use `ScaleManager#lockOrientation`?

This API is implemented via `Screen.lockOrientation()`. But, as MDN said:

> This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the compatibility table at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.

In most of browser, it just call a depracated API without doing any other useful thing.

## Current thought about how to implement force orientation

### Step 1: add a toggle

Add a toggle for the policy of force oriencation - `GameConfig#forceOrientation`.

### Step 2: implement the policy

Get expected layout of game according `game.config.width` / `game.config.height`:
+ when `game.config.width >= game.config.height`, `ScaleManager#isGameLandscape` is true.
+ when `game.config.width < game.config.height`, `ScaleManager#isGamePortrait` is true.

Get current layout of screen via `ScaleManager#isScreenLandscape` / `ScaleManager#isScreenLandscape`.

> Currently, `ScaleManager#isScreenLandscape` / `ScaleManager#isScreenLandscape` is simple and crude, i will improve it later.

Compare `ScaleManager#isScreenLandscape` / `ScaleManager#isScreenLandscape` with `ScaleManager#isGameLandscape` / `ScaleManager#isGamePortrait` to determine that if Phaser should:
+ rotate the canvas.
+ remap input onto a rotated canvas.

## Current progress

Complete.

> When input works, clicking green point in demo will print 'Oh!' in browser's console.
> And the input is broken when the canvas is rotated. 

> @photonstorm After reading the code of `InputManager`, I still have no idea where is the best place to remap input. Maybe you can give me some tips. ;)

> Update: Found the way to `remap input onto a rotated canvas`, working on it.

> `remap input onto a rotated canvas` is done.
