### PR TITLE
Index ImageCollections during Tiled JSON parsing

### DIFF
--- a/src/tilemaps/parsers/tiled/BuildImageCollectionIndex.js
+++ b/src/tilemaps/parsers/tiled/BuildImageCollectionIndex.js
@@ -1,13 +1,13 @@
 /**
- * @author       Richard Davey <rich@photonstorm.com>
- * @copyright    2019 Photon Storm Ltd.
+ * @author       Faelin Landy <faelin.landy@gmail.com>
+ * @copyright    2019 Faelin Landy
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
 /**
  * Master list of tiles -> x, y, index in tileset.
  *
- * @function Phaser.Tilemaps.Parsers.Tiled.BuildTilesetIndex
+ * @function Phaser.Tilemaps.Parsers.Tiled.BuildImageCollectionIndex
  * @since 3.0.0
  *
  * @param {Phaser.Tilemaps.MapData} mapData - [description]

--- a/src/tilemaps/parsers/tiled/BuildImageCollectionIndex.js
+++ b/src/tilemaps/parsers/tiled/BuildImageCollectionIndex.js
@@ -1,0 +1,49 @@
+/**
+ * @author       Richard Davey <rich@photonstorm.com>
+ * @copyright    2019 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+/**
+ * Master list of tiles -> x, y, index in tileset.
+ *
+ * @function Phaser.Tilemaps.Parsers.Tiled.BuildTilesetIndex
+ * @since 3.0.0
+ *
+ * @param {Phaser.Tilemaps.MapData} mapData - [description]
+ *
+ * @return {array} [description]
+ */
+var BuildImageCollectionIndex = function (mapData)
+{
+    var tiles = [];
+
+    for (var i = 0; i < mapData.imageCollections.length; i++)
+    {
+        var set = mapData.imageCollections[i];
+
+        var x = set.imageMargin;
+        var y = set.imageMargin;
+
+        var count = 0;
+
+        for (var t = set.firstgid; t < set.firstgid + set.total; t++)
+        {
+            //  Can add extra properties here as needed
+            tiles[t] = [ x, y, i ];
+
+            x += set.imageWidth + set.imageSpacing;
+
+            count++;
+
+            if (count === set.total)
+            {
+                break;
+            }
+        }
+    }
+
+    return tiles;
+};
+
+module.exports = BuildImageCollectionIndex;

--- a/src/tilemaps/parsers/tiled/BuildTileIndex.js
+++ b/src/tilemaps/parsers/tiled/BuildTileIndex.js
@@ -1,0 +1,22 @@
+/**
+ * @author       Richard Davey <rich@photonstorm.com>
+ * @copyright    2019 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+/**
+ * Master list of tiles -> x, y, index in tileset.
+ *
+ * @function Phaser.Tilemaps.Parsers.Tiled.BuildTilesetIndex
+ * @since 3.0.0
+ *
+ * @param {Phaser.Tilemaps.MapData} mapData - [description]
+ *
+ * @return {array} [description]
+ */
+var BuildTileIndex = function (mapData)
+{
+    return tiles = BuildTilesetIndex(mapData).concat(BuildImageCollectionIndex(mapData));
+};
+
+module.exports = BuildTileIndex;

--- a/src/tilemaps/parsers/tiled/BuildTileIndex.js
+++ b/src/tilemaps/parsers/tiled/BuildTileIndex.js
@@ -1,13 +1,13 @@
 /**
- * @author       Richard Davey <rich@photonstorm.com>
- * @copyright    2019 Photon Storm Ltd.
+ * @author       Faelin Landy <faelin.landy@gmail.com>
+ * @copyright    2019 Faelin Landy
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
 /**
  * Master list of tiles -> x, y, index in tileset.
  *
- * @function Phaser.Tilemaps.Parsers.Tiled.BuildTilesetIndex
+ * @function Phaser.Tilemaps.Parsers.Tiled.BuildTileIndex
  * @since 3.0.0
  *
  * @param {Phaser.Tilemaps.MapData} mapData - [description]

--- a/src/tilemaps/parsers/tiled/ParseJSONTiled.js
+++ b/src/tilemaps/parsers/tiled/ParseJSONTiled.js
@@ -62,7 +62,7 @@ var ParseJSONTiled = function (name, json, insertNull)
 
     mapData.objects = ParseObjectLayers(json);
 
-    mapData.tiles = BuildTilesetIndex(mapData);
+    mapData.tiles = BuildTileIndex(mapData);
 
     AssignTileProperties(mapData);
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR:
* Adds a new feature
* Fixes a bug

_Describe the changes below:_

Adds two new functions that allow allows the `ParseJSONTiled` function to index ImageCollection tilesets. Previously, if an image collection was included in your Tiled JSON export, then the AssignTileProperties` function called from within `ParseJSONTiled` would look for tile GUIDs from the `mapData.layers` array, but not be able to find GUIDs that were described in an collection-of-images tileset, which causes a fatal error (`Cannot read property '2' of undefined`).

This PR provides a new `BuildImageCollectionIndex` function (based on `BuildTilesetIndex`) return an index array of GUIDs found in collection-of-images tilesets. To create a full index of tiles, `ParseJSONTiled` will now call the second new function, `BuildTileIndex`, which simply concatenates the arrays provided by `BuildImageCollectionIndex` and `BuildTilesetIndex`.


Final note:
This is my very first PR ever, so I apologize if I did anything badly. Please let me know if there is anything about the formatting/layout/information of the PR that I do better next time!