### PR TITLE
Use defaultStrokeWidth in drawDebug()

### DIFF
--- a/src/physics/arcade/StaticBody.js
+++ b/src/physics/arcade/StaticBody.js
@@ -800,7 +800,7 @@ var StaticBody = new Class({
 
         if (this.debugShowBody)
         {
-            graphic.lineStyle(1, this.debugBodyColor, 1);
+            graphic.lineStyle(graphic.defaultStrokeWidth, this.debugBodyColor, 1);
 
             if (this.isCircle)
             {


### PR DESCRIPTION
This PR

* Fixes a bug

This makes StaticBody display consistent with Body (#4069).

