### PR TITLE
expose ParseXMLBitmapFont for combined XML font file

### DIFF
--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -622,7 +622,7 @@ BitmapText.ParseFromAtlas = ParseFromAtlas;
  *
  * @name Phaser.GameObjects.BitmapText.ParseXMLBitmapFont
  * @type {function}
- * @since 3.0.0
+ * @since 3.17.0
  *
  * @param {XMLDocument} xml - The XML Document to parse the font from.
  * @param {integer} [xSpacing=0] - The x-axis spacing to add between each letter.

--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -9,6 +9,7 @@ var Components = require('../../components');
 var GameObject = require('../../GameObject');
 var GetBitmapTextSize = require('../GetBitmapTextSize');
 var ParseFromAtlas = require('../ParseFromAtlas');
+var ParseXMLBitmapFont = require('../ParseXMLBitmapFont');
 var Render = require('./BitmapTextRender');
 
 /**
@@ -615,5 +616,21 @@ BitmapText.ALIGN_RIGHT = 2;
  * @return {boolean} Whether the parsing was successful or not.
  */
 BitmapText.ParseFromAtlas = ParseFromAtlas;
+
+/**
+ * Parse an XML font to Bitmap Font data for the Bitmap Font cache.
+ *
+ * @name Phaser.GameObjects.BitmapText.ParseXMLBitmapFont
+ * @type {function}
+ * @since 3.0.0
+ *
+ * @param {XMLDocument} xml - The XML Document to parse the font from.
+ * @param {integer} [xSpacing=0] - The x-axis spacing to add between each letter.
+ * @param {integer} [ySpacing=0] - The y-axis spacing to add to the line height.
+ * @param {Phaser.Textures.Frame} [frame] - The texture frame to take into account while parsing.
+ *
+ * @return {Phaser.GameObjects.BitmapText.Types.BitmapFontData} The parsed Bitmap Font data.
+ */
+BitmapText.ParseXMLBitmapFont = ParseXMLBitmapFont;
 
 module.exports = BitmapText;


### PR DESCRIPTION
Describe the changes below:

the situation is:
I have 16 font.xml which take a lot of parallel downloading slots, so I combined them into just 1 file:

    <fonts>
        <font..... />
        <font.... />
        <font.... />
    </fonts>

then use this code to parse when loaded:

        const fontNodes = this.cache.xml.get("cmmfnt").getElementsByTagName("font");  // all font nodes
        for (const font of fontNodes) {
            const faceName = font.getElementsByTagName("info")[0].getAttribute("face");    // font name
            const fontData = Phaser.GameObjects.BitmapText.ParseXMLBitmapFont(font);    // use the exposed static method to parse
            const frame = this.sys.textures.getFrame("cmmfnt", faceName);
            if (frame && fontData) {
                console.info(` ---> ${ faceName }`);
                this.sys.cache.bitmapFont.add(faceName, { data: fontData, texture: "cmmfnt", frame: faceName });      // then add to cache
            } else
                throw new Error(`Invalid font ${ faceName } data`);
        }

actually this piece of code is the same content as what `Phaser.GameObjects.BitmapText.ParseFromAtlas` does, but it does not accept XML node object as an argument but needs a cache key instead.

so now there are 2 static method on `Phaser.GameObjects.BitmapText`:
1. `ParseFromAtlas`
2. `ParseXMLBitmapFont`

is this acceptable?
