### PR TITLE
Changed tile getTint function to use getTintAppendFloatAlphaAndSwap

### DIFF
--- a/src/tilemaps/dynamiclayer/DynamicTilemapLayerWebGLRenderer.js
+++ b/src/tilemaps/dynamiclayer/DynamicTilemapLayerWebGLRenderer.js
@@ -36,7 +36,7 @@ var DynamicTilemapLayerWebGLRenderer = function (renderer, src, interpolationPer
     var gidMap = src.gidMap;
     var pipeline = src.pipeline;
 
-    var getTint = Utils.getTintAppendFloatAlpha;
+    var getTint = Utils.getTintAppendFloatAlphaAndSwap;
 
     var scrollFactorX = src.scrollFactorX;
     var scrollFactorY = src.scrollFactorY;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Currently tinting tilemap tiles gives unexpected colors when rendered, as referenced in issue 3882 (https://github.com/photonstorm/phaser/issues/3882). If I tried to tint a plain white tile blue for instance, it came out closer to orange. Experimenting a bit, it appeared that the "r" and "b" values of a tint were roughly being swapped at some point.

Diving into the source code, I found that the tile tint function was currently using the `Utils.getTintAppendFloatAlpha` function to calculate the tint value. I noticed there was a similar `Utils.getTintAppendFloatAlphaAndSwap` function. When tried, it appeared to fix the original issue with colors appearing as the original tints.

I'd very much like a second set of eyes on this change however, since I'm not familiar with the full Phaser rendering engine. I'd hate if the true issue was elsewhere in the codebase, and this was just a case of two wrongs making a right!


