### PR TITLE
Fix bug where graphics methods were using old names

### DIFF
--- a/src/tilemaps/components/RenderDebug.js
+++ b/src/tilemaps/components/RenderDebug.js
@@ -42,8 +42,8 @@ var RenderDebug = function (graphics, styleConfig, layer)
 
     var tiles = GetTilesWithin(0, 0, layer.width, layer.height, null, layer);
 
-    graphics.translate(layer.tilemapLayer.x, layer.tilemapLayer.y);
-    graphics.scale(layer.tilemapLayer.scaleX, layer.tilemapLayer.scaleY);
+    graphics.translateCanvas(layer.tilemapLayer.x, layer.tilemapLayer.y);
+    graphics.scaleCanvas(layer.tilemapLayer.scaleX, layer.tilemapLayer.scaleY);
 
     for (var i = 0; i < tiles.length; i++)
     {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR 

* Fixes a bug

Describe the changes below:
Change the name of the called methods to reflect the changes in 3.18.1

Specifically, change `graphics.translate` to `graphics.translateCanvas` and change `graphics.scale` to `graphics.scaleCanvas`. Did a search through the api and didn't find any other instances.
