### PR TITLE
Throw an error when adding a sound from a missing asset

### DIFF
--- a/src/sound/html5/HTML5AudioSound.js
+++ b/src/sound/html5/HTML5AudioSound.js
@@ -47,9 +47,7 @@ var HTML5AudioSound = new Class({
 
         if (!this.tags)
         {
-            // eslint-disable-next-line no-console
-            console.warn('Audio cache entry missing: ' + key);
-            return;
+            throw new Error('There is no audio asset with key "' + key + '" in the audio cache');
         }
 
         /**

--- a/src/sound/webaudio/WebAudioSound.js
+++ b/src/sound/webaudio/WebAudioSound.js
@@ -45,9 +45,7 @@ var WebAudioSound = new Class({
 
         if (!this.audioBuffer)
         {
-            // eslint-disable-next-line no-console
-            console.warn('Audio cache entry missing: ' + key);
-            return;
+            throw new Error('There is no audio asset with key "' + key + '" in the audio cache');
         }
 
         /**


### PR DESCRIPTION
This PR

* Adds a new feature

Currently if you add a sound for a missing/wrong `key` and then play it you'll get

> [Warning] Audio cache entry missing: music  
> [Error] TypeError: undefined is not an object (evaluating 'this.currentConfig.seek = 0')

If you pause or resume instead you'll get a different TypeError.

The warning implies what the problem is but the error messages can be confusing to authors.

This PR throws an error from the constructor in place of the warning.

If authors need to handle a missing key condition they should avoid creating a sound, e.g.,

```js
if (this.cache.audio.has('music')) {
    this.add.sound('music').play();
}
```