### PR TITLE
Fix doc static functions

### DIFF
--- a/src/gameobjects/bitmaptext/ParseFromAtlas.js
+++ b/src/gameobjects/bitmaptext/ParseFromAtlas.js
@@ -20,8 +20,8 @@ var ParseXMLBitmapFont = require('./ParseXMLBitmapFont');
  * @param {string} textureKey - The key of the BitmapFont's texture.
  * @param {string} frameKey - The key of the BitmapFont texture's frame.
  * @param {string} xmlKey - The key of the XML data of the font to parse.
- * @param {integer} xSpacing - The x-axis spacing to add between each letter.
- * @param {integer} ySpacing - The y-axis spacing to add to the line height.
+ * @param {integer} [xSpacing] - The x-axis spacing to add between each letter.
+ * @param {integer} [ySpacing] - The y-axis spacing to add to the line height.
  *
  * @return {boolean} Whether the parsing was successful or not.
  */

--- a/src/gameobjects/bitmaptext/static/BitmapText.js
+++ b/src/gameobjects/bitmaptext/static/BitmapText.js
@@ -15,7 +15,7 @@ var Render = require('./BitmapTextRender');
 /**
  * @classdesc
  * BitmapText objects work by taking a texture file and an XML or JSON file that describes the font structure.
- * 
+ *
  * During rendering for each letter of the text is rendered to the display, proportionally spaced out and aligned to
  * match the font structure.
  *
@@ -185,7 +185,7 @@ var BitmapText = new Class({
 
         /**
          * Internal cache var holding the maxWidth.
-         * 
+         *
          * @name Phaser.GameObjects.BitmapText#_maxWidth
          * @type {number}
          * @private
@@ -431,7 +431,7 @@ var BitmapText = new Class({
      * If no whitespace was found then no wrapping will take place and consequently the `maxWidth` value will not be honored.
      *
      * Disable maxWidth by setting the value to 0.
-     * 
+     *
      * You can set the whitespace character to be searched for by setting the `wordWrapCharCode` parameter or property.
      *
      * @method Phaser.GameObjects.BitmapText#setMaxWidth
@@ -690,8 +690,7 @@ BitmapText.ALIGN_RIGHT = 2;
  *
  * Adds the parsed Bitmap Font data to the cache with the `fontName` key.
  *
- * @name Phaser.GameObjects.BitmapText.ParseFromAtlas
- * @type {function}
+ * @method Phaser.GameObjects.BitmapText.ParseFromAtlas
  * @since 3.0.0
  *
  * @param {Phaser.Scene} scene - The Scene to parse the Bitmap Font for.
@@ -709,8 +708,7 @@ BitmapText.ParseFromAtlas = ParseFromAtlas;
 /**
  * Parse an XML font to Bitmap Font data for the Bitmap Font cache.
  *
- * @name Phaser.GameObjects.BitmapText.ParseXMLBitmapFont
- * @type {function}
+ * @method Phaser.GameObjects.BitmapText.ParseXMLBitmapFont
  * @since 3.17.0
  *
  * @param {XMLDocument} xml - The XML Document to parse the font from.

--- a/src/input/InputPluginCache.js
+++ b/src/input/InputPluginCache.js
@@ -22,11 +22,10 @@ var InputPluginCache = {};
  * Plugin is the object to instantiate to create the plugin
  * Mapping is what the plugin is injected into the Scene.Systems as (i.e. input)
  *
- * @name Phaser.Input.InputPluginCache.register
- * @type {function}
+ * @function Phaser.Input.InputPluginCache.register
  * @static
  * @since 3.10.0
- * 
+ *
  * @param {string} key - A reference used to get this plugin from the plugin cache.
  * @param {function} plugin - The plugin to be stored. Should be the core object, not instantiated.
  * @param {string} mapping - If this plugin is to be injected into the Input Plugin, this is the property key used.
@@ -41,11 +40,10 @@ InputPluginCache.register = function (key, plugin, mapping, settingsKey, configK
 /**
  * Returns the input plugin object from the cache based on the given key.
  *
- * @name Phaser.Input.InputPluginCache.getCore
- * @type {function}
+ * @function Phaser.Input.InputPluginCache.getCore
  * @static
  * @since 3.10.0
- * 
+ *
  * @param {string} key - The key of the input plugin to get.
  *
  * @return {Phaser.Types.Input.InputPluginContainer} The input plugin object.
@@ -58,11 +56,10 @@ InputPluginCache.getPlugin = function (key)
 /**
  * Installs all of the registered Input Plugins into the given target.
  *
- * @name Phaser.Input.InputPluginCache.install
- * @type {function}
+ * @function Phaser.Input.InputPluginCache.install
  * @static
  * @since 3.10.0
- * 
+ *
  * @param {Phaser.Input.InputPlugin} target - The target InputPlugin to install the plugins into.
  */
 InputPluginCache.install = function (target)
@@ -88,11 +85,10 @@ InputPluginCache.install = function (target)
 /**
  * Removes an input plugin based on the given key.
  *
- * @name Phaser.Input.InputPluginCache.remove
- * @type {function}
+ * @function Phaser.Input.InputPluginCache.remove
  * @static
  * @since 3.10.0
- * 
+ *
  * @param {string} key - The key of the input plugin to remove.
  */
 InputPluginCache.remove = function (key)


### PR DESCRIPTION
This PR 

* Updates the Documentation

1. Change some JSDoc types in order to get a complete TS definitions of the methods. This is the list of affected methods:

   `Phaser.GameObjects.BitmapText.ParseFromAtlas`
   `Phaser.GameObjects.BitmapText.ParseXMLBitmapFont`
   `Phaser.Input.InputPluginCache.getCore`
   `Phaser.Input.InputPluginCache.register`
   `Phaser.Input.InputPluginCache.install`
   `Phaser.Input.InputPluginCache.remove`

2. Add optional params to `ParseFromAtlas` function.


