### PR TITLE
Fixed Phaser.Actions.Spread ignoring the min parameter

### DIFF
--- a/src/actions/Spread.js
+++ b/src/actions/Spread.js
@@ -40,14 +40,14 @@ var Spread = function (items, property, min, max, inc)
     {
         for (i = 0; i < items.length; i++)
         {
-            items[i][property] += i * step;
+            items[i][property] += i * step + min;
         }
     }
     else
     {
         for (i = 0; i < items.length; i++)
         {
-            items[i][property] = i * step;
+            items[i][property] = i * step + min;
         }
     }
 


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
 
* Fixed Phaser.Actions.Spread ignoring the min parameter
