### PR TITLE
update SpineGameObject.d.ts

### DIFF
--- a/types/SpineFile.d.ts
+++ b/types/SpineFile.d.ts
@@ -1,18 +1,18 @@
 declare namespace Phaser.Loader.FileTypes {
     interface SpineFileConfig {
-        key: string
-        textureURL?: string
-        textureExtension?: string
-        textureXhrSettings?: Phaser.Types.Loader.XHRSettingsObject
-        normalMap?: string
-        atlasURL?: string
-        atlasExtension?: string
-        atlasXhrSettings?: Phaser.Types.Loader.XHRSettingsObject
+        key: string;
+        textureURL?: string;
+        textureExtension?: string;
+        textureXhrSettings?: Phaser.Types.Loader.XHRSettingsObject;
+        normalMap?: string;
+        atlasURL?: string;
+        atlasExtension?: string;
+        atlasXhrSettings?: Phaser.Types.Loader.XHRSettingsObject;
     }
 
     class SpineFile extends Phaser.Loader.MultiFile {
         constructor(loader: Phaser.Loader.LoaderPlugin, key: string | Phaser.Loader.FileTypes.SpineFileConfig, jsonURL: string | string[], atlasURL: string, preMultipliedAlpha: boolean, jsonXhrSettings: Phaser.Types.Loader.XHRSettingsObject, atlasXhrSettings: Phaser.Types.Loader.XHRSettingsObject)
 
-        addToCache()
+        addToCache();
 	}
 }

--- a/types/SpineGameObject.d.ts
+++ b/types/SpineGameObject.d.ts
@@ -1,85 +1,125 @@
 /// <reference path="./spine.d.ts" />
+/// <reference path="./SpinePlugin.d.ts" />
 
