### PR TITLE
fix addCanvas Memory Leak

### DIFF
--- a/src/textures/TextureManager.js
+++ b/src/textures/TextureManager.js
@@ -474,7 +474,6 @@ var TextureManager = new Class({
         }
 
         return null;
-        
     },
 
     /**

--- a/src/textures/TextureManager.js
+++ b/src/textures/TextureManager.js
@@ -460,7 +460,6 @@ var TextureManager = new Class({
     {
         if (skipCache === undefined) { skipCache = false; }
 
-
         if (skipCache)
         {
             return new CanvasTexture(this, key, source, source.width, source.height);
@@ -475,6 +474,7 @@ var TextureManager = new Class({
         }
 
         return null;
+        
     },
 
     /**

--- a/src/textures/TextureManager.js
+++ b/src/textures/TextureManager.js
@@ -460,6 +460,7 @@ var TextureManager = new Class({
     {
         if (skipCache === undefined) { skipCache = false; }
 
+
         if (skipCache)
         {
             return new CanvasTexture(this, key, source, source.width, source.height);
@@ -469,9 +470,11 @@ var TextureManager = new Class({
             this.list[key] = new CanvasTexture(this, key, source, source.width, source.height);
 
             this.emit(Events.ADD, key, this.list[key]);
-            
+
             return this.list[key];
         }
+
+        return null;
     },
 
     /**

--- a/src/textures/TextureManager.js
+++ b/src/textures/TextureManager.js
@@ -460,22 +460,18 @@ var TextureManager = new Class({
     {
         if (skipCache === undefined) { skipCache = false; }
 
-        var texture = null;
-
         if (skipCache)
         {
-            texture = new CanvasTexture(this, key, source, source.width, source.height);
+            return new CanvasTexture(this, key, source, source.width, source.height);
         }
         else if (this.checkKey(key))
         {
-            texture = new CanvasTexture(this, key, source, source.width, source.height);
+            this.list[key] = new CanvasTexture(this, key, source, source.width, source.height);
 
-            this.list[key] = texture;
-
-            this.emit(Events.ADD, key, texture);
+            this.emit(Events.ADD, key, this.list[key]);
+            
+            return this.list[key];
         }
-
-        return texture;
     },
 
     /**


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
src /  textures/ TextureManager.js

in the addCanvas function, there is a variable `texture` 
```javascript
var texture = null;
```
this variable will cause a reference to CanvasTexture instance, so Memory Leak happened

I test it by chrome dev tool - Memory snapshots

