### PR TITLE
drawDebug, display checkCollision sides

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1424,7 +1424,12 @@ var Body = new Class({
             }
             else
             {
-                graphic.strokeRect(pos.x, pos.y, this.width, this.height);
+                //graphic.strokeRect(pos.x, pos.y, this.width, this.height);
+                // only draw the sides where checkCollision is true, similar to debugger in layer
+				if (this.checkCollision.up)    { graphic.lineBetween(pos.x,              pos.y,               pos.x + this.width, pos.y); }
+				if (this.checkCollision.right) { graphic.lineBetween(pos.x + this.width, pos.y,               pos.x + this.width, pos.y + this.height); }
+				if (this.checkCollision.down)  { graphic.lineBetween(pos.x,              pos.y + this.height, pos.x + this.width, pos.y + this.height); }
+				if (this.checkCollision.left)  { graphic.lineBetween(pos.x,              pos.y,               pos.x,              pos.y + this.height); }
             }
         }
 

--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1426,10 +1426,22 @@ var Body = new Class({
             {
                 //graphic.strokeRect(pos.x, pos.y, this.width, this.height);
                 // only draw the sides where checkCollision is true, similar to debugger in layer
-				if (this.checkCollision.up)    { graphic.lineBetween(pos.x,              pos.y,               pos.x + this.width, pos.y); }
-				if (this.checkCollision.right) { graphic.lineBetween(pos.x + this.width, pos.y,               pos.x + this.width, pos.y + this.height); }
-				if (this.checkCollision.down)  { graphic.lineBetween(pos.x,              pos.y + this.height, pos.x + this.width, pos.y + this.height); }
-				if (this.checkCollision.left)  { graphic.lineBetween(pos.x,              pos.y,               pos.x,              pos.y + this.height); }
+				if (this.checkCollision.up)
+                {
+                    graphic.lineBetween(pos.x, pos.y, pos.x + this.width, pos.y);
+                }
+				if (this.checkCollision.right)
+                {
+                    graphic.lineBetween(pos.x + this.width, pos.y, pos.x + this.width, pos.y + this.height);
+                }
+				if (this.checkCollision.down)
+                {
+                    graphic.lineBetween(pos.x, pos.y + this.height, pos.x + this.width, pos.y + this.height);
+                }
+				if (this.checkCollision.left)
+                {
+                    graphic.lineBetween(pos.x, pos.y, pos.x, pos.y + this.height);
+                }
             }
         }
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR
* Adds a new feature

Describe the changes below:
drawDebug, instead of rectangle only draw the sides where checkCollision is true, similar to debugger in layer

