### PR TITLE
Correct docs for Phaser.Math.GetSpeed()

### DIFF
--- a/src/math/GetSpeed.js
+++ b/src/math/GetSpeed.js
@@ -5,15 +5,19 @@
  */
 
 /**
- * Calculate the speed required to cover a distance in the time given.
+ * Calculate a per-ms speed from a distance and time (given in seconds).
  *
  * @function Phaser.Math.GetSpeed
  * @since 3.0.0
  *
- * @param {number} distance - The distance to travel in pixels.
- * @param {integer} time - The time, in ms, to cover the distance in.
+ * @param {number} distance - The distance.
+ * @param {integer} time - The time, in seconds.
  *
- * @return {number} The amount you will need to increment the position by each step in order to cover the distance in the time given.
+ * @return {number} The speed, in distance per ms.
+ *
+ * @example
+ * // 400px over 1 second is 0.4 px/ms
+ * Phaser.Math.GetSpeed(400, 1) // -> 0.4
  */
 var GetSpeed = function (distance, time)
 {


### PR DESCRIPTION
This PR

* Updates the Documentation

From the [examples](http://labs.phaser.io/edit.html?src=src/pools\bullets.js 'Bullet Pool') I'm guessing that GetSpeed's calculation is correct and the docs are incorrect.

Input `time` is seconds and output is distance per ms. 


Fixes #4895


