### PR TITLE
Override default Curve.getUtoTmapping method

### DIFF
--- a/src/curves/LineCurve.js
+++ b/src/curves/LineCurve.js
@@ -215,8 +215,7 @@ var LineCurve = new Class({
         if (distance)
         {
             var arcLengths = this.getLengths(divisions);
-            var il = arcLengths.length;
-            var lineLength = arcLengths[il-1];
+            var lineLength = arcLengths[arcLengths.length - 1];
             //  Cannot overshoot the curve
             var targetLineLength = Math.min(distance, lineLength);
 

--- a/src/curves/LineCurve.js
+++ b/src/curves/LineCurve.js
@@ -194,6 +194,42 @@ var LineCurve = new Class({
         return tangent.normalize();
     },
 
+    //  Override default Curve.getUtoTmapping
+
+    /**
+     * [description]
+     *
+     * @method Phaser.Curves.Line#getUtoTmapping
+     * @since 3.0.0
+     *
+     * @param {number} u - [description]
+     * @param {integer} distance - [description]
+     * @param {integer} [divisions] - [description]
+     *
+     * @return {number} [description]
+     */
+    getUtoTmapping: function (u, distance, divisions)
+    {
+        var t;
+
+        if (distance)
+        {
+            var arcLengths = this.getLengths(divisions);
+            var il = arcLengths.length;
+            var lineLength = arcLengths[il-1];
+            //  Cannot overshoot the curve
+            var targetLineLength = Math.min(distance, lineLength);
+
+            t = targetLineLength / lineLength;
+        }
+        else
+        {
+            t = u;
+        }        
+
+        return t;
+    },
+
     //  Override default Curve.draw because this is better than calling getPoints on a line!
 
     /**


### PR DESCRIPTION
This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Since `u` is equal to `t` in LineCurve, `LineCurve.getUtoTmapping` could return `u` directly, to reduce calculation.

