### PR TITLE
CHANGELOG.md typo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 * `Group.setVisible` is a new method that sets the visible state on each Group member (thanks @rexrainbow)
 * `WebAudioSoundManager.setAudioContext` is a new method that allows you to set the Sound Manager Audio Context to a different context instance. It will also disconnect and re-create the gain nodes on the new context.
 * `Group.type` is a new property that holds a string-based name of the Game Object type, as with other GO's (thanks @samme)
-* `Arade.Group.type` is a new property that holds a string-based name of the Game Object type, as with other GO's (thanks @samme)
+* `Arcade.Group.type` is a new property that holds a string-based name of the Game Object type, as with other GO's (thanks @samme)
 * `Arcade.StaticGroup.type` is a new property that holds a string-based name of the Game Object type, as with other GO's (thanks @samme)
 * `ArcadePhysics.overlapCirc` is a new method that allows you to return an array of all Arcade Physics bodies that overlap with the given circular area of the world. It can return either dynamic or static bodies, or a mixture of both (thanks @samme)
 


### PR DESCRIPTION
`Arade` to `Arcade`.
