### PR TITLE
New types for the optional scene methods

### DIFF
--- a/src/scene/Scene.js
+++ b/src/scene/Scene.js
@@ -11,6 +11,8 @@ var Systems = require('./Systems');
  * @classdesc
  * A base Phaser.Scene class which can be extended for your own use.
  *
+ * You can also define the optional methods {@link Phaser.Types.Scenes.SceneInitCallback init()}, {@link Phaser.Types.Scenes.ScenePreloadCallback preload()}, and {@link Phaser.Types.Scenes.SceneCreateCallback create()}.
+ *
  * @class Scene
  * @memberof Phaser
  * @constructor
@@ -292,36 +294,6 @@ var Scene = new Class({
     update: function ()
     {
     }
-
-    /**
-     * Can be defined on your own Scenes.
-     * This method is called by the Scene Manager when the scene starts, before `preload()` and `create()`.
-     *
-     * @method Phaser.Scene#init
-     * @since 3.0.0
-     *
-     * @param {object} data - Any data passed via `ScenePlugin.add()` or `ScenePlugin.start()`. Same as Scene.settings.data.
-     */
-
-    /**
-     * Can be defined on your own Scenes. Use it to load assets.
-     * This method is called by the Scene Manager, after `init()` and before `create()`, only if the Scene has a LoaderPlugin.
-     * After this method completes, if the LoaderPlugin's queue isn't empty, the LoaderPlugin will start automatically.
-     *
-     * @method Phaser.Scene#preload
-     * @since 3.0.0
-     */
-
-    /**
-     * Can be defined on your own Scenes. Use it to create your game objects.
-     * This method is called by the Scene Manager when the scene starts, after `init()` and `preload()`.
-     * If the LoaderPlugin started after `preload()`, then this method is called only after loading is complete.
-     *
-     * @method Phaser.Scene#create
-     * @since 3.0.0
-     *
-     * @param {object} data - Any data passed via `ScenePlugin.add()` or `ScenePlugin.start()`. Same as Scene.settings.data.
-     */
 
 });
 

--- a/src/scene/typedefs/CreateSceneFromObjectConfig.js
+++ b/src/scene/typedefs/CreateSceneFromObjectConfig.js
@@ -2,10 +2,10 @@
  * @typedef {object} Phaser.Types.Scenes.CreateSceneFromObjectConfig
  * @since 3.17.0
  *
- * @property {function} [init] - See {@link Phaser.Scene#init}.
- * @property {function} [preload] - See See {@link Phaser.Scene#preload}.
- * @property {function} [create] - See {@link Phaser.Scene#create}.
- * @property {function} [update] - See {@link Phaser.Scene#update}.
+ * @property {Phaser.Types.Scenes.SceneInitCallback} [init] - The scene's init callback.
+ * @property {Phaser.Types.Scenes.ScenePreloadCallback} [preload] - The scene's preload callback.
+ * @property {Phaser.Types.Scenes.SceneCreateCallback} [create] - The scene's create callback.
+ * @property {function} [update] - The scene's update callback. See {@link Phaser.Scene#update}.
  * @property {any} [extend] - Any additional properties, which will be copied to the Scene after it's created (except `data` or `sys`).
  * @property {any} [extend.data] - Any values, which will be merged into the Scene's Data Manager store.
  */

--- a/src/scene/typedefs/SceneCreateCallback.js
+++ b/src/scene/typedefs/SceneCreateCallback.js
@@ -1,0 +1,10 @@
+/**
+ * Can be defined on your own Scenes. Use it to create your game objects.
+ * This method is called by the Scene Manager when the scene starts, after `init()` and `preload()`.
+ * If the LoaderPlugin started after `preload()`, then this method is called only after loading is complete.
+ *
+ * @callback Phaser.Types.Scenes.SceneCreateCallback
+ * @since 3.0.0
+ *
+ * @param {object} data - Any data passed via `ScenePlugin.add()` or `ScenePlugin.start()`. Same as Scene.settings.data.
+ */

--- a/src/scene/typedefs/SceneInitCallback.js
+++ b/src/scene/typedefs/SceneInitCallback.js
@@ -1,0 +1,9 @@
+/**
+ * Can be defined on your own Scenes.
+ * This method is called by the Scene Manager when the scene starts, before `preload()` and `create()`.
+ *
+ * @callback Phaser.Types.Scenes.SceneInitCallback
+ * @since 3.0.0
+ *
+ * @param {object} data - Any data passed via `ScenePlugin.add()` or `ScenePlugin.start()`. Same as Scene.settings.data.
+ */

--- a/src/scene/typedefs/ScenePreloadCallback.js
+++ b/src/scene/typedefs/ScenePreloadCallback.js
@@ -1,0 +1,8 @@
+/**
+ * Can be defined on your own Scenes. Use it to load assets.
+ * This method is called by the Scene Manager, after `init()` and before `create()`, only if the Scene has a LoaderPlugin.
+ * After this method completes, if the LoaderPlugin's queue isn't empty, the LoaderPlugin will start automatically.
+ *
+ * @callback Phaser.Types.Scenes.ScenePreloadCallback
+ * @since 3.0.0
+ */


### PR DESCRIPTION
This PR

* Updates the Documentation

This makes the CreateSceneFromObjectConfig definitions more accurate and should finally add the extra scene methods to the JSDocs (#4469).
