### PR TITLE
Create tilesets from image collections

### DIFF
--- a/src/tilemaps/parsers/tiled/BuildTilesetIndex.js
+++ b/src/tilemaps/parsers/tiled/BuildTilesetIndex.js
@@ -14,9 +14,27 @@
  *
  * @return {array} [description]
  */
+
+var Tileset = require('../../Tileset');
+
 var BuildTilesetIndex = function (mapData)
 {
     var tiles = [];
+
+    for (var i = 0; i < mapData.imageCollections.length; i++)
+    {
+        var collection = mapData.imageCollections[i];
+        var images = collection.images;
+
+        for (var j = 0; j < images.length; j++) {
+            var image = images[j];
+
+            var set = new Tileset(image.image, image.gid, collection.imageWidth, collection.imageHeight, 0, 0);
+            set.updateTileData(collection.imageWidth, collection.imageHeight);
+
+            mapData.tilesets.push(set);
+        }
+    }
 
     for (var i = 0; i < mapData.tilesets.length; i++)
     {


### PR DESCRIPTION
This PR

* Adds a new feature

Describe the changes below:

Supports Tiled image-collections tilesets by creating one tileset per image.
This is a quick solution for #4780 .
This is not the most efficient way to do it but it is useful when prototyping/developing and requested by several users.

Let me know if some change is required.
