### PR TITLE
Correct docs of arcade physics body member

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -516,7 +516,7 @@ var Body = new Class({
         this.mass = 1;
 
         /**
-         * The calculated angle of this Body's velocity vector, in degrees, during the last step.
+         * The calculated angle of this Body's velocity vector, in radians, during the last step.
          *
          * @name Phaser.Physics.Arcade.Body#angle
          * @type {number}


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:

The member _angle_ of Phaser.Physics.Arcade.Body returns the value in radians, not degrees.
