### PR TITLE
Add `type` for Group, Arcade.Group, Arcade.StaticGroup

### DIFF
--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -104,6 +104,17 @@ var Group = new Class({
         this.isParent = true;
 
         /**
+         * A textual representation of this Game Object.
+         * Used internally by Phaser but is available for your own custom classes to populate.
+         *
+         * @name Phaser.GameObjects.Group#type
+         * @type {string}
+         * @default 'Group'
+         * @since 3.21.0
+         */
+        this.type = 'Group';
+
+        /**
          * The class to create new group members from.
          *
          * @name Phaser.GameObjects.Group#classType
@@ -291,7 +302,7 @@ var Group = new Class({
             for (var i = 0; i < config.length; i++)
             {
                 var entries = this.createFromConfig(config[i]);
-    
+
                 output = output.concat(entries);
             }
         }

--- a/src/physics/arcade/PhysicsGroup.js
+++ b/src/physics/arcade/PhysicsGroup.js
@@ -87,7 +87,7 @@ var PhysicsGroup = new Class({
 
         /**
          * The class to create new Group members from.
-         * 
+         *
          * This should be either `Phaser.Physics.Arcade.Image`, `Phaser.Physics.Arcade.Sprite`, or a class extending one of those.
          *
          * @name Phaser.Physics.Arcade.Group#classType
@@ -146,6 +146,17 @@ var PhysicsGroup = new Class({
         }
 
         Group.call(this, scene, children, config);
+
+        /**
+         * A textual representation of this Game Object.
+         * Used internally by Phaser but is available for your own custom classes to populate.
+         *
+         * @name Phaser.Physics.Arcade.Group#type
+         * @type {string}
+         * @default 'PhysicsGroup'
+         * @since 3.21.0
+         */
+        this.type = 'PhysicsGroup';
     },
 
     /**

--- a/src/physics/arcade/StaticPhysicsGroup.js
+++ b/src/physics/arcade/StaticPhysicsGroup.js
@@ -93,6 +93,17 @@ var StaticPhysicsGroup = new Class({
         this.physicsType = CONST.STATIC_BODY;
 
         Group.call(this, scene, children, config);
+
+        /**
+         * A textual representation of this Game Object.
+         * Used internally by Phaser but is available for your own custom classes to populate.
+         *
+         * @name Phaser.Physics.Arcade.Group#type
+         * @type {string}
+         * @default 'StaticPhysicsGroup'
+         * @since 3.21.0
+         */
+        this.type = 'StaticPhysicsGroup';
     },
 
     /**


### PR DESCRIPTION
This PR

* Adds a new feature

Adds a [type](https://photonstorm.github.io/phaser3-docs/Phaser.GameObjects.GameObject.html#type) property as in the other Game Objects. Could be useful for debugging or plugins.

The types are `Group`, `PhysicsGroup`, `StaticPhysicsGroup`.

