### PR TITLE
fix: Inconsistent return in Tween#pause()

### DIFF
--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -611,7 +611,7 @@ var Tween = new Class({
     {
         if (this.state === TWEEN_CONST.PAUSED)
         {
-            return;
+            return this;
         }
 
         this.paused = true;


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:

Calling `tween.pause();` returns the instance of `Tween`, however, if it was already paused, it would return `undefined`, causing problems when chaining the methods, e.g. `tween.pause().seek(0.1);` while the tween was paused.