### PR TITLE
Feature/Fix for issue #4510

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -1208,16 +1208,17 @@ var SceneManager = new Class({
      * @since 3.0.0
      *
      * @param {string} key - The Scene to stop.
+     * @param {object} [data] - Optional data object to pass to Scene.shutdown.
      *
      * @return {Phaser.Scenes.SceneManager} This SceneManager.
      */
-    stop: function (key)
+    stop: function (key, data)
     {
         var scene = this.getScene(key);
 
         if (scene && !scene.sys.isTransitioning())
         {
-            scene.sys.shutdown();
+            scene.sys.shutdown(data);
         }
 
         return this;


### PR DESCRIPTION
This PR Adds a new feature

### Description of changes:
As described in issue #4510 there was no parameter accepted in the SceneManager.stop() function so that data could be passed through to the shutdown event for the scene. This PR adds that parameter to stop and documents it in the JSDoc.  It is directly passed to the shutdown event and behaves as transient data just for the event not adjusting or falling back to sys.settings.data in any way.