### PR TITLE
Add types for tween `props` configs

### DIFF
--- a/src/tweens/typedefs/GetEndCallback.js
+++ b/src/tweens/typedefs/GetEndCallback.js
@@ -1,0 +1,10 @@
+/**
+ * @callback Phaser.Types.Tweens.GetEndCallback
+ * @since 3.18.0
+ *
+ * @param {any} target - The tween target.
+ * @param {string} key - The target property.
+ * @param {number} value - The current value of the target property.
+ *
+ * @return {number} - The new value.
+ */

--- a/src/tweens/typedefs/GetStartCallback.js
+++ b/src/tweens/typedefs/GetStartCallback.js
@@ -1,0 +1,10 @@
+/**
+ * @callback Phaser.Types.Tweens.GetStartCallback
+ * @since 3.18.0
+ *
+ * @param {any} target - The tween target.
+ * @param {string} key - The target property.
+ * @param {number} value - The current value of the target property.
+ *
+ * @return {number} - The new value.
+ */

--- a/src/tweens/typedefs/TweenBuilderConfig.js
+++ b/src/tweens/typedefs/TweenBuilderConfig.js
@@ -18,7 +18,7 @@
  * @property {number|function|object|array} [loop=0] - The number of times the tween will repeat. (A value of 1 means the tween will play twice, as it repeated once.) The first loop starts after every property tween has completed once.
  * @property {number|function|object|array} [loopDelay=0] - The time the tween will pause before starting either a yoyo or returning to the start for a repeat.
  * @property {boolean} [paused=false] - Does the tween start in a paused state (true) or playing (false)?
- * @property {object} [props] - The properties to tween.
+ * @property {Object.<string,(number|string|Phaser.Types.Tweens.GetEndCallback|Phaser.Types.Tweens.TweenPropConfig)>} [props] - The properties to tween.
  * @property {boolean} [useFrames=false] - Use frames or milliseconds?
  * @property {any} [callbackScope] - Scope (this) for the callbacks. The default scope is the tween.
  * @property {Phaser.Types.Tweens.TweenOnCompleteCallback} [onComplete] - A function to call when the tween completes.

--- a/src/tweens/typedefs/TweenPropConfig.js
+++ b/src/tweens/typedefs/TweenPropConfig.js
@@ -1,0 +1,17 @@
+/**
+ * @typedef {object} Phaser.Types.Tweens.TweenPropConfig
+ * @since 3.18.0
+ *
+ * @property {(number|string|Phaser.Types.Tweens.GetEndCallback|Phaser.Types.Tweens.TweenPropConfig)} [value] - What the property will be at the END of the Tween.
+ * @property {Phaser.Types.Tweens.GetEndCallback} [getEnd] - What the property will be at the END of the Tween.
+ * @property {Phaser.Types.Tweens.GetStartCallback} [getStart] - What the property will be at the START of the Tween.
+ * @property {(string|function)} [ease] - The ease function this tween uses.
+ * @property {number} [delay] - Time in ms/frames before tween will start.
+ * @property {number} [duration] - Duration of the tween in ms/frames.
+ * @property {boolean} [yoyo] - Determines whether the tween should return back to its start value after hold has expired.
+ * @property {number} [hold] - Time in ms/frames the tween will pause before repeating or returning to its starting value if yoyo is set to true.
+ * @property {number} [repeat] - Number of times to repeat the tween. The tween will always run once regardless, so a repeat value of '1' will play the tween twice.
+ * @property {number} [repeatDelay] - Time in ms/frames before the repeat will start.
+ * @property {boolean} [flipX] - Should toggleFlipX be called when yoyo or repeat happens?
+ * @property {boolean} [flipY] - Should toggleFlipY be called when yoyo or repeat happens?
+ */


### PR DESCRIPTION
This PR

* Updates the Documentation/TypeScript

Adds

- Phaser.Types.Tweens.GetEndCallback
- Phaser.Types.Tweens.GetStartCallback
- Phaser.Types.Tweens.TweenPropConfig