### PR TITLE
Remove BasePlugin#boot; and plugins docs updates

### DIFF
--- a/src/plugins/BasePlugin.js
+++ b/src/plugins/BasePlugin.js
@@ -49,7 +49,7 @@ var BasePlugin = new Class({
          * A reference to the Scene that has installed this plugin.
          * Only set if it's a Scene Plugin, otherwise `null`.
          * This property is only set when the plugin is instantiated and added to the Scene, not before.
-         * You cannot use it during the `init` method, but you can during the `boot` method.
+         * You can use it during the `boot` method.
          *
          * @name Phaser.Plugins.BasePlugin#scene
          * @type {?Phaser.Scene}
@@ -62,7 +62,7 @@ var BasePlugin = new Class({
          * A reference to the Scene Systems of the Scene that has installed this plugin.
          * Only set if it's a Scene Plugin, otherwise `null`.
          * This property is only set when the plugin is instantiated and added to the Scene, not before.
-         * You cannot use it during the `init` method, but you can during the `boot` method.
+         * You can use it during the `boot` method.
          *
          * @name Phaser.Plugins.BasePlugin#systems
          * @type {?Phaser.Scenes.Systems}
@@ -73,10 +73,11 @@ var BasePlugin = new Class({
     },
 
     /**
-     * Called by the PluginManager when this plugin is first instantiated.
+     * The PluginManager calls this method on a Global Plugin when the plugin is first instantiated.
      * It will never be called again on this instance.
      * In here you can set-up whatever you need for this plugin to run.
      * If a plugin is set to automatically start then `BasePlugin.start` will be called immediately after this.
+     * On a Scene Plugin, this method is never called. Use {@link Phaser.Plugins.ScenePlugin#boot} instead.
      *
      * @method Phaser.Plugins.BasePlugin#init
      * @since 3.8.0
@@ -88,9 +89,10 @@ var BasePlugin = new Class({
     },
 
     /**
-     * Called by the PluginManager when this plugin is started.
+     * The PluginManager calls this method on a Global Plugin when the plugin is started.
      * If a plugin is stopped, and then started again, this will get called again.
      * Typically called immediately after `BasePlugin.init`.
+     * On a Scene Plugin, this method is never called.
      *
      * @method Phaser.Plugins.BasePlugin#start
      * @since 3.8.0
@@ -114,11 +116,12 @@ var BasePlugin = new Class({
     },
 
     /**
-     * Called by the PluginManager when this plugin is stopped.
+     * The PluginManager calls this method on a Global Plugin when the plugin is stopped.
      * The game code has requested that your plugin stop doing whatever it does.
      * It is now considered as 'inactive' by the PluginManager.
      * Handle that process here (i.e. stop listening for events, etc)
      * If the plugin is started again then `BasePlugin.start` will be called again.
+     * On a Scene Plugin, this method is never called.
      *
      * @method Phaser.Plugins.BasePlugin#stop
      * @since 3.8.0

--- a/src/plugins/BasePlugin.js
+++ b/src/plugins/BasePlugin.js
@@ -128,34 +128,6 @@ var BasePlugin = new Class({
     },
 
     /**
-     * If this is a Scene Plugin (i.e. installed into a Scene) then this method is called when the Scene boots.
-     * By this point the plugin properties `scene` and `systems` will have already been set.
-     * In here you can listen for Scene events and set-up whatever you need for this plugin to run.
-     *
-     * @method Phaser.Plugins.BasePlugin#boot
-     * @since 3.8.0
-     */
-    boot: function ()
-    {
-        //  Here are the Scene events you can listen to.
-        //  At the very least you should offer a destroy handler for when the Scene closes down.
-
-        // var eventEmitter = this.systems.events;
-
-        // eventEmitter.once('destroy', this.sceneDestroy, this);
-        // eventEmitter.on('start', this.sceneStart, this);
-        // eventEmitter.on('preupdate', this.scenePreUpdate, this);
-        // eventEmitter.on('update', this.sceneUpdate, this);
-        // eventEmitter.on('postupdate', this.scenePostUpdate, this);
-        // eventEmitter.on('pause', this.scenePause, this);
-        // eventEmitter.on('resume', this.sceneResume, this);
-        // eventEmitter.on('sleep', this.sceneSleep, this);
-        // eventEmitter.on('wake', this.sceneWake, this);
-        // eventEmitter.on('shutdown', this.sceneShutdown, this);
-        // eventEmitter.on('destroy', this.sceneDestroy, this);
-    },
-
-    /**
      * Game instance has been destroyed.
      * You must release everything in here, all references, all objects, free it all up.
      *

--- a/src/plugins/ScenePlugin.js
+++ b/src/plugins/ScenePlugin.js
@@ -41,29 +41,29 @@ var ScenePlugin = new Class({
 
     /**
      * This method is called when the Scene boots. It is only ever called once.
-     * 
+     *
      * By this point the plugin properties `scene` and `systems` will have already been set.
-     * 
-     * In here you can listen for Scene events and set-up whatever you need for this plugin to run.
+     *
+     * In here you can listen for {@link Phaser.Scenes.Events Scene events} and set-up whatever you need for this plugin to run.
      * Here are the Scene events you can listen to:
-     * 
-     * start
-     * ready
-     * preupdate
-     * update
-     * postupdate
-     * resize
-     * pause
-     * resume
-     * sleep
-     * wake
-     * transitioninit
-     * transitionstart
-     * transitioncomplete
-     * transitionout
-     * shutdown
-     * destroy
-     * 
+     *
+     * - start
+     * - ready
+     * - preupdate
+     * - update
+     * - postupdate
+     * - resize
+     * - pause
+     * - resume
+     * - sleep
+     * - wake
+     * - transitioninit
+     * - transitionstart
+     * - transitioncomplete
+     * - transitionout
+     * - shutdown
+     * - destroy
+     *
      * At the very least you should offer a destroy handler for when the Scene closes down, i.e:
      *
      * ```javascript


### PR DESCRIPTION
* Removes BasePlugin#boot
* Docs updates for BasePlugin and ScenePlugin

In particular, only global plugins use `init()`, `start()`, `stop()` and only scene plugins use `boot()`, `scene`, `systems` (#4471).

I removed BasePlugin#boot since Phaser never calls it for global plugins, as far as I can tell. That could be a breaking change if someone has made a scene plugin by extending BasePlugin only and their plugin class doesn’t define its own boot() method. But I expect most people are extending ScenePlugin.

Should I remove BasePlugin#scene and BasePlugin#systems as well?
