### PR TITLE
Warn when plugin entry is missing `plugin` property

### DIFF
--- a/src/plugins/PluginManager.js
+++ b/src/plugins/PluginManager.js
@@ -159,9 +159,17 @@ var PluginManager = new Class({
             mapping = GetFastValue(entry, 'mapping', null);
             data = GetFastValue(entry, 'data', null);
 
-            if (key && plugin)
+            if (key)
             {
-                this.install(key, plugin, start, mapping, data);
+                if (plugin)
+                {
+                    this.install(key, plugin, start, mapping, data);
+                }
+                else
+                {
+                    console.warn('Missing `plugin` for key: ' + key);
+                }
+                
             }
         }
 
@@ -181,9 +189,16 @@ var PluginManager = new Class({
             plugin = GetFastValue(entry, 'plugin', null);
             mapping = GetFastValue(entry, 'mapping', null);
 
-            if (key && plugin)
+            if (key)
             {
-                this.installScenePlugin(key, plugin, mapping);
+                if (plugin)
+                {
+                    this.installScenePlugin(key, plugin, mapping);
+                }
+                else
+                {
+                    console.warn('Missing `plugin` for key: ' + key);
+                }
             }
         }
 


### PR DESCRIPTION
This PR

* Adds a new feature

Adds a console warning when PluginManager skips installing a plugin (during boot) because the `plugin` value is missing or empty. IMHOP this change should help users catch this mistake and is also consistent with the warnings given by PluginManager.install() and PluginManager.installScenePlugin().
