### PR TITLE
Set canvas size equal to text object size

### DIFF
--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -1118,13 +1118,20 @@ var Text = new Class({
 
         var padding = this.padding;
 
+        var textWidth;
+
         if (style.fixedWidth === 0)
         {
             this.width = textSize.width + padding.left + padding.right;
+            textWidth = textSize.width;
         }
         else
         {
             this.width = style.fixedWidth;
+            textWidth = this.width - padding.left - padding.right;
+            if (textWidth < textSize.width) {
+                textWidth = textSize.width;
+            }
         }
 
         if (style.fixedHeight === 0)
@@ -1198,11 +1205,11 @@ var Text = new Class({
             }
             else if (style.align === 'right')
             {
-                linePositionX += textSize.width - textSize.lineWidths[i];
+                linePositionX += textWidth - textSize.lineWidths[i];
             }
             else if (style.align === 'center')
             {
-                linePositionX += (textSize.width - textSize.lineWidths[i]) / 2;
+                linePositionX += (textWidth - textSize.lineWidths[i]) / 2;
             }
 
             if (this.autoRound)

--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -1129,7 +1129,8 @@ var Text = new Class({
         {
             this.width = style.fixedWidth;
             textWidth = this.width - padding.left - padding.right;
-            if (textWidth < textSize.width) {
+            if (textWidth < textSize.width) 
+            {
                 textWidth = textSize.width;
             }
         }

--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -1118,12 +1118,9 @@ var Text = new Class({
 
         var padding = this.padding;
 
-        var w = textSize.width + padding.left + padding.right;
-        var h = textSize.height + padding.top + padding.bottom;
-
         if (style.fixedWidth === 0)
         {
-            this.width = w;
+            this.width = textSize.width + padding.left + padding.right;
         }
         else
         {
@@ -1132,22 +1129,15 @@ var Text = new Class({
 
         if (style.fixedHeight === 0)
         {
-            this.height = h;
+            this.height = textSize.height + padding.top + padding.bottom;
         }
         else
         {
             this.height = style.fixedHeight;
         }
 
-        if (w > this.width)
-        {
-            w = this.width;
-        }
-
-        if (h > this.height)
-        {
-            h = this.height;
-        }
+        var w = this.width;
+        var h = this.height;
 
         this.updateDisplayOrigin();
 

--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -185,7 +185,7 @@ var Text = new Class({
          * @private
          * @since 3.12.0
          */
-        this._text = '';
+        this._text = undefined;
 
         /**
          * Specify a padding value which is added to the line width and height when calculating the Text size.

--- a/src/gameobjects/text/static/TextCanvasRenderer.js
+++ b/src/gameobjects/text/static/TextCanvasRenderer.js
@@ -21,10 +21,12 @@
  */
 var TextCanvasRenderer = function (renderer, src, interpolationPercentage, camera, parentMatrix)
 {
-    if (src.text !== '')
+    if ((src.width === 0) || (src.height === 0))
     {
-        renderer.batchSprite(src, src.frame, camera, parentMatrix);
+        return;
     }
+
+    renderer.batchSprite(src, src.frame, camera, parentMatrix);
 };
 
 module.exports = TextCanvasRenderer;

--- a/src/gameobjects/text/static/TextWebGLRenderer.js
+++ b/src/gameobjects/text/static/TextWebGLRenderer.js
@@ -23,7 +23,7 @@ var Utils = require('../../../renderer/webgl/Utils');
  */
 var TextWebGLRenderer = function (renderer, src, interpolationPercentage, camera, parentMatrix)
 {
-    if (src.text === '')
+    if ((src.width === 0) || (src.height === 0))
     {
         return;
     }


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Canvas size might less than text object size, when `fixedWidth` and `fixedHeight` is set.
