### PR TITLE
Update documentation and one import, to use the consistent name of `Vector2`

### DIFF
--- a/src/cameras/2d/BaseCamera.js
+++ b/src/cameras/2d/BaseCamera.js
@@ -577,7 +577,7 @@ var BaseCamera = new Class({
      *
      * @param {number} x - The horizontal coordinate to center on.
      * @param {number} y - The vertical coordinate to center on.
-     * @param {Phaser.Math.Vector2} [out] - A Vec2 to store the values in. If not given a new Vec2 is created.
+     * @param {Phaser.Math.Vector2} [out] - A Vector2 to store the values in. If not given a new Vector2 is created.
      *
      * @return {Phaser.Math.Vector2} The scroll coordinates stored in the `x` and `y` properties.
      */

--- a/src/curves/path/Path.js
+++ b/src/curves/path/Path.js
@@ -198,12 +198,12 @@ var Path = new Class({
      * @method Phaser.Curves.Path#cubicBezierTo
      * @since 3.0.0
      *
-     * @param {(number|Phaser.Math.Vector2)} x - The x coordinate of the end point. Or, if a Vec2, the p1 value.
-     * @param {(number|Phaser.Math.Vector2)} y - The y coordinate of the end point. Or, if a Vec2, the p2 value.
-     * @param {(number|Phaser.Math.Vector2)} control1X - The x coordinate of the first control point. Or, if a Vec2, the p3 value.
-     * @param {number} [control1Y] - The y coordinate of the first control point. Not used if vec2s are provided as the first 3 arguments.
-     * @param {number} [control2X] - The x coordinate of the second control point. Not used if vec2s are provided as the first 3 arguments.
-     * @param {number} [control2Y] - The y coordinate of the second control point. Not used if vec2s are provided as the first 3 arguments.
+     * @param {(number|Phaser.Math.Vector2)} x - The x coordinate of the end point. Or, if a Vector2, the p1 value.
+     * @param {(number|Phaser.Math.Vector2)} y - The y coordinate of the end point. Or, if a Vector2, the p2 value.
+     * @param {(number|Phaser.Math.Vector2)} control1X - The x coordinate of the first control point. Or, if a Vector2, the p3 value.
+     * @param {number} [control1Y] - The y coordinate of the first control point. Not used if Vector2s are provided as the first 3 arguments.
+     * @param {number} [control2X] - The x coordinate of the second control point. Not used if Vector2s are provided as the first 3 arguments.
+     * @param {number} [control2Y] - The y coordinate of the second control point. Not used if Vector2s are provided as the first 3 arguments.
      *
      * @return {Phaser.Curves.Path} This Path object.
      */
@@ -214,7 +214,7 @@ var Path = new Class({
         var p2;
         var p3;
 
-        //  Assume they're all vec2s
+        //  Assume they're all Vector2s
         if (x instanceof Vector2)
         {
             p1 = x;
@@ -252,7 +252,7 @@ var Path = new Class({
         var p1;
         var p2;
 
-        //  Assume they're all vec2s
+        //  Assume they're all Vector2s
         if (x instanceof Vector2)
         {
             p1 = x;

--- a/src/gameobjects/shape/polygon/Polygon.js
+++ b/src/gameobjects/shape/polygon/Polygon.js
@@ -25,7 +25,7 @@ var Smooth = require('../../../geom/polygon/Smooth');
  * internal Polygon geometry object. The points can be set from a variety of formats:
  *
  * - A string containing paired values separated by a single space: `'40 0 40 20 100 20 100 80 40 80 40 100 0 50'`
- * - An array of Point or Vector2 objects: `[new Phaser.Math.Vec2(x1, y1), ...]`
+ * - An array of Point or Vector2 objects: `[new Phaser.Math.Vector2(x1, y1), ...]`
  * - An array of objects with public x/y properties: `[obj1, obj2, ...]`
  * - An array of paired numbers that represent point coordinates: `[x1,y1, x2,y2, ...]`
  * - An array of arrays with two elements representing x/y coordinates: `[[x1, y1], [x2, y2], ...]`

--- a/src/gameobjects/shape/polygon/PolygonFactory.js
+++ b/src/gameobjects/shape/polygon/PolygonFactory.js
@@ -22,7 +22,7 @@ var Polygon = require('./Polygon');
  * The Polygon Shape is created by providing a list of points, which are then used to create an
  * internal Polygon geometry object. The points can be set from a variety of formats:
  *
- * - An array of Point or Vector2 objects: `[new Phaser.Math.Vec2(x1, y1), ...]`
+ * - An array of Point or Vector2 objects: `[new Phaser.Math.Vector2(x1, y1), ...]`
  * - An array of objects with public x/y properties: `[obj1, obj2, ...]`
  * - An array of paired numbers that represent point coordinates: `[x1,y1, x2,y2, ...]`
  * - An array of arrays with two elements representing x/y coordinates: `[[x1, y1], [x2, y2], ...]`

--- a/src/math/ToXY.js
+++ b/src/math/ToXY.js
@@ -7,11 +7,11 @@
 var Vector2 = require('./Vector2');
 
 /**
- * Returns a Vec2 containing the x and y position of the given index in a `width` x `height` sized grid.
+ * Returns a Vector2 containing the x and y position of the given index in a `width` x `height` sized grid.
  * 
  * For example, in a 6 x 4 grid, index 16 would equal x: 4 y: 2.
  * 
- * If the given index is out of range an empty Vec2 is returned.
+ * If the given index is out of range an empty Vector2 is returned.
  *
  * @function Phaser.Math.ToXY
  * @since 3.19.0

--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1634,7 +1634,7 @@ var Body = new Class({
     /**
      * Sets whether this Body collides with the world boundary.
      *
-     * Optionally also sets the World Bounce values. If the `Body.worldBounce` is null, it's set to a new Vec2 first.
+     * Optionally also sets the World Bounce values. If the `Body.worldBounce` is null, it's set to a new Phaser.Math.Vector2 first.
      *
      * @method Phaser.Physics.Arcade.Body#setCollideWorldBounds
      * @since 3.0.0

--- a/src/physics/arcade/components/Bounce.js
+++ b/src/physics/arcade/components/Bounce.js
@@ -70,7 +70,7 @@ var Bounce = {
     /**
      * Sets whether this Body collides with the world boundary.
      * 
-     * Optionally also sets the World Bounce values. If the `Body.worldBounce` is null, it's set to a new Vec2 first.
+     * Optionally also sets the World Bounce values. If the `Body.worldBounce` is null, it's set to a new Phaser.Math.Vector2 first.
      *
      * @method Phaser.Physics.Arcade.Components.Bounce#setCollideWorldBounds
      * @since 3.0.0

--- a/src/physics/matter-js/BodyBounds.js
+++ b/src/physics/matter-js/BodyBounds.js
@@ -5,7 +5,7 @@
  */
 
 var Class = require('../../utils/Class');
-var Vec2 = require('../../math/Vector2');
+var Vector2 = require('../../math/Vector2');
 
 /**
  * @classdesc
@@ -34,22 +34,22 @@ var BodyBounds = new Class({
     function BodyBounds ()
     {
         /**
-         * A vec2 that stores the temporary bounds center value during calculations by methods in this class.
+         * A Vector2 that stores the temporary bounds center value during calculations by methods in this class.
          *
          * @name Phaser.Physics.Matter.BodyBounds#boundsCenter
          * @type {Phaser.Math.Vector2}
          * @since 3.22.0
          */
-        this.boundsCenter = new Vec2();
+        this.boundsCenter = new Vector2();
 
         /**
-         * A vec2 that stores the temporary center diff values during calculations by methods in this class.
+         * A Vector2 that stores the temporary center diff values during calculations by methods in this class.
          *
          * @name Phaser.Physics.Matter.BodyBounds#centerDiff
          * @type {Phaser.Math.Vector2}
          * @since 3.22.0
          */
-        this.centerDiff = new Vec2();
+        this.centerDiff = new Vector2();
     },
 
     /**
@@ -115,7 +115,7 @@ var BodyBounds = new Class({
             var center = this.boundsCenter;
             var diff = this.centerDiff;
 
-            return new Vec2(
+            return new Vector2(
                 x + center.x + diff.x,
                 y + center.y + diff.y
             );
@@ -149,7 +149,7 @@ var BodyBounds = new Class({
             var center = this.boundsCenter;
             var diff = this.centerDiff;
 
-            return new Vec2(
+            return new Vector2(
                 x + diff.x,
                 y + center.y + diff.y
             );
@@ -183,7 +183,7 @@ var BodyBounds = new Class({
             var center = this.boundsCenter;
             var diff = this.centerDiff;
 
-            return new Vec2(
+            return new Vector2(
                 x - (center.x - diff.x),
                 y + center.y + diff.y
             );
@@ -217,7 +217,7 @@ var BodyBounds = new Class({
             var center = this.boundsCenter;
             var diff = this.centerDiff;
 
-            return new Vec2(
+            return new Vector2(
                 x + center.x + diff.x,
                 y + diff.y
             );
@@ -250,7 +250,7 @@ var BodyBounds = new Class({
         {
             var diff = this.centerDiff;
 
-            return new Vec2(
+            return new Vector2(
                 x + diff.x,
                 y + diff.y
             );
@@ -284,7 +284,7 @@ var BodyBounds = new Class({
             var center = this.boundsCenter;
             var diff = this.centerDiff;
 
-            return new Vec2(
+            return new Vector2(
                 x - (center.x - diff.x),
                 y + diff.y
             );
@@ -318,7 +318,7 @@ var BodyBounds = new Class({
             var center = this.boundsCenter;
             var diff = this.centerDiff;
 
-            return new Vec2(
+            return new Vector2(
                 x + center.x + diff.x,
                 y - (center.y - diff.y)
             );
@@ -352,7 +352,7 @@ var BodyBounds = new Class({
             var center = this.boundsCenter;
             var diff = this.centerDiff;
 
-            return new Vec2(
+            return new Vector2(
                 x + diff.x,
                 y - (center.y - diff.y)
             );
@@ -386,7 +386,7 @@ var BodyBounds = new Class({
             var center = this.boundsCenter;
             var diff = this.centerDiff;
 
-            return new Vec2(
+            return new Vector2(
                 x - (center.x - diff.x),
                 y - (center.y - diff.y)
             );


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:

Update documentation and one import, to use the consistent name of `Vector2`

There were examples that used Vec2, which wouldn't work. For example `An array of Point or Vector2 objects: [new Phaser.Math.Vec2(x1, y1), ...]` was not copy and pastable.

