### PR TITLE
Fix bug of game.destroy()

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -671,11 +671,11 @@ var Game = new Class({
      */
     runDestroy: function ()
     {
+        this.scene.destroy();
+        
         this.events.emit(Events.DESTROY);
 
         this.events.removeAllListeners();
-
-        this.scene.destroy();
 
         if (this.renderer)
         {


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Destroy scenes before destroying any global plugins.
Fix renderTexture destroy bug under game.destroy() #4849 , #4876 