### PR TITLE
Correct emitOnly values for particle emitter angle, lifespan, x, y

### DIFF
--- a/src/gameobjects/particles/EmitterOp.js
+++ b/src/gameobjects/particles/EmitterOp.js
@@ -535,9 +535,9 @@ var EmitterOp = new Class({
     },
 
     /**
-     * An `onEmit` callback that returns an eased value between the
-     * {@link Phaser.GameObjects.Particles.EmitterOp#start} and {@link Phaser.GameObjects.Particles.EmitterOp#end}
-     * range.
+     * An `onEmit` callback for an eased property.
+     *
+     * It prepares the particle for easing by {@link Phaser.GameObjects.Particles.EmitterOp#easeValueUpdate}.
      *
      * @method Phaser.GameObjects.Particles.EmitterOp#easedValueEmit
      * @since 3.0.0
@@ -545,7 +545,7 @@ var EmitterOp = new Class({
      * @param {Phaser.GameObjects.Particles.Particle} particle - The particle.
      * @param {string} key - The name of the property.
      *
-     * @return {number} The new value of the property.
+     * @return {number} {@link Phaser.GameObjects.Particles.EmitterOp#start}, as the new value of the property.
      */
     easedValueEmit: function (particle, key)
     {

--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -182,7 +182,7 @@ var ParticleEmitter = new Class({
          * @since 3.0.0
          * @see Phaser.GameObjects.Particles.ParticleEmitter#setPosition
          */
-        this.x = new EmitterOp(config, 'x', 0);
+        this.x = new EmitterOp(config, 'x', 0, true);
 
         /**
          * The y-coordinate of the particle origin (where particles will be emitted).
@@ -193,7 +193,7 @@ var ParticleEmitter = new Class({
          * @since 3.0.0
          * @see Phaser.GameObjects.Particles.ParticleEmitter#setPosition
          */
-        this.y = new EmitterOp(config, 'y', 0);
+        this.y = new EmitterOp(config, 'y', 0, true);
 
         /**
          * A radial emitter will emit particles in all directions between angle min and max,
@@ -396,7 +396,7 @@ var ParticleEmitter = new Class({
          * @since 3.0.0
          * @see Phaser.GameObjects.Particles.ParticleEmitter#setLifespan
          */
-        this.lifespan = new EmitterOp(config, 'lifespan', 1000);
+        this.lifespan = new EmitterOp(config, 'lifespan', 1000, true);
 
         /**
          * The angle of the initial velocity of emitted particles, in degrees.
@@ -407,7 +407,7 @@ var ParticleEmitter = new Class({
          * @since 3.0.0
          * @see Phaser.GameObjects.Particles.ParticleEmitter#setAngle
          */
-        this.angle = new EmitterOp(config, 'angle', { min: 0, max: 360 });
+        this.angle = new EmitterOp(config, 'angle', { min: 0, max: 360 }, true);
 
         /**
          * The rotation of emitted particles, in degrees.
@@ -1082,8 +1082,8 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#setPosition
      * @since 3.0.0
      *
-     * @param {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} x - The x-coordinate of the particle origin.
-     * @param {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} y - The y-coordinate of the particle origin.
+     * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} x - The x-coordinate of the particle origin.
+     * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} y - The y-coordinate of the particle origin.
      *
      * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
      */
@@ -1346,7 +1346,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#setAngle
      * @since 3.0.0
      *
-     * @param {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} value - The angle of the initial velocity of emitted particles.
+     * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} value - The angle of the initial velocity of emitted particles.
      *
      * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
      */
@@ -1363,7 +1363,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#setLifespan
      * @since 3.0.0
      *
-     * @param {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} value - The particle lifespan, in ms.
+     * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} value - The particle lifespan, in ms.
      *
      * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
      */

--- a/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
+++ b/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
@@ -29,10 +29,10 @@
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [accelerationX] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#accelerationX} (emit only).
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [accelerationY] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#accelerationY} (emit only).
  * @property {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} [alpha] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#alpha}.
- * @property {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} [angle] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#angle}.
+ * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [angle] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#angle} (emit only).
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [bounce] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#bounce} (emit only).
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [delay] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#delay} (emit only).
- * @property {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} [lifespan] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#lifespan}.
+ * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [lifespan] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#lifespan} (emit only).
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [maxVelocityX] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#maxVelocityX} (emit only).
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [maxVelocityY] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#maxVelocityY} (emit only).
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [moveToX] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#moveToX} (emit only).
@@ -46,8 +46,8 @@
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [speedX] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#speedX} (emit only).
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [speedY] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#speedY} (emit only).
  * @property {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} [tint] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#tint}.
- * @property {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} [x] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#x}.
- * @property {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} [y] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#y}.
+ * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [x] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#x} (emit only).
+ * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [y] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#y} (emit only).
  * @property {object} [emitZone] - As {@link Phaser.GameObjects.Particles.ParticleEmitter#setEmitZone}.
  * @property {Phaser.Types.GameObjects.Particles.ParticleEmitterBounds|Phaser.Types.GameObjects.Particles.ParticleEmitterBoundsAlt} [bounds] - As {@link Phaser.GameObjects.Particles.ParticleEmitter#setBounds}.
  * @property {object} [followOffset] - Assigns to {@link Phaser.GameObjects.Particles.ParticleEmitter#followOffset}.


### PR DESCRIPTION
This PR

* Updates the Documentation
* Fixes a bug

I changed these to emitOnly=true because, judging from [Particle#update](https://photonstorm.github.io/phaser3-docs/Phaser.GameObjects.Particles.Particle.html#update), they're not actually updatable. (`alpha`, `rotate`, `scaleX`, `scaleY`, and `tint` are the only updatable emitter properties.)
