### PR TITLE
RenderTexture would not update texture size on resize

### DIFF
--- a/src/gameobjects/rendertexture/RenderTexture.js
+++ b/src/gameobjects/rendertexture/RenderTexture.js
@@ -349,7 +349,10 @@ var RenderTexture = new Class({
 
                 this.canvas.width = width;
                 this.canvas.height = height;
-
+                
+                this.texture.width = width;
+                this.texture.height = height;
+                
                 if (this.gl)
                 {
                     var gl = this.gl;


### PR DESCRIPTION
This PR Fixes a bug

Describe the changes below:
If the texture size is not updated on resize() then the subsequent calls to draw() or drawFrames() will produce a distorted output.

