### PR TITLE
add SpinePlugin, SpineGameObject, SpineFile d.ts

### DIFF
--- a/types/SpineFile.d.ts
+++ b/types/SpineFile.d.ts
@@ -1,0 +1,18 @@
+declare namespace Phaser.Loader.FileTypes {
+    interface SpineFileConfig {
+        key: string
+        textureURL?: string
+        textureExtension?: string
+        textureXhrSettings?: Phaser.Types.Loader.XHRSettingsObject
+        normalMap?: string
+        atlasURL?: string
+        atlasExtension?: string
+        atlasXhrSettings?: Phaser.Types.Loader.XHRSettingsObject
+    }
+
+    class SpineFile extends Phaser.Loader.MultiFile {
+        constructor(loader: Phaser.Loader.LoaderPlugin, key: string | Phaser.Loader.FileTypes.SpineFileConfig, jsonURL: string | string[], atlasURL: string, preMultipliedAlpha: boolean, jsonXhrSettings: Phaser.Types.Loader.XHRSettingsObject, atlasXhrSettings: Phaser.Types.Loader.XHRSettingsObject)
+
+        addToCache()
+	}
+}

--- a/types/SpineGameObject.d.ts
+++ b/types/SpineGameObject.d.ts
@@ -1,0 +1,85 @@
+/// <reference path="./spine.d.ts" />
+
+declare class SpineGameObject {
+    constructor(scene: Phaser.Scene, pluginManager: SpinePlugin, x: number, y: number, key?: string, animationName?: string, loop?: boolean)
+
+    alpha: number
+
+    readonly blendMode: number
+
+    blue: number
+    bounds: any
+    displayOriginX: number
+    displayOriginY: number
+    drawDebug: boolean
+    green: number
+    plugin: SpinePlugin
+    preMultipliedAlpha: boolean
+    red: number
+    root: spine.Bone
+    scaleX: number
+    scaleY: number
+    skeleton: spine.Skeleton
+    skeletonData: spine.SkeletonData
+    state: spine.AnimationState
+    stateData: spine.AnimationStateData
+    timeScale: number
+
+    addAnimation(trackIndex: integer, animationName: string, loop?: boolean, delay?: integer): spine.TrackEntry
+    angleBoneToXY(bone: spine.Bone, worldX: number, worldY: number, offset?: number, minAngle?: number, maxAngle?: number): SpineGameObject
+    clearTrack(trackIndex: integer): SpineGameObject
+    clearTracks(): SpineGameObject
+    findAnimation(animationName: string): spine.Animation
+    findBone(boneName: string): spine.Bone
+    findBoneIndex(boneName: string): number
+    findEvent(eventDataName: string): spine.EventData
+    findIkConstraint(constraintName: string): spine.IkConstraintData
+    findPathConstraint(constraintName: string): spine.PathConstraintData
+    findPathConstraintIndex(constraintName: string): number
+    findSkin(skinName: string): spine.Skin
+    findSlot(slotName: string): spine.Slot
+    findSlotIndex(slotName: string): number
+    findTransformConstraint(constraintName: string): spine.TransformConstraintData
+    getAnimationList(): string[]
+    getAttachment(slotIndex: integer, attachmentName: string): spine.Attachment
+    getAttachmentByName(slotName: string, attachmentName: string): spine.Attachment
+    getBoneList(): string[]
+    getBounds(): any
+    getCurrentAnimation(trackIndex?: integer): spine.Animation
+    getRootBone(): spine.Bone
+    getSkinList(): string[]
+    getSlotList(): string[]
+    play(animationName: string, loop?: boolean, ignoreIfPlaying?: boolean): SpineGameObject
+
+    protected preUpdate(time: number, delta: number): void
+    protected preDestroy(): void
+
+    refresh(): SpineGameObject
+    setAlpha(value?: number): SpineGameObject
+    setAnimation(trackIndex: integer, animationName: string, loop?: boolean, ignoreIfPlaying?: boolean): spine.TrackEntry
+    setAttachment(slotName: string, attachmentName: string): SpineGameObject
+    setBonesToSetupPose(): SpineGameObject
+    setColor(color?: integer, slotName?: string): SpineGameObject
+    setEmptyAnimation(trackIndex: integer, mixDuration?: integer): spine.TrackEntry
+    setMix(fromName: string, toName: string, duration?: number): SpineGameObject
+    setOffset(offsetX?: number, offsetY?: number): SpineGameObject
+    setSize(width?: number, height?: number, offsetX?: number, offsetY?: number): SpineGameObject
+    setSkeleton(atlasDataKey: string, skeletonJSON: object, animationName?: string, loop?: boolean): SpineGameObject
+    setSkeletonFromJSON(atlasDataKey: string, skeletonJSON: object, animationName?: string, loop?: boolean): SpineGameObject
+    setSkin(newSkin: spine.Skin): SpineGameObject
+    setSkinByName(skinName: string): SpineGameObject
+    setSlotsToSetupPose(): SpineGameObject
+    setToSetupPose(): SpineGameObject
+    updateSize(): SpineGameObject
+    willRender(): boolean
+}
+
+declare interface SpineGameObjectConfig extends Phaser.Types.GameObjects.GameObjectConfig
+{
+    key?: string
+    animationName?: string
+    loop?: boolean
+    skinName?: string
+    slotName?: string
+    attachmentName?: string
+}

