### PR TITLE
fix light2d using tileset from dynamictilemaplayer (#4167,#4079)

### DIFF
--- a/src/renderer/webgl/pipelines/ForwardDiffuseLightPipeline.js
+++ b/src/renderer/webgl/pipelines/ForwardDiffuseLightPipeline.js
@@ -250,7 +250,14 @@ var ForwardDiffuseLightPipeline = new Class({
         }
         else if (gameObject.tileset)
         {
-            normalTexture = gameObject.tileset.image.dataSource[0];
+            if (Array.isArray(gameObject.tileset))
+            {
+                normalTexture = gameObject.tileset[0].image.dataSource[0];
+            }
+            else
+            {
+                normalTexture = gameObject.tileset.image.dataSource[0];
+            }
         }
 
         if (!normalTexture)


### PR DESCRIPTION
This PR

* Fixes 2 bugs (#4167, #4079)

Dynamictilemaplayer is broken when used with light2d. The reason is that since Phaser v3.14 the tileset property is an array and not a single reference. Currently the code is referencing:

`normalTexture = gameObject.tileset.image.dataSource[0];`

the result is an Error breaking the whole application. To fix this we must replace it with:

`normalTexture = gameObject.tileset[0].image.dataSource[0];`

For safety reasons i added a check if gameObject.tileset is really an array with a fallback if not.

Yes, i ran the linter ;)