### PR TITLE
Set customHitArea to false if shape is not defined

### DIFF
--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -2101,6 +2101,7 @@ var InputPlugin = new Class({
         var cursor = false;
         var useHandCursor = false;
         var pixelPerfect = false;
+        var customHitArea = true;
 
         //  Config object?
         if (IsPlainObject(shape))
@@ -2127,6 +2128,7 @@ var InputPlugin = new Class({
             if (!shape || !callback)
             {
                 this.setHitAreaFromTexture(gameObjects);
+                customHitArea = false;
             }
         }
         else if (typeof shape === 'function' && !callback)
@@ -2147,7 +2149,7 @@ var InputPlugin = new Class({
 
             var io = (!gameObject.input) ? CreateInteractiveObject(gameObject, shape, callback) : gameObject.input;
 
-            io.customHitArea = true;
+            io.customHitArea = customHitArea;
             io.dropZone = dropZone;
             io.cursor = (useHandCursor) ? 'pointer' : cursor;
 


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

In [setHitArea](https://github.com/photonstorm/phaser/blob/master/src/input/InputPlugin.js#L2087) method, use [setHitAreaFromTexture](https://github.com/photonstorm/phaser/blob/master/src/input/InputPlugin.js#L2129) if shape is undefined. Suppose that it is *not* a case of `customHitArea`