--- a/types/SpinePlugin.d.ts
+++ b/types/SpinePlugin.d.ts
@@ -1,0 +1,57 @@
+/// <reference path="./spine.d.ts" />
+
+declare namespace Phaser.Loader {
+    interface LoaderPlugin extends Phaser.Events.EventEmitter {
+        spine(key: string | Phaser.Loader.FileTypes.SpineFileConfig | Phaser.Loader.FileTypes.SpineFileConfig[], jsonURL: string, atlasURL: string | string[], preMultipliedAlpha?: boolean, textureXhrSettings?: Phaser.Types.Loader.XHRSettingsObject, atlasXhrSettings?: Phaser.Types.Loader.XHRSettingsObject): LoaderPlugin
+    }
+}
+
+declare namespace Phaser.GameObjects {
+    interface GameObjectFactory {
+        spine(x: number, y: number, key?: string, aimationName?: string, loop?: boolean): SpineGameObject
+    }
+
+	interface GameObjectCreator {
+        spine(config: SpineGameObjectConfig, addToScene?: boolean): SpineGameObject
+    }
+}
+
+declare class SpinePlugin extends Phaser.Plugins.ScenePlugin {
+    constructor(scene: Phaser.Scene, pluginManager: Phaser.Plugins.PluginManager)
+
+    readonly isWebGL: boolean
+
+    cache: Phaser.Cache.BaseCache
+    spineTextures: Phaser.Cache.BaseCache
+    json: Phaser.Cache.BaseCache
+    textures: Phaser.Textures.TextureManager
+    drawDebug: boolean
+    gl: WebGLRenderingContext
+    renderer: Phaser.Renderer.Canvas.CanvasRenderer | Phaser.Renderer.WebGL.WebGLRenderer
+    sceneRenderer: spine.webgl.SceneRenderer
+    skeletonRenderer: spine.canvas.SkeletonRenderer | spine.webgl.SkeletonRenderer
+    skeletonDebugRenderer: spine.webgl.SkeletonDebugRenderer
+
+    plugin: typeof spine
+
+    getAtlasCanvas(key: string): spine.TextureAtlas
+    getAtlasWebGL(key: string): spine.TextureAtlas
+    worldToLocal(x: number, y: number, skeleton: spine.Skeleton, bone?: spine.Bone): spine.Vector2
+    getVector2(x: number, y: number): spine.Vector2
+    getVector3(x: number, y: number, z: number): spine.Vector2
+    setDebugBones(value?: boolean): SpinePlugin
+    setDebugRegionAttachments(value?: boolean): SpinePlugin
+    setDebugBoundingBoxes(value?: boolean): SpinePlugin
+    setDebugMeshHull(value?: boolean): SpinePlugin
+    setDebugMeshTriangles(value?: boolean): SpinePlugin
+    setDebugPaths(value?: boolean): SpinePlugin
+    setDebugSkeletonXY(value?: boolean): SpinePlugin
+    setDebugClipping(value?: boolean): SpinePlugin
+    setEffect(effect?: spine.VertexEffect): SpinePlugin
+    createSkeleton(key: string, skeletonJSON?: object): any | null
+    createAnimationState(skeleton: spine.Skeleton): any
+    getBounds(skeleton: spine.Skeleton): any
+    onResize(): void
+    add(x: number, y: number, key?: string, animationName?: string, loop?: boolean): SpineGameObject
+    make(config: SpineGameObjectConfig, addToScene?: boolean): SpineGameObject
+}


### PR DESCRIPTION
**This PR**

* Adds SpinePlugin TypeScript definition files
* reference issue #4759 

**Describe the changes below:**

Adds TypeScript definition files for:

- SpinePlugin
- SpineGameObject
- SpineFile

Added to the `types` folder. This should remove type check errors when using TypeScript and the SpinePlugin for things like `this.add.spine()`, `this.load.spine()`, etc.

I realize all the definition file names are currently lower case and match the corresponding .js files. But the SpinePlugin file names are in Pascal case so I chose that. Happy to change it if lower case or dash separated is preferred.

I've also kept it to 3 separate files to follow the existing `spine.d.ts`, `spine-canvas.d.ts`, and `spine-webgl.d.ts` convention which seems to mirror the existing .js files.

In SpineFile.d.ts I have namespaced `SpineFileConfig` to `Phaser.Loader.FileTypes` to follow the JSDoc (https://github.com/photonstorm/phaser/blob/v3.21.0/plugins/spine/src/SpineFile.js#L15). However, I see it referenced as being in `Phaser.Types.Loader.FileTypes` in other places.

The comments are also not included in the definition files with the thinking that it is better to have a single source for truth in the source files for the comments.

Happy to take guidance on this or any other changes to better match style and conventions.

