### PR TITLE
Fix incorrect lighting when batching several sprites

### DIFF
--- a/src/renderer/webgl/pipelines/ForwardDiffuseLightPipeline.js
+++ b/src/renderer/webgl/pipelines/ForwardDiffuseLightPipeline.js
@@ -171,7 +171,9 @@ var ForwardDiffuseLightPipeline = new Class({
             renderer.setFloat1(program, lightName + 'intensity', light.intensity);
             renderer.setFloat1(program, lightName + 'radius', light.radius);
         }
-        
+
+        this.currentNormalMapRotation = null;
+
         return this;
     },
 
@@ -438,25 +440,35 @@ var ForwardDiffuseLightPipeline = new Class({
      */
     setNormalMapRotation: function (rotation)
     {
-        var inverseRotationMatrix = this.inverseRotationMatrix;
-
-        if (rotation)
+        if (rotation !== this.currentNormalMapRotation || this.batches.length === 0)
         {
-            var rot = -rotation;
-            var c = Math.cos(rot);
-            var s = Math.sin(rot);
+            if (this.batches.length > 0)
+            {
+                this.flush();
+            }
 
-            inverseRotationMatrix[1] = s;
-            inverseRotationMatrix[3] = -s;
-            inverseRotationMatrix[0] = inverseRotationMatrix[4] = c;
-        }
-        else
-        {
-            inverseRotationMatrix[0] = inverseRotationMatrix[4] = 1;
-            inverseRotationMatrix[1] = inverseRotationMatrix[3] = 0;
-        }
+            var inverseRotationMatrix = this.inverseRotationMatrix;
 
-        this.renderer.setMatrix3(this.program, 'uInverseRotationMatrix', false, inverseRotationMatrix);
+            if (rotation)
+            {
+                var rot = -rotation;
+                var c = Math.cos(rot);
+                var s = Math.sin(rot);
+
+                inverseRotationMatrix[1] = s;
+                inverseRotationMatrix[3] = -s;
+                inverseRotationMatrix[0] = inverseRotationMatrix[4] = c;
+            }
+            else
+            {
+                inverseRotationMatrix[0] = inverseRotationMatrix[4] = 1;
+                inverseRotationMatrix[1] = inverseRotationMatrix[3] = 0;
+            }
+
+            this.renderer.setMatrix3(this.program, 'uInverseRotationMatrix', false, inverseRotationMatrix);
+
+            this.currentNormalMapRotation = rotation;
+        }
     },
 
     /**


### PR DESCRIPTION

This PR
* Fixes a bug

Hello!

The lighting is not correct when batching several sprites with different rotations:
Each sprite should use its own uInverseRotationMatrix to compute the lighting correctly.
Because of the batching the uniform has the rotation of the last rendered sprite.

This is wrong so this PR add a check and flush the batching if needed.

Let me know if you have any question or if I need to change something!

Recorded issue here, the cursor is the light position:

![Peek 2019-10-06 20-48](https://user-images.githubusercontent.com/1249453/66274049-b7464280-e87a-11e9-94ed-83d3a649820a.gif)
