### PR TITLE
Move `remove-files-webpack-plugin` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "fs-extra": "^6.0.1",
     "jsdoc": "^3.6.1",
     "node-sloc": "^0.1.11",
+    "remove-files-webpack-plugin": "^1.1.3",
     "uglifyjs-webpack-plugin": "^1.3.0",
     "vivid-cli": "^1.1.2",
     "webpack": "^4.23.0",
@@ -79,7 +80,6 @@
     "eventemitter3": "^3.1.0",
     "exports-loader": "^0.7.0",
     "imports-loader": "^0.8.0",
-    "path": "^0.12.7",
-    "remove-files-webpack-plugin": "^1.1.3"
+    "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Surely, this dependency should be a devDependency.
I'm building my phaser app with [parceljs](https://parceljs.org/) and do not have `webpack` installed at all. As a consequence I'm running into this warning
```
warning "phaser > remove-files-webpack-plugin@1.1.3" has unmet peer dependency "webpack@*".
```

Everything works fine, because obviously I'm not running the build process when I depend on phaser.
