### PR TITLE
Remove event hook of children when destroyChildren is false

### DIFF
--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -1134,22 +1134,7 @@ var Group = new Class({
             return;
         }
 
-        if (destroyChildren)
-        {
-            var children = this.children;
-
-            for (var i = 0; i < children.size; i++)
-            {
-                var gameObject = children.entries[i];
-
-                //  Remove the event hook first or it'll go all recursive hell on us
-                gameObject.off(Events.DESTROY, this.remove, this);
-
-                gameObject.destroy();
-            }
-        }
-
-        this.children.clear();
+        this.clear(false, destroyChildren);
 
         this.scene = undefined;
         this.children = undefined;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Previously, DESTROY event hook of children won't be removed when destroyChildren is false. 
It will fire error message when destroy children after group destroyed, for example,
```javascript
var txt = this.add.text(0, 0, 'abc');
this.add.group().add(txt).destroy(false);
txt.destroy();
```

Now the DESTROY event hook will be removed in all cases.