### PR TITLE
Update rectangle hit-area when updated text

### DIFF
--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -15,6 +15,7 @@ var GetValue = require('../../../utils/object/GetValue');
 var RemoveFromDOM = require('../../../dom/RemoveFromDOM');
 var TextRender = require('./TextRender');
 var TextStyle = require('../TextStyle');
+var Rectangle = require('../../../geom/rectangle/Rectangle');
 
 /**
  * @classdesc
@@ -1236,6 +1237,12 @@ var Text = new Class({
         }
 
         this.dirty = true;
+
+        if (this.input && this.input.hitArea instanceof Rectangle)
+        {
+            this.input.hitArea.width = this.width;
+            this.input.hitArea.height = this.height;
+        }
 
         return this;
     },


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Update rectangle hit-area when updated text. (#4456)
(This code is modified from [Zone game object](https://github.com/photonstorm/phaser/blob/master/src/gameobjects/zone/Zone.js#L168-L172))
