### PR TITLE
Expose BaseCamera module

### DIFF
--- a/src/cameras/2d/index.js
+++ b/src/cameras/2d/index.js
@@ -11,6 +11,7 @@
 module.exports = {
 
     Camera: require('./Camera'),
+    BaseCamera: require('./BaseCamera'),
     CameraManager: require('./CameraManager'),
     Effects: require('./effects'),
     Events: require('./events')


### PR DESCRIPTION
This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Expose BaseCamera module. Use-case: RenderTexture game object has an internal camera (BaseCamera).