### PR TITLE
Correct type for Phaser.Tilemaps.LayerData.data

### DIFF
--- a/src/tilemaps/mapdata/LayerData.js
+++ b/src/tilemaps/mapdata/LayerData.js
@@ -194,7 +194,7 @@ var LayerData = new Class({
          * An array of the tile indexes
          *
          * @name Phaser.Tilemaps.LayerData#data
-         * @type {(number[])}
+         * @type {Array.<Array.<Phaser.Tilemaps.Tile>>}
          * @since 3.0.0
          */
         this.data = GetFastValue(config, 'data', []);

--- a/src/tilemaps/mapdata/LayerData.js
+++ b/src/tilemaps/mapdata/LayerData.js
@@ -194,7 +194,7 @@ var LayerData = new Class({
          * An array of the tile indexes
          *
          * @name Phaser.Tilemaps.LayerData#data
-         * @type {Array.<Array.<Phaser.Tilemaps.Tile>>}
+         * @type {Phaser.Tilemaps.Tile[][]}
          * @since 3.0.0
          */
         this.data = GetFastValue(config, 'data', []);


### PR DESCRIPTION
* Updates the Documentation

Fixes #4904. Needs squashing.