-declare class SpineGameObject {
-    constructor(scene: Phaser.Scene, pluginManager: SpinePlugin, x: number, y: number, key?: string, animationName?: string, loop?: boolean)
+declare class SpineGameObject extends Phaser.GameObjects.GameObject implements Omit<Phaser.GameObjects.Components.ComputedSize, 'setSize'>, Phaser.GameObjects.Components.Depth, Phaser.GameObjects.Components.Flip, Phaser.GameObjects.Components.ScrollFactor, Phaser.GameObjects.Components.Transform, Phaser.GameObjects.Components.Visible {
+    constructor(scene: Phaser.Scene, pluginManager: SpinePlugin, x: number, y: number, key?: string, animationName?: string, loop?: boolean);
 
-    alpha: number
+    alpha: number;
+    angle: integer;
 
-    readonly blendMode: number
+    readonly blendMode: number;
 
-    blue: number
-    bounds: any
-    displayOriginX: number
-    displayOriginY: number
-    drawDebug: boolean
-    green: number
-    plugin: SpinePlugin
-    preMultipliedAlpha: boolean
-    red: number
-    root: spine.Bone
+    blue: number;
+    bounds: any;
+    displayOriginX: number;
+    displayOriginY: number;
+    drawDebug: boolean;
+    depth: number;
+    displayWidth: number;
+    displayHeight: number;
+    flipX: boolean;
+    flipY: boolean;
+    green: number;
+    height: number;
+    plugin: SpinePlugin;
+    preMultipliedAlpha: boolean;
+    red: number;
+    root: spine.Bone;
+    rotation: number;
+    scale: number;
     scaleX: number
     scaleY: number
-    skeleton: spine.Skeleton
-    skeletonData: spine.SkeletonData
-    state: spine.AnimationState
-    stateData: spine.AnimationStateData
-    timeScale: number
+    scrollFactorX: number;
+    scrollFactorY: number;
+    skeleton: spine.Skeleton;
+    skeletonData: spine.SkeletonData;
+    // @ts-ignore - spine.AnimationState significantly different than GameObject.state
+    state: spine.AnimationState;
+    stateData: spine.AnimationStateData;
+    timeScale: number;
+    visible: boolean;
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    width: number;
 
-    addAnimation(trackIndex: integer, animationName: string, loop?: boolean, delay?: integer): spine.TrackEntry
-    angleBoneToXY(bone: spine.Bone, worldX: number, worldY: number, offset?: number, minAngle?: number, maxAngle?: number): SpineGameObject
-    clearTrack(trackIndex: integer): SpineGameObject
-    clearTracks(): SpineGameObject
-    findAnimation(animationName: string): spine.Animation
-    findBone(boneName: string): spine.Bone
-    findBoneIndex(boneName: string): number
-    findEvent(eventDataName: string): spine.EventData
-    findIkConstraint(constraintName: string): spine.IkConstraintData
-    findPathConstraint(constraintName: string): spine.PathConstraintData
-    findPathConstraintIndex(constraintName: string): number
-    findSkin(skinName: string): spine.Skin
-    findSlot(slotName: string): spine.Slot
-    findSlotIndex(slotName: string): number
-    findTransformConstraint(constraintName: string): spine.TransformConstraintData
-    getAnimationList(): string[]
-    getAttachment(slotIndex: integer, attachmentName: string): spine.Attachment
-    getAttachmentByName(slotName: string, attachmentName: string): spine.Attachment
-    getBoneList(): string[]
-    getBounds(): any
-    getCurrentAnimation(trackIndex?: integer): spine.Animation
-    getRootBone(): spine.Bone
-    getSkinList(): string[]
-    getSlotList(): string[]
-    play(animationName: string, loop?: boolean, ignoreIfPlaying?: boolean): SpineGameObject
+    addAnimation(trackIndex: integer, animationName: string, loop?: boolean, delay?: integer): spine.TrackEntry;
+    angleBoneToXY(bone: spine.Bone, worldX: number, worldY: number, offset?: number, minAngle?: number, maxAngle?: number): SpineGameObject;
+    clearTrack(trackIndex: integer): SpineGameObject;
+    clearTracks(): SpineGameObject;
+    findAnimation(animationName: string): spine.Animation;
+    findBone(boneName: string): spine.Bone;
+    findBoneIndex(boneName: string): number;
+    findEvent(eventDataName: string): spine.EventData;
+    findIkConstraint(constraintName: string): spine.IkConstraintData;
+    findPathConstraint(constraintName: string): spine.PathConstraintData;
+    findPathConstraintIndex(constraintName: string): number;
+    findSkin(skinName: string): spine.Skin;
+    findSlot(slotName: string): spine.Slot;
+    findSlotIndex(slotName: string): number;
+    findTransformConstraint(constraintName: string): spine.TransformConstraintData;
+    getAnimationList(): string[];
+    getAttachment(slotIndex: integer, attachmentName: string): spine.Attachment;
+    getAttachmentByName(slotName: string, attachmentName: string): spine.Attachment;
+    getBoneList(): string[];
+    getBounds(): any;
+    getCurrentAnimation(trackIndex?: integer): spine.Animation;
+    getLocalTransformMatrix(tempMatrix?: Phaser.GameObjects.Components.TransformMatrix): Phaser.GameObjects.Components.TransformMatrix;
+    getParentRotation(): number;
+    getRootBone(): spine.Bone;
+    getSkinList(): string[];
+    getSlotList(): string[];
+    getWorldTransformMatrix(tempMatrix?: Phaser.GameObjects.Components.TransformMatrix, parentMatrix?: Phaser.GameObjects.Components.TransformMatrix): Phaser.GameObjects.Components.TransformMatrix;
+    play(animationName: string, loop?: boolean, ignoreIfPlaying?: boolean): SpineGameObject;
 
-    protected preUpdate(time: number, delta: number): void
-    protected preDestroy(): void
+    protected preUpdate(time: number, delta: number): void;
+    protected preDestroy(): void;
 
-    refresh(): SpineGameObject
-    setAlpha(value?: number): SpineGameObject
-    setAnimation(trackIndex: integer, animationName: string, loop?: boolean, ignoreIfPlaying?: boolean): spine.TrackEntry
-    setAttachment(slotName: string, attachmentName: string): SpineGameObject
-    setBonesToSetupPose(): SpineGameObject
-    setColor(color?: integer, slotName?: string): SpineGameObject
-    setEmptyAnimation(trackIndex: integer, mixDuration?: integer): spine.TrackEntry
-    setMix(fromName: string, toName: string, duration?: number): SpineGameObject
-    setOffset(offsetX?: number, offsetY?: number): SpineGameObject
-    setSize(width?: number, height?: number, offsetX?: number, offsetY?: number): SpineGameObject
-    setSkeleton(atlasDataKey: string, skeletonJSON: object, animationName?: string, loop?: boolean): SpineGameObject
-    setSkeletonFromJSON(atlasDataKey: string, skeletonJSON: object, animationName?: string, loop?: boolean): SpineGameObject
-    setSkin(newSkin: spine.Skin): SpineGameObject
-    setSkinByName(skinName: string): SpineGameObject
-    setSlotsToSetupPose(): SpineGameObject
-    setToSetupPose(): SpineGameObject
-    updateSize(): SpineGameObject
-    willRender(): boolean
+    refresh(): SpineGameObject;
+    resetFlip(): this;
+    setAlpha(value?: number): SpineGameObject;
+    setAngle(degrees?: number): this;
+    setAnimation(trackIndex: integer, animationName: string, loop?: boolean, ignoreIfPlaying?: boolean): spine.TrackEntry;
+    setAttachment(slotName: string, attachmentName: string): SpineGameObject;
+    setBonesToSetupPose(): SpineGameObject;
+    setColor(color?: integer, slotName?: string): SpineGameObject;
+    setDepth(value: integer): this;
+    setDisplaySize(width: number, height: number): this;
+    setEmptyAnimation(trackIndex: integer, mixDuration?: integer): spine.TrackEntry;
+    setFlipX(value: boolean): this;
+    setFlipY(value: boolean): this;
+    setFlip(x: boolean, y: boolean): this;
+    setMix(fromName: string, toName: string, duration?: number): SpineGameObject;
+    setOffset(offsetX?: number, offsetY?: number): SpineGameObject;
+    setPosition(x?: number, y?: number, z?: number, w?: number): this;
+    setRandomPosition(x?: number, y?: number, width?: number, height?: number): this;
+    setRotation(radians?: number): this;
+    setScale(x: number, y?: number): this;
+    setScrollFactor(x: number, y?: number): this;
+    setSize(width?: number, height?: number, offsetX?: number, offsetY?: number): SpineGameObject;
+    setSkeleton(atlasDataKey: string, skeletonJSON: object, animationName?: string, loop?: boolean): SpineGameObject;
+    setSkeletonFromJSON(atlasDataKey: string, skeletonJSON: object, animationName?: string, loop?: boolean): SpineGameObject;
+    setSkin(newSkin: spine.Skin): SpineGameObject;
+    setSkinByName(skinName: string): SpineGameObject;
+    setSlotsToSetupPose(): SpineGameObject;
+    setToSetupPose(): SpineGameObject;
+    setVisible(value: boolean): this;
+    setX(value?: number): this;
+    setY(value?: number): this;
+    setZ(value?: number): this;
+    setW(value?: number): this;
+    toggleFlipX(): this;
+    toggleFlipY(): this;
+    updateSize(): SpineGameObject;
+    willRender(): boolean;
 }
 
-declare interface SpineGameObjectConfig extends Phaser.Types.GameObjects.GameObjectConfig
-{
-    key?: string
-    animationName?: string
-    loop?: boolean
-    skinName?: string
-    slotName?: string
-    attachmentName?: string
+declare interface SpineGameObjectConfig extends Phaser.Types.GameObjects.GameObjectConfig {
+    key?: string;
+    animationName?: string;
+    loop?: boolean;
+    skinName?: string;
+    slotName?: string;
+    attachmentName?: string;
 }

--- a/types/SpinePlugin.d.ts
+++ b/types/SpinePlugin.d.ts
@@ -1,57 +1,59 @@
 /// <reference path="./spine.d.ts" />
+/// <reference path="./SpineFile.d.ts" />
+/// <reference path="./SpineGameObject.d.ts" />
 
 declare namespace Phaser.Loader {
     interface LoaderPlugin extends Phaser.Events.EventEmitter {
-        spine(key: string | Phaser.Loader.FileTypes.SpineFileConfig | Phaser.Loader.FileTypes.SpineFileConfig[], jsonURL: string, atlasURL: string | string[], preMultipliedAlpha?: boolean, textureXhrSettings?: Phaser.Types.Loader.XHRSettingsObject, atlasXhrSettings?: Phaser.Types.Loader.XHRSettingsObject): LoaderPlugin
+        spine(key: string | Phaser.Loader.FileTypes.SpineFileConfig | Phaser.Loader.FileTypes.SpineFileConfig[], jsonURL: string, atlasURL: string | string[], preMultipliedAlpha?: boolean, textureXhrSettings?: Phaser.Types.Loader.XHRSettingsObject, atlasXhrSettings?: Phaser.Types.Loader.XHRSettingsObject): LoaderPlugin;
     }
 }
 
 declare namespace Phaser.GameObjects {
     interface GameObjectFactory {
-        spine(x: number, y: number, key?: string, aimationName?: string, loop?: boolean): SpineGameObject
+        spine(x: number, y: number, key?: string, aimationName?: string, loop?: boolean): SpineGameObject;
     }
 
 	interface GameObjectCreator {
-        spine(config: SpineGameObjectConfig, addToScene?: boolean): SpineGameObject
+        spine(config: SpineGameObjectConfig, addToScene?: boolean): SpineGameObject;
     }
 }
 
 declare class SpinePlugin extends Phaser.Plugins.ScenePlugin {
-    constructor(scene: Phaser.Scene, pluginManager: Phaser.Plugins.PluginManager)
+    constructor(scene: Phaser.Scene, pluginManager: Phaser.Plugins.PluginManager);
 
-    readonly isWebGL: boolean
+    readonly isWebGL: boolean;
 
-    cache: Phaser.Cache.BaseCache
-    spineTextures: Phaser.Cache.BaseCache
-    json: Phaser.Cache.BaseCache
-    textures: Phaser.Textures.TextureManager
-    drawDebug: boolean
-    gl: WebGLRenderingContext
-    renderer: Phaser.Renderer.Canvas.CanvasRenderer | Phaser.Renderer.WebGL.WebGLRenderer
-    sceneRenderer: spine.webgl.SceneRenderer
-    skeletonRenderer: spine.canvas.SkeletonRenderer | spine.webgl.SkeletonRenderer
-    skeletonDebugRenderer: spine.webgl.SkeletonDebugRenderer
+    cache: Phaser.Cache.BaseCache;
+    spineTextures: Phaser.Cache.BaseCache;
+    json: Phaser.Cache.BaseCache;
+    textures: Phaser.Textures.TextureManager;
+    drawDebug: boolean;
+    gl: WebGLRenderingContext;
+    renderer: Phaser.Renderer.Canvas.CanvasRenderer | Phaser.Renderer.WebGL.WebGLRenderer;
+    sceneRenderer: spine.webgl.SceneRenderer;
+    skeletonRenderer: spine.canvas.SkeletonRenderer | spine.webgl.SkeletonRenderer;
+    skeletonDebugRenderer: spine.webgl.SkeletonDebugRenderer;
 
-    plugin: typeof spine
+    plugin: typeof spine;
 
-    getAtlasCanvas(key: string): spine.TextureAtlas
-    getAtlasWebGL(key: string): spine.TextureAtlas
-    worldToLocal(x: number, y: number, skeleton: spine.Skeleton, bone?: spine.Bone): spine.Vector2
-    getVector2(x: number, y: number): spine.Vector2
-    getVector3(x: number, y: number, z: number): spine.Vector2
-    setDebugBones(value?: boolean): SpinePlugin
-    setDebugRegionAttachments(value?: boolean): SpinePlugin
-    setDebugBoundingBoxes(value?: boolean): SpinePlugin
-    setDebugMeshHull(value?: boolean): SpinePlugin
-    setDebugMeshTriangles(value?: boolean): SpinePlugin
-    setDebugPaths(value?: boolean): SpinePlugin
-    setDebugSkeletonXY(value?: boolean): SpinePlugin
-    setDebugClipping(value?: boolean): SpinePlugin
-    setEffect(effect?: spine.VertexEffect): SpinePlugin
-    createSkeleton(key: string, skeletonJSON?: object): any | null
-    createAnimationState(skeleton: spine.Skeleton): any
-    getBounds(skeleton: spine.Skeleton): any
-    onResize(): void
-    add(x: number, y: number, key?: string, animationName?: string, loop?: boolean): SpineGameObject
-    make(config: SpineGameObjectConfig, addToScene?: boolean): SpineGameObject
+    getAtlasCanvas(key: string): spine.TextureAtlas;
+    getAtlasWebGL(key: string): spine.TextureAtlas;
+    worldToLocal(x: number, y: number, skeleton: spine.Skeleton, bone?: spine.Bone): spine.Vector2;
+    getVector2(x: number, y: number): spine.Vector2;
+    getVector3(x: number, y: number, z: number): spine.Vector2;
+    setDebugBones(value?: boolean): SpinePlugin;
+    setDebugRegionAttachments(value?: boolean): SpinePlugin;
+    setDebugBoundingBoxes(value?: boolean): SpinePlugin;
+    setDebugMeshHull(value?: boolean): SpinePlugin;
+    setDebugMeshTriangles(value?: boolean): SpinePlugin;
+    setDebugPaths(value?: boolean): SpinePlugin;
+    setDebugSkeletonXY(value?: boolean): SpinePlugin;
+    setDebugClipping(value?: boolean): SpinePlugin;
+    setEffect(effect?: spine.VertexEffect): SpinePlugin;
+    createSkeleton(key: string, skeletonJSON?: object): any | null;
+    createAnimationState(skeleton: spine.Skeleton): any;
+    getBounds(skeleton: spine.Skeleton): any;
+    onResize(): void;
+    add(x: number, y: number, key?: string, animationName?: string, loop?: boolean): SpineGameObject;
+    make(config: SpineGameObjectConfig, addToScene?: boolean): SpineGameObject;
 }


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the TypeScript definitions

Describe the changes below:

Reference comment by @jonchun https://github.com/photonstorm/phaser/pull/4948

- extends from Phaser.GameObjects.GameObject
- implements interfaces for mixins
- use Omit for setSize signature conflicts in ComputedSize
- use @ts-ignore for state property conflict; spine.AnimationState significantly different than GameObject.state
- added semi-colons to better match rest of definition files