### PR TITLE
Make Phaser.Display.Align.In.QuickSet accepts LEFT_BOTTOM, LEFT_TOP, RIGHT_BOTTOM, and RIGHT_TOP.

### DIFF
--- a/src/display/align/in/QuickSet.js
+++ b/src/display/align/in/QuickSet.js
@@ -17,6 +17,10 @@ AlignInMap[ALIGN_CONST.RIGHT_CENTER] = require('./RightCenter');
 AlignInMap[ALIGN_CONST.TOP_CENTER] = require('./TopCenter');
 AlignInMap[ALIGN_CONST.TOP_LEFT] = require('./TopLeft');
 AlignInMap[ALIGN_CONST.TOP_RIGHT] = require('./TopRight');
+AlignInMap[ALIGN_CONST.LEFT_BOTTOM] = AlignInMap[ALIGN_CONST.BOTTOM_LEFT];
+AlignInMap[ALIGN_CONST.LEFT_TOP] = AlignInMap[ALIGN_CONST.TOP_LEFT];
+AlignInMap[ALIGN_CONST.RIGHT_BOTTOM] = AlignInMap[ALIGN_CONST.BOTTOM_RIGHT];
+AlignInMap[ALIGN_CONST.RIGHT_TOP] = AlignInMap[ALIGN_CONST.TOP_RIGHT];
 
 /**
  * Takes given Game Object and aligns it so that it is positioned relative to the other.


### PR DESCRIPTION
This PR
* Fixes a bug

Describe the changes below:

It solves #4927

`Phaser.Display.Align.In.QuickSet` now accepts `LEFT_BOTTOM` as `BOTTOM_LEFT`, `LEFT_TOP` as `TOP_LEFT`, `RIGHT_BOTTOM` as `BOTTOM_RIGHT`, and `RIGHT_TOP` as `TOP_RIGHT`.

I found it more intuitive this way. Especiallyy when using autocomplete since the autocomplete will list all possible value of `Phaser.Display.Align`. 
