### PR TITLE
Fixed zero-length constraint and API inconsistency

### DIFF
--- a/src/physics/matter-js/Factory.js
+++ b/src/physics/matter-js/Factory.js
@@ -454,11 +454,7 @@ var Factory = new Class({
         options.bodyA = (bodyA.type === 'body') ? bodyA : bodyA.body;
         options.bodyB = (bodyB.type === 'body') ? bodyB : bodyB.body;
 
-        if (length)
-        {
-            options.length = length;
-        }
-
+        options.length = length;
         options.stiffness = stiffness;
 
         var constraint = Constraint.create(options);
@@ -487,6 +483,7 @@ var Factory = new Class({
         if (options === undefined) { options = {}; }
 
         options.bodyB = (bodyB.type === 'body') ? bodyB : bodyB.body;
+        
         options.length = length;
         options.stiffness = stiffness;
 

--- a/types/phaser.d.ts
+++ b/types/phaser.d.ts
@@ -64601,7 +64601,7 @@ declare namespace Phaser {
                  * @param stiffness [description] Default 1.
                  * @param options [description] Default {}.
                  */
-                constraint(bodyA: MatterJS.Body, bodyB: MatterJS.Body, length?: number, stiffness?: number, options?: object): MatterJS.Constraint;
+                constraint(bodyA: MatterJS.Body, bodyB: MatterJS.Body, length: number, stiffness?: number, options?: object): MatterJS.Constraint;
 
                 /**
                  * [description]


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

The constraint API no longer accepts zero-length constraints in 3.18. This broke my game, where I use zero-length constraints to attach sensors to my bodies.

I opted for fixing the problem by making the length parameter mandatory (as it was prior to 3.18), and dropping the check for zero.

An alternative fix could have been to keep optionality, and alter the check to accept zero.

Comparing the API to other constraint APIs (e.g. worldConstraint, spring, joint) it appears that the length parameter was not optional there either. I opted for API consistency. 

Hope this helps. 