### PR TITLE
docs: fix copy-paste error

### DIFF
--- a/src/actions/RandomRectangle.js
+++ b/src/actions/RandomRectangle.js
@@ -7,7 +7,7 @@
 var Random = require('../geom/rectangle/Random');
 
 /**
- * Takes an array of Game Objects and positions them at random locations within the Ellipse.
+ * Takes an array of Game Objects and positions them at random locations within the Rectangle.
  *
  * @function Phaser.Actions.RandomRectangle
  * @since 3.0.0


### PR DESCRIPTION
This PR
* Updates the Documentation

Describe the changes below:
Description of RandomRectangle.js changed from "Ellipse" to "Rectangle". Looks like it was copy-pasted from RandomEllipse.js and didn't get its wording updated.