### PR TITLE
Datamanager feature: update(key, object, forceCreate)

### DIFF
--- a/src/data/DataManager.js
+++ b/src/data/DataManager.js
@@ -379,6 +379,35 @@ var DataManager = new Class({
     },
 
     /**
+     * @method Phaser.Data.DataManager#update
+     * @since 3.19.0
+     * @fires Phaser.Data.Events#CHANGE_DATA
+     * @param {string} key - the key of the object to be updated
+     * @param {*} object - object containing new fields for the key
+     * @param {boolean} forceCreate - if fields in object aren't present, create them
+     * 
+     * @return {Phaser.Data.DataManager} This DataManager object.
+     */
+    update: function(key, object, forceCreate)
+    {
+        var existing = this.get(key);
+
+        //If the object already exists
+        if(existing !== undefined){
+            for(var key in object){
+                //If the field exists inside the object, update, otherwise if forceCreate is true add field anyway
+                if(existing[key] !== null || forceCreate === true){
+                    existing[key] = object[key];
+                }
+            }
+
+            this.set(key, existing);
+        }
+
+        return this;
+    },
+
+    /**
      * Merge the given object of key value pairs into this DataManager.
      *
      * Any newly created values will emit a `setdata` event. Any updated values (see the `overwrite` argument)

--- a/src/data/DataManager.js
+++ b/src/data/DataManager.js
@@ -379,6 +379,9 @@ var DataManager = new Class({
     },
 
     /**
+     * Takes a partial or complete object and updates any corresponding fields for the object
+     * found using the key. Has an optional flag to ignore fields not already present in the 
+     * object
      * @method Phaser.Data.DataManager#update
      * @since 3.19.0
      * @fires Phaser.Data.Events#CHANGE_DATA
@@ -391,7 +394,7 @@ var DataManager = new Class({
     update: function(key, object, forceCreate)
     {
         var existing = this.get(key);
-
+        if(forceCreate === undefined){forceCreate = true}
         //If the object already exists
         if(existing !== undefined){
             for(var key in object){


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR:
Adds a new feature


Describe the changes below:
This adds an update method that will take an object and update the existing object in the datamanager with the fields in the object passed in. 

Example:

```
this.data.set('test', {x:10, y:20});
this.data.update('test', {x:20});

var newTest = this.data.get('test');
//newTest.x = 20, newTest.y = 20
```

