### PR TITLE
Use `customHitArea` in condition

### DIFF
--- a/src/gameobjects/zone/Zone.js
+++ b/src/gameobjects/zone/Zone.js
@@ -165,10 +165,12 @@ var Zone = new Class({
         this.width = width;
         this.height = height;
 
-        if (resizeInput && this.input && this.input.hitArea instanceof Rectangle)
+        var input = this.input;
+
+        if (resizeInput && input && !input.customHitArea)
         {
-            this.input.hitArea.width = width;
-            this.input.hitArea.height = height;
+            input.hitArea.width = width;
+            input.hitArea.height = height;
         }
 
         return this;


### PR DESCRIPTION
This PR (delete as applicable)

does not add a new feature, not fix a bug.

It uses new `customHitArea` property (added in 3.17.0) in hitArea checking condition, like text game object.