### PR TITLE
`deltaSmoothingMax` should at least larger than 0

### DIFF
--- a/src/core/TimeStep.js
+++ b/src/core/TimeStep.js
@@ -313,7 +313,7 @@ var TimeStep = new Class({
          * @default 10
          * @since 3.0.0
          */
-        this.deltaSmoothingMax = GetValue(config, 'deltaHistory', 10);
+        this.deltaSmoothingMax = Math.max(1, GetValue(config, 'deltaHistory', 10));
 
         /**
          * The number of frames that the cooldown is set to after the browser panics over the FPS rate, usually

--- a/src/gameobjects/rendertexture/RenderTexture.js
+++ b/src/gameobjects/rendertexture/RenderTexture.js
@@ -38,6 +38,7 @@ var UUID = require('../../utils/string/UUID');
  * @extends Phaser.GameObjects.Components.Alpha
  * @extends Phaser.GameObjects.Components.BlendMode
  * @extends Phaser.GameObjects.Components.ComputedSize
+ * @extends Phaser.GameObjects.Components.Crop
  * @extends Phaser.GameObjects.Components.Depth
  * @extends Phaser.GameObjects.Components.Flip
  * @extends Phaser.GameObjects.Components.GetBounds

--- a/src/scene/ScenePlugin.js
+++ b/src/scene/ScenePlugin.js
@@ -343,7 +343,7 @@ var ScenePlugin = new Class({
     checkValidTransition: function (target)
     {
         //  Not a valid target if it doesn't exist, isn't active or is already transitioning in or out
-        if (!target || target.sys.isActive() || target.sys.isTransitioning() || target === this.scene || this.systems.isTransitioning())
+        if (!target || !target.sys.isActive() || target.sys.isTransitioning() || target === this.scene || this.systems.isTransitioning())
         {
             return false;
         }


### PR DESCRIPTION
this variable is for accumulating avg FPS, but if user set 'deltaHistory' to 0 in the GameConfig, then in `step` method of `TimeStpe.js` it will get an NaN value.

https://github.com/photonstorm/phaser/blob/64690cf987937662f23aaa1fe536f1b166093b6e/src/core/TimeStep.js#L559-L567
