### PR TITLE
fix: Inconsistent return in TweenManager#makeActive()

### DIFF
--- a/src/tweens/TweenManager.js
+++ b/src/tweens/TweenManager.js
@@ -411,7 +411,7 @@ var TweenManager = new Class({
     {
         if (this._add.indexOf(tween) !== -1 || this._active.indexOf(tween) !== -1)
         {
-            return;
+            return this;
         }
 
         var idx = this._pending.indexOf(tween);


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:

Calling `TweenManager#makeActive(tween);` returns the TweenManager instance itself, however, if you create a tween externally (since those aren't in the add or active lists) and try to call `makeActive()` with it, this would return `undefined`.