### PR TITLE
Check for disabled body in collideSpriteVsGroup()

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1948,7 +1948,7 @@ var World = new Class({
             {
                 bodyB = results[i];
 
-                if (bodyA === bodyB || !group.contains(bodyB.gameObject))
+                if (bodyA === bodyB || !bodyB.enable || !group.contains(bodyB.gameObject))
                 {
                     //  Skip if comparing against itself, or if bodyB isn't actually part of the Group
                     continue;


### PR DESCRIPTION
This PR

* Fixes a bug (optimization)

`group.contains()` can be skipped when the colliding body is disabled.
