### PR TITLE
Add Group#name

### DIFF
--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -114,6 +114,17 @@ var Group = new Class({
         this.classType = GetFastValue(config, 'classType', Sprite);
 
         /**
+         * The name of this group.
+         * Empty by default and never populated by Phaser, this is left for developers to use.
+         *
+         * @name Phaser.GameObjects.Group#name
+         * @type {string}
+         * @default ''
+         * @since 3.18.0
+         */
+        this.name = GetFastValue(config, 'name', '');
+
+        /**
          * Whether this group runs its {@link Phaser.GameObjects.Group#preUpdate} method
          * (which may update any members).
          *

--- a/src/gameobjects/group/typedefs/GroupConfig.js
+++ b/src/gameobjects/group/typedefs/GroupConfig.js
@@ -3,6 +3,7 @@
  * @since 3.0.0
  *
  * @property {?Function} [classType=Sprite] - Sets {@link Phaser.GameObjects.Group#classType}.
+ * @property {?string} [name=''] - Sets Sets {@link Phaser.GameObjects.Group#name}.
  * @property {?boolean} [active=true] - Sets {@link Phaser.GameObjects.Group#active}.
  * @property {?number} [maxSize=-1] - Sets {@link Phaser.GameObjects.Group#maxSize}.
  * @property {?string} [defaultKey=null] - Sets {@link Phaser.GameObjects.Group#defaultKey}.


### PR DESCRIPTION
This PR

* Adds a new feature

Adds a `name` property for Groups. Can be set via GroupCreateConfig.

