### PR TITLE
JSDoc fix returned object type

### DIFF
--- a/src/gameobjects/text/MeasureText.js
+++ b/src/gameobjects/text/MeasureText.js
@@ -14,7 +14,7 @@ var CanvasPool = require('../../display/canvas/CanvasPool');
  *
  * @param {Phaser.GameObjects.TextStyle} textStyle - The TextStyle object to measure.
  *
- * @return {object} An object containing the ascent, descent and fontSize of the TextStyle.
+ * @return {Phaser.Types.GameObjects.Text.TextMetrics} An object containing the ascent, descent and fontSize of the TextStyle.
  */
 var MeasureText = function (textStyle)
 {


### PR DESCRIPTION
This PR

* Updates JSDoc

Describe the changes below:
Fixed JSDoc @return type. With it we should be able to use metrics without having to cast them each time.
