### PR TITLE
Fixes #3833

### DIFF
--- a/src/cameras/2d/effects/Fade.js
+++ b/src/cameras/2d/effects/Fade.js
@@ -56,7 +56,7 @@ var Fade = new Class({
 
         /**
          * Has this effect finished running?
-         * 
+         *
          * This is different from `isRunning` because it remains set to `true` when the effect is over,
          * until the effect is either reset or started again.
          *
@@ -265,6 +265,7 @@ var Fade = new Class({
         }
         else
         {
+            this.alpha = (this.direction) ? 1 : 0;
             this.effectComplete();
         }
     },


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug (#3833) 

Describe the changes below:

The camera Fade effect did not update the alpha value of the overlay in the final update call, resulting in an incomplete transition.