### PR TITLE
Fixes external Fullscreen API calls being blocked by fullscreenchange listener

### DIFF
--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -347,16 +347,6 @@ var ScaleManager = new Class({
         this._createdFullscreenTarget = false;
 
         /**
-         * Internal var that keeps track of the user, or the browser, requesting fullscreen changes.
-         *
-         * @name Phaser.Scale.ScaleManager#_requestedFullscreenChange
-         * @type {boolean}
-         * @private
-         * @since 3.16.2
-         */
-        this._requestedFullscreenChange = false;
-
-        /**
          * The dirty state of the Scale Manager.
          * Set if there is a change between the parent size and the current size.
          *
@@ -1238,8 +1228,6 @@ var ScaleManager = new Class({
         {
             var fsTarget = this.getFullscreenTarget();
 
-            this._requestedFullscreenChange = true;
-
             var fsPromise;
             
             if (fullscreen.keyboard)
@@ -1382,8 +1370,6 @@ var ScaleManager = new Class({
 
         if (fullscreen.active)
         {
-            this._requestedFullscreenChange = true;
-
             document[fullscreen.cancel]();
         }
 
@@ -1490,12 +1476,10 @@ var ScaleManager = new Class({
     onFullScreenChange: function ()
     {
         //  They pressed ESC while in fullscreen mode
-        if (!this._requestedFullscreenChange)
+        if (!(document.fullscreenElement || document.webkitFullscreenElement || document.msFullscreenElement || document.mozFullScreenElement))
         {
             this.stopFullscreen();
         }
-
-        this._requestedFullscreenChange = false;
     },
 
     /**


### PR DESCRIPTION
This PR (delete as applicable)

* ~~Updates the Documentation~~
* ~~Adds a new feature~~
* Fixes a bug

**Describe the changes below:**

Related to: https://github.com/photonstorm/phaser/issues/4689

Fixes external calls to the Fullscreen API using `el.requestFullscreen()` from being blocked by Phaser.

If you have a Phaser game embedded into a web page, as Phaser will not know that requestFullscreen was called, and the `this._requestedFullscreenChange` flag was never set, the onFullScreenChange listener would fire `this.stopFullscreen()` right away.

**Background:**

`this._requestedFullscreenChange` was originally added to fix this issue: https://github.com/photonstorm/phaser/issues/4352
I have replaced this by checking if the browser is in fullscreen through `document.fullscreenElement`.

**How to reproduce the bug:**

You can goto any Phaser game in Chrome (because Chrome does not require it be fired from an input event in the console), and type `document.body.requestFullscreen();`.
The browser will go fullscreen, then it exits fullscreen right away.