### PR TITLE
TypeScript: Improve `Phaser.Utils.Array.Matrix` types

### DIFF
--- a/src/utils/array/matrix/CheckMatrix.js
+++ b/src/utils/array/matrix/CheckMatrix.js
@@ -22,8 +22,11 @@
  *
  * @function Phaser.Utils.Array.Matrix.CheckMatrix
  * @since 3.0.0
+ * 
+ * @generic T
+ * @genericUse {T[][]} - [matrix]
  *
- * @param {array} matrix - The array to check.
+ * @param {T[][]} [matrix] - The array to check.
  *
  * @return {boolean} `true` if the given `matrix` array is a valid matrix.
  */

--- a/src/utils/array/matrix/MatrixToString.js
+++ b/src/utils/array/matrix/MatrixToString.js
@@ -13,7 +13,10 @@ var CheckMatrix = require('./CheckMatrix');
  * @function Phaser.Utils.Array.Matrix.MatrixToString
  * @since 3.0.0
  *
- * @param {array} matrix - A 2-dimensional array.
+ * @generic T
+ * @genericUse {T[][]} - [matrix]
+ *
+ * @param {T[][]} [matrix] - A 2-dimensional array.
  *
  * @return {string} A string representing the matrix.
  */

--- a/src/utils/array/matrix/ReverseColumns.js
+++ b/src/utils/array/matrix/ReverseColumns.js
@@ -10,9 +10,12 @@
  * @function Phaser.Utils.Array.Matrix.ReverseColumns
  * @since 3.0.0
  *
- * @param {array} matrix - The array matrix to reverse the columns for.
+ * @generic T
+ * @genericUse {T[][]} - [matrix,$return]
  *
- * @return {array} The column reversed matrix.
+ * @param {T[][]} [matrix] - The array matrix to reverse the columns for.
+ *
+ * @return {T[][]} The column reversed matrix.
  */
 var ReverseColumns = function (matrix)
 {

--- a/src/utils/array/matrix/ReverseRows.js
+++ b/src/utils/array/matrix/ReverseRows.js
@@ -10,9 +10,12 @@
  * @function Phaser.Utils.Array.Matrix.ReverseRows
  * @since 3.0.0
  *
- * @param {array} matrix - The array matrix to reverse the rows for.
+ * @generic T
+ * @genericUse {T[][]} - [matrix,$return]
  *
- * @return {array} The column reversed matrix.
+ * @param {T[][]} [matrix] - The array matrix to reverse the rows for.
+ *
+ * @return {T[][]} The column reversed matrix.
  */
 var ReverseRows = function (matrix)
 {

--- a/src/utils/array/matrix/Rotate180.js
+++ b/src/utils/array/matrix/Rotate180.js
@@ -12,9 +12,12 @@ var RotateMatrix = require('./RotateMatrix');
  * @function Phaser.Utils.Array.Matrix.Rotate180
  * @since 3.0.0
  *
- * @param {array} matrix - The array to rotate.
+ * @generic T
+ * @genericUse {T[][]} - [matrix,$return]
  *
- * @return {array} The rotated matrix array. The source matrix should be discard for the returned matrix.
+ * @param {T[][]} [matrix] - The array to rotate.
+ *
+ * @return {T[][]} The rotated matrix array. The source matrix should be discard for the returned matrix.
  */
 var Rotate180 = function (matrix)
 {

--- a/src/utils/array/matrix/RotateLeft.js
+++ b/src/utils/array/matrix/RotateLeft.js
@@ -12,9 +12,12 @@ var RotateMatrix = require('./RotateMatrix');
  * @function Phaser.Utils.Array.Matrix.RotateLeft
  * @since 3.0.0
  *
- * @param {array} matrix - The array to rotate.
+ * @generic T
+ * @genericUse {T[][]} - [matrix,$return]
  *
- * @return {array} The rotated matrix array. The source matrix should be discard for the returned matrix.
+ * @param {T[][]} [matrix] - The array to rotate.
+ *
+ * @return {T[][]} The rotated matrix array. The source matrix should be discard for the returned matrix.
  */
 var RotateLeft = function (matrix)
 {

--- a/src/utils/array/matrix/RotateMatrix.js
+++ b/src/utils/array/matrix/RotateMatrix.js
@@ -18,10 +18,13 @@ var TransposeMatrix = require('./TransposeMatrix');
  * @function Phaser.Utils.Array.Matrix.RotateMatrix
  * @since 3.0.0
  *
- * @param {array} matrix - The array to rotate.
+ * @generic T
+ * @genericUse {T[][]} - [matrix,$return]
+ *
+ * @param {T[][]} [matrix] - The array to rotate.
  * @param {(number|string)} [direction=90] - The amount to rotate the matrix by.
  *
- * @return {array} The rotated matrix array. The source matrix should be discard for the returned matrix.
+ * @return {T[][]} The rotated matrix array. The source matrix should be discard for the returned matrix.
  */
 var RotateMatrix = function (matrix, direction)
 {

--- a/src/utils/array/matrix/RotateRight.js
+++ b/src/utils/array/matrix/RotateRight.js
@@ -12,9 +12,12 @@ var RotateMatrix = require('./RotateMatrix');
  * @function Phaser.Utils.Array.Matrix.RotateRight
  * @since 3.0.0
  *
- * @param {array} matrix - The array to rotate.
+ * @generic T
+ * @genericUse {T[][]} - [matrix,$return]
  *
- * @return {array} The rotated matrix array. The source matrix should be discard for the returned matrix.
+ * @param {T[][]} [matrix] - The array to rotate.
+ *
+ * @return {T[][]} The rotated matrix array. The source matrix should be discard for the returned matrix.
  */
 var RotateRight = function (matrix)
 {

--- a/src/utils/array/matrix/TransposeMatrix.js
+++ b/src/utils/array/matrix/TransposeMatrix.js
@@ -11,10 +11,13 @@
  *
  * @function Phaser.Utils.Array.Matrix.TransposeMatrix
  * @since 3.0.0
+ * 
+ * @generic T
+ * @genericUse {T[][]} - [array,$return]
+ * 
+ * @param {T[][]} [array] - The array matrix to transpose.
  *
- * @param {array} array - The array matrix to transpose.
- *
- * @return {array} A new array matrix which is a transposed version of the given array.
+ * @return {T[][]} A new array matrix which is a transposed version of the given array.
  */
 var TransposeMatrix = function (array)
 {


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:

In TypeScript, all `Phaser.Utils.Array.Matrix` methods now use a generic `T[][]` as their matrix type, instead of `any[]`