### PR TITLE
Fix some JSDoc descriptions

### DIFF
--- a/plugins/camera3d/src/Camera.js
+++ b/plugins/camera3d/src/Camera.js
@@ -112,13 +112,12 @@ var Camera = new Class({
          */
         this.position = new Vector3();
 
-        //  The mapping from 3D size units to pixels.
-        //  In the default case 1 3D unit = 128 pixels. So a sprite that is
-        //  256 x 128 px in size will be 2 x 1 units.
-        //  Change to whatever best fits your game assets.
 
         /**
-         * [description]
+         *  The mapping from 3D size units to pixels.
+         *  In the default case 1 3D unit = 128 pixels. So a sprite that is
+         *  256 x 128 px in size will be 2 x 1 units.
+         *  Change to whatever best fits your game assets.
          *
          * @name Phaser.Cameras.Sprite3D#pixelScale
          * @type {number}

--- a/src/curves/Curve.js
+++ b/src/curves/Curve.js
@@ -203,10 +203,8 @@ var Curve = new Class({
         return this.getPointAt(1, out);
     },
 
-    // Get total curve arc length
-
     /**
-     * [description]
+     * Get total curve arc length
      *
      * @method Phaser.Curves.Curve#getLength
      * @since 3.0.0
@@ -220,10 +218,9 @@ var Curve = new Class({
         return lengths[lengths.length - 1];
     },
 
-    // Get list of cumulative segment lengths
 
     /**
-     * [description]
+     * Get list of cumulative segment lengths
      *
      * @method Phaser.Curves.Curve#getLengths
      * @since 3.0.0
@@ -382,13 +379,11 @@ var Curve = new Class({
         return this.getPointAt(0, out);
     },
 
-    // Returns a unit vector tangent at t
-    // In case any sub curve does not implement its tangent derivation,
-    // 2 points a small delta apart will be used to find its gradient
-    // which seems to give a reasonable approximation
-
     /**
-     * [description]
+     * Returns a unit vector tangent at t
+     * In case any sub curve does not implement its tangent derivation,
+     * 2 points a small delta apart will be used to find its gradient
+     * which seems to give a reasonable approximation
      *
      * @method Phaser.Curves.Curve#getTangent
      * @since 3.0.0

--- a/src/curves/path/Path.js
+++ b/src/curves/path/Path.js
@@ -690,10 +690,8 @@ var Path = new Class({
         return out.copy(this.startPoint);
     },
 
-    //  Creates a line curve from the previous end point to x/y
-
     /**
-     * [description]
+     * Creates a line curve from the previous end point to x/y
      *
      * @method Phaser.Curves.Path#lineTo
      * @since 3.0.0
@@ -780,10 +778,8 @@ var Path = new Class({
         };
     },
 
-    // cacheLengths must be recalculated.
-
     /**
-     * [description]
+     * cacheLengths must be recalculated.
      *
      * @method Phaser.Curves.Path#updateArcLengths
      * @since 3.0.0

--- a/src/geom/rectangle/GetSize.js
+++ b/src/geom/rectangle/GetSize.js
@@ -6,11 +6,10 @@
 
 var Point = require('../point/Point');
 
-//  The size of the Rectangle object, expressed as a Point object
-//  with the values of the width and height properties.
 
 /**
- * [description]
+ *  The size of the Rectangle object, expressed as a Point object
+ *  with the values of the width and height properties.
  *
  * @function Phaser.Geom.Rectangle.GetSize
  * @since 3.0.0

--- a/src/geom/rectangle/MarchingAnts.js
+++ b/src/geom/rectangle/MarchingAnts.js
@@ -7,11 +7,10 @@
 var Perimeter = require('./Perimeter');
 var Point = require('../point/Point');
 
-//  Return an array of points from the perimeter of the rectangle
-//  each spaced out based on the quantity or step required
 
 /**
- * [description]
+ *  Return an array of points from the perimeter of the rectangle
+ *  each spaced out based on the quantity or step required
  *
  * @function Phaser.Geom.Rectangle.MarchingAnts
  * @since 3.0.0


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR

* Updates the Documentation

Describe the changes below:
While reading the docs, I noticed that some methods had descriptions in the source code, but these were outside the JSDoc so they didn't appear in the online documentation.

Clear example of what I mean:
Online docs: [MarchingAnts in Rectangle](https://photonstorm.github.io/phaser3-docs/Phaser.Geom.Rectangle.html#.MarchingAnts__anchor)
Source code with description: [here](https://github.com/photonstorm/phaser/blob/v3.17.0/src/geom/rectangle/MarchingAnts.js#L9-L11)
