### PR TITLE
Set (width,height) of arc/circle to (diameter,diameter)

### DIFF
--- a/src/gameobjects/shape/arc/Arc.js
+++ b/src/gameobjects/shape/arc/Arc.js
@@ -109,7 +109,9 @@ var Arc = new Class({
         this._iterations = 0.01;
 
         this.setPosition(x, y);
-        this.setSize(this.geom.radius, this.geom.radius);
+
+        var diameter = this.geom.radius * 2;
+        this.setSize(diameter, diameter);
 
         if (fillColor !== undefined)
         {


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Set (width,height) of arc/cricle to (diameter,diameter), not (radius,radius). #4123 