### PR TITLE
set depth of input debug body

### DIFF
--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -2466,6 +2466,7 @@ var InputPlugin = new Class({
                 debug.setScale(gameObject.scaleX, gameObject.scaleY);
                 debug.setPosition(gameObject.x + offsetx, gameObject.y + offsety);
                 debug.setScrollFactor(gameObject.scrollFactorX, gameObject.scrollFactorY);
+                debug.setDepth(gameObject.depth);
             };
 
             updateList.add(debug);


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)
* Fixes a bug

Describe the changes below:

When you enable a game object for input debug, the debug body's depth is not set, so it's 0, which is problematic when dealing with different layers. This sets the depth to the depth of the actual game object. Maybe it should even be set to an arbitrary high number or highest depth found in other game objects.