### PR TITLE
update vertexComponentCount in WebGLPipeline addAttribute

### DIFF
--- a/src/renderer/webgl/WebGLPipeline.js
+++ b/src/renderer/webgl/WebGLPipeline.js
@@ -275,6 +275,10 @@ var WebGLPipeline = new Class({
             offset: offset
         });
 
+        this.vertexComponentCount = Utils.getComponentCount(
+            this.attributes,
+            this.gl
+        );
         return this;
     },
 


### PR DESCRIPTION
This PR enhance an already existing method

Describe the changes below:
If you want to  add an attribute you also need to update manually the vertexComponentCount afterwards, so I thought maybe we should do it in addAttribute as well.
