### PR TITLE
[Blitter] Set dirty flag only when render state of bob is changed

### DIFF
--- a/src/gameobjects/blitter/Bob.js
+++ b/src/gameobjects/blitter/Bob.js
@@ -343,8 +343,8 @@ var Bob = new Class({
 
         set: function (value)
         {
+            this.parent.dirty |= (this._visible !== value);
             this._visible = value;
-            this.parent.dirty = true;
         }
 
     },
@@ -367,8 +367,8 @@ var Bob = new Class({
 
         set: function (value)
         {
+            this.parent.dirty |= ((this._alpha > 0) !== (value > 0));
             this._alpha = value;
-            this.parent.dirty = true;
         }
 
     }


### PR DESCRIPTION
This PR (delete as applicable)

* Enhance a little performance

Describe the changes below:

Only set *dirty* flag when bob becomes invisible (visible === false, or alpha <= 0) from visible state, or from visible state to invisible state.
Use case: when bob.alpha is changed between 1 to 0.0000x, it won't set *dirty* flag.