### PR TITLE
Fix alpha for children of Container

### DIFF
--- a/src/gameobjects/container/ContainerWebGLRenderer.js
+++ b/src/gameobjects/container/ContainerWebGLRenderer.js
@@ -52,6 +52,7 @@ var ContainerWebGLRenderer = function (renderer, container, interpolationPercent
         renderer.setBlendMode(0);
     }
 
+    var alpha = container._alpha;
     var alphaTopLeft = container.alphaTopLeft;
     var alphaTopRight = container.alphaTopRight;
     var alphaBottomLeft = container.alphaBottomLeft;
@@ -72,6 +73,8 @@ var ContainerWebGLRenderer = function (renderer, container, interpolationPercent
             continue;
         }
 
+        var quadAlpha = child.constructor.name === 'Sprite';
+        var childAlpha = child.alpha;
         var childAlphaTopLeft;
         var childAlphaTopRight;
         var childAlphaBottomLeft;
@@ -123,14 +126,28 @@ var ContainerWebGLRenderer = function (renderer, container, interpolationPercent
         //  Set parent values
         child.setScrollFactor(childScrollFactorX * scrollFactorX, childScrollFactorY * scrollFactorY);
 
-        child.setAlpha(childAlphaTopLeft * alphaTopLeft, childAlphaTopRight * alphaTopRight, childAlphaBottomLeft * alphaBottomLeft, childAlphaBottomRight * alphaBottomRight);
+        if (quadAlpha)
+        {
+            child.setAlpha(childAlphaTopLeft * alphaTopLeft, childAlphaTopRight * alphaTopRight, childAlphaBottomLeft * alphaBottomLeft, childAlphaBottomRight * alphaBottomRight);
+        }
+        else
+        {
+            child.setAlpha(childAlpha * alpha)
+        }
 
         //  Render
         child.renderWebGL(renderer, child, interpolationPercentage, camera, transformMatrix);
 
         //  Restore original values
 
-        child.setAlpha(childAlphaTopLeft, childAlphaTopRight, childAlphaBottomLeft, childAlphaBottomRight);
+        if (quadAlpha)
+        {
+            child.setAlpha(childAlphaTopLeft, childAlphaTopRight, childAlphaBottomLeft, childAlphaBottomRight);
+        }
+        else
+        {
+            child.setAlpha(childAlpha)
+        }
 
         child.setScrollFactor(childScrollFactorX, childScrollFactorY);
 

--- a/src/gameobjects/container/ContainerWebGLRenderer.js
+++ b/src/gameobjects/container/ContainerWebGLRenderer.js
@@ -89,8 +89,6 @@ var ContainerWebGLRenderer = function (renderer, container, interpolationPercent
         }
         else
         {
-            var childAlpha = child.alpha;
-
             childAlphaTopLeft = childAlpha;
             childAlphaTopRight = childAlpha;
             childAlphaBottomLeft = childAlpha;

--- a/src/gameobjects/container/ContainerWebGLRenderer.js
+++ b/src/gameobjects/container/ContainerWebGLRenderer.js
@@ -132,7 +132,7 @@ var ContainerWebGLRenderer = function (renderer, container, interpolationPercent
         }
         else
         {
-            child.setAlpha(childAlpha * alpha)
+            child.setAlpha(childAlpha * alpha);
         }
 
         //  Render
@@ -146,7 +146,7 @@ var ContainerWebGLRenderer = function (renderer, container, interpolationPercent
         }
         else
         {
-            child.setAlpha(childAlpha)
+            child.setAlpha(childAlpha);
         }
 
         child.setScrollFactor(childScrollFactorX, childScrollFactorY);


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

# Issue https://github.com/photonstorm/phaser/issues/4916

Alpha of Container doesn't work for the children.

Demo:

- 3.19.0 https://codepen.io/laineus/pen/yLLqBOO
- 3.20.1 https://codepen.io/laineus/pen/JjjZgqJ

# Solution

I believe any Graphics can not be applied alpha in quad values.
But Container is setting quad alpha to the children kind of all.

So I checked if the child is Sprite to decide whether to set single value or quad values.