### PR TITLE
Fix EmitterOp config with { random: false }

### DIFF
--- a/src/gameobjects/particles/EmitterOp.js
+++ b/src/gameobjects/particles/EmitterOp.js
@@ -275,7 +275,7 @@ var EmitterOp = new Class({
             this.start = this.has(value, 'start') ? value.start : value.min;
             this.end = this.has(value, 'end') ? value.end : value.max;
 
-            var isRandom = (this.hasBoth(value, 'min', 'max') || this.has(value, 'random'));
+            var isRandom = (this.hasBoth(value, 'min', 'max') || !!value.random);
 
             //  A random starting value (using 'min | max' instead of 'start | end' automatically implies a random value)
 


### PR DESCRIPTION
This PR

* Fixes a bug

The docs imply that an EmitterOp value like

    { start: 0, end: 1, random: false }

should be identical to 

    { start: 0, end: 1 }

(i.e., nonrandom) but in practice it is identical to

    { start: 0, end: 1, random: true }
