### PR TITLE
Fixed separateCircle cause the position set NaN.

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1467,8 +1467,8 @@ var World = new Class({
         var dx = body1.position.x - body2.position.x;
         var dy = body1.position.y - body2.position.y;
         var d = Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2));
-        var nx = (body2.position.x - body1.position.x) / d;
-        var ny = (body2.position.y - body1.position.y) / d;
+        var nx = ((body2.position.x - body1.position.x) / d) || 0;
+        var ny = ((body2.position.y - body1.position.y) / d) || 0;
         var p = 2 * (body1.velocity.x * nx + body1.velocity.y * ny - body2.velocity.x * nx - body2.velocity.y * ny) / (body1.mass + body2.mass);
 
         if (!body1.immovable)


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

https://github.com/photonstorm/phaser/blob/v3.17.0/src/physics/arcade/World.js#L1470-L1471
```javascript
var nx = (body2.position.x - body1.position.x) / d;
var ny = (body2.position.y - body1.position.y) / d;
```
If (body2.position.x - body1.position.x) is equal to 0 and 'd' is equal to 0, then it is 0 / 0 = NaN.



https://codepen.io/hizzd/pen/zQBrbz?editors=0010
In this example, if the positions of the two sprites are the same, the position will be updated to NaN.


