### PR TITLE
Fixed semicolon in updateList doc

### DIFF
--- a/src/gameobjects/GameObjectCreator.js
+++ b/src/gameobjects/GameObjectCreator.js
@@ -63,7 +63,7 @@ var GameObjectCreator = new Class({
         /**
          * A reference to the Scene Update List.
          *
-         * @name Phaser.GameObjects.GameObjectCreator#updateList;
+         * @name Phaser.GameObjects.GameObjectCreator#updateList
          * @type {Phaser.GameObjects.UpdateList}
          * @protected
          * @since 3.0.0

--- a/src/gameobjects/GameObjectFactory.js
+++ b/src/gameobjects/GameObjectFactory.js
@@ -62,7 +62,7 @@ var GameObjectFactory = new Class({
         /**
          * A reference to the Scene Update List.
          *
-         * @name Phaser.GameObjects.GameObjectFactory#updateList;
+         * @name Phaser.GameObjects.GameObjectFactory#updateList
          * @type {Phaser.GameObjects.UpdateList}
          * @protected
          * @since 3.0.0
@@ -105,7 +105,7 @@ var GameObjectFactory = new Class({
 
     /**
      * Adds an existing Game Object to this Scene.
-     * 
+     *
      * If the Game Object renders, it will be added to the Display List.
      * If it has a `preUpdate` method, it will be added to the Update List.
      *


### PR DESCRIPTION
This PR

* Updates the Documentation

Fixed semicolon in the `updateList` attribute doc in order to generate correctly the TS definition file.

