### PR TITLE
Fix for bug related to Issue #4737

### DIFF
--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -1564,6 +1564,13 @@ var Tilemap = new Class({
         if (index !== null)
         {
             SpliceOne(this.layers, index);
+            for (var i = index; i < this.layers.length; i++)
+            {
+                if (this.layers[i].tilemapLayer)
+                {
+                    this.layers[i].tilemapLayer.layerIndex--;
+                }
+            }
 
             if (this.currentLayerIndex === index)
             {


### PR DESCRIPTION
This PR
* Fixes a bug

Describe the changes below:
- When removing a layer from a tilemap, layerIndex on existing tilemapLayers can become invalid
- Added loop to fix any existing tilemapLayer.layerIndex values by decrementing
- Root cause of Issue #4737