### PR TITLE
Fix IE compatibility with use of Number.MIN_SAFE_INTEGER & Number.MAX_SAFE_INTEGER

### DIFF
--- a/src/curves/path/Path.js
+++ b/src/curves/path/Path.js
@@ -404,8 +404,8 @@ var Path = new Class({
         out.y = Number.MAX_VALUE;
 
         var bounds = new Rectangle();
-        var maxRight = Number.MIN_SAFE_INTEGER;
-        var maxBottom = Number.MIN_SAFE_INTEGER;
+        var maxRight = Number.MIN_SAFE_INTEGER || -9007199254740991;
+        var maxBottom = Number.MIN_SAFE_INTEGER || -9007199254740991;
 
         for (var i = 0; i < this.curves.length; i++)
         {

--- a/src/gameobjects/video/Video.js
+++ b/src/gameobjects/video/Video.js
@@ -333,7 +333,7 @@ var Video = new Class({
          * @private
          * @since 3.20.0
          */
-        this._markerOut = Number.MAX_SAFE_INTEGER;
+        this._markerOut = Number.MAX_SAFE_INTEGER || 9007199254740991;
 
         /**
          * The last time the TextureSource was updated.

--- a/src/geom/rectangle/FromPoints.js
+++ b/src/geom/rectangle/FromPoints.js
@@ -39,8 +39,8 @@ var FromPoints = function (points, out)
     var minX = Number.MAX_VALUE;
     var minY = Number.MAX_VALUE;
 
-    var maxX = Number.MIN_SAFE_INTEGER;
-    var maxY = Number.MIN_SAFE_INTEGER;
+    var maxX = Number.MIN_SAFE_INTEGER || -9007199254740991;
+    var maxY = Number.MIN_SAFE_INTEGER || -9007199254740991;
 
     var p;
     var px;

--- a/src/tweens/builders/StaggerBuilder.js
+++ b/src/tweens/builders/StaggerBuilder.js
@@ -105,7 +105,7 @@ var StaggerBuilder = function (value, options)
             fromY = (gridHeight - 1) / 2;
         }
 
-        var gridMax = Number.MIN_SAFE_INTEGER;
+        var gridMax = Number.MIN_SAFE_INTEGER || -9007199254740991;
 
         for (var toY = 0; toY < gridHeight; toY++)
         {

--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -516,7 +516,7 @@ var Tween = new Class({
     calcDuration: function ()
     {
         var maxDuration = 0;
-        var minDelay = Number.MAX_SAFE_INTEGER;
+        var minDelay = Number.MAX_SAFE_INTEGER || 9007199254740991;
 
         var data = this.data;
 


### PR DESCRIPTION
This PR fixes a bug

Bug: 
tweens onStart callback is not invoked in IE (Events.TWEEN_START never dispatched)

Cause:
Number.MIN_SAFE_INTEGER & Number.MAX_SAFE_INTEGER are not supported in IE

See:
https://docs.w3cub.com/javascript/global_objects/number/min_safe_integer/
https://docs.w3cub.com/javascript/global_objects/number/max_safe_integer/

You could probably just set these constants once somewhere if they're not already set, instead of fixing every use of them, but I'm not familiar enough with the code base to know where I would do so