### PR TITLE
Fix input-event bug in nested container

### DIFF
--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -2658,6 +2658,8 @@ var InputPlugin = new Class({
                     return indexB - indexA;
                 }
             }
+
+            return listB.length - listA.length;
         }
 
         //  Technically this shouldn't happen, but ...


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

[Here](https://codepen.io/rexrainbow/pen/wvvmxqj) is a demo of this issue: there is a (white rectangle) game object added into a nested container. This child and its parent's parent both have pointer-up event.
When pointer-up at this game object
- Pointer-up in top-left side, parent's parent container will fire event (Which is not correct, since child should fire event in this case)
- Others, child will fire event.


[Original thread of this issue](https://phaser.discourse.group/t/why-did-i-click-on-the-top-left-corner-of-the-gobtn-button-but-execute-layers-pointerup-event/4149)