### PR TITLE
changed L12 `"pointerup"` to `"pointerout"`

### DIFF
--- a/src/input/events/POINTER_OUT_EVENT.js
+++ b/src/input/events/POINTER_OUT_EVENT.js
@@ -9,7 +9,7 @@
  * 
  * This event is dispatched by the Input Plugin belonging to a Scene if a pointer moves out of any interactive Game Object.
  * 
- * Listen to this event from within a Scene using: `this.input.on('pointerup', listener)`.
+ * Listen to this event from within a Scene using: `this.input.on('pointerout', listener)`.
  * 
  * The event hierarchy is as follows:
  * 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:
I have changed `"pointerup"` to `"pointerout"` in the example to `POINTER_OUT` event section in the docs.
