### PR TITLE
Fixed `this` return types

### DIFF
--- a/src/gameobjects/bitmaptext/dynamic/DynamicBitmapText.js
+++ b/src/gameobjects/bitmaptext/dynamic/DynamicBitmapText.js
@@ -155,7 +155,7 @@ var DynamicBitmapText = new Class({
      * @param {number} width - The width of the crop.
      * @param {number} height - The height of the crop.
      *
-     * @return {Phaser.GameObjects.DynamicBitmapText} This Game Object.
+     * @return {this} This Game Object.
      */
     setSize: function (width, height)
     {
@@ -179,7 +179,7 @@ var DynamicBitmapText = new Class({
      *
      * @param {Phaser.Types.GameObjects.BitmapText.DisplayCallback} callback - The display callback to set.
      *
-     * @return {Phaser.GameObjects.DynamicBitmapText} This Game Object.
+     * @return {this} This Game Object.
      */
     setDisplayCallback: function (callback)
     {
@@ -196,7 +196,7 @@ var DynamicBitmapText = new Class({
      *
      * @param {number} value - The horizontal scroll position to set.
      *
-     * @return {Phaser.GameObjects.DynamicBitmapText} This Game Object.
+     * @return {this} This Game Object.
      */
     setScrollX: function (value)
     {
@@ -213,7 +213,7 @@ var DynamicBitmapText = new Class({
      *
      * @param {number} value - The vertical scroll position to set.
      *
-     * @return {Phaser.GameObjects.DynamicBitmapText} This Game Object.
+     * @return {this} This Game Object.
      */
     setScrollY: function (value)
     {

--- a/src/gameobjects/blitter/Bob.js
+++ b/src/gameobjects/blitter/Bob.js
@@ -152,7 +152,7 @@ var Bob = new Class({
      *
      * @param {(string|integer|Phaser.Textures.Frame)} [frame] - The frame to be used during rendering.
      *
-     * @return {Phaser.GameObjects.Bob} This Bob Game Object.
+     * @return {this} This Bob Game Object.
      */
     setFrame: function (frame)
     {
@@ -178,7 +178,7 @@ var Bob = new Class({
      * @method Phaser.GameObjects.Bob#resetFlip
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Bob} This Bob Game Object.
+     * @return {this} This Bob Game Object.
      */
     resetFlip: function ()
     {
@@ -202,7 +202,7 @@ var Bob = new Class({
      * @param {number} y - The y position of the Bob. Bob coordinate are relative to the position of the Blitter object.
      * @param {(string|integer|Phaser.Textures.Frame)} [frame] - The Frame the Bob will use. It _must_ be part of the Texture the parent Blitter object is using.
      *
-     * @return {Phaser.GameObjects.Bob} This Bob Game Object.
+     * @return {this} This Bob Game Object.
      */
     reset: function (x, y, frame)
     {
@@ -234,7 +234,7 @@ var Bob = new Class({
      * @param {number} x - The x position of the Bob. Bob coordinate are relative to the position of the Blitter object.
      * @param {number} y - The y position of the Bob. Bob coordinate are relative to the position of the Blitter object.
      *
-     * @return {Phaser.GameObjects.Bob} This Bob Game Object.
+     * @return {this} This Bob Game Object.
      */
     setPosition: function (x, y)
     {
@@ -252,7 +252,7 @@ var Bob = new Class({
      *
      * @param {boolean} value - The flipped state. `false` for no flip, or `true` to be flipped.
      *
-     * @return {Phaser.GameObjects.Bob} This Bob Game Object.
+     * @return {this} This Bob Game Object.
      */
     setFlipX: function (value)
     {
@@ -269,7 +269,7 @@ var Bob = new Class({
      *
      * @param {boolean} value - The flipped state. `false` for no flip, or `true` to be flipped.
      *
-     * @return {Phaser.GameObjects.Bob} This Bob Game Object.
+     * @return {this} This Bob Game Object.
      */
     setFlipY: function (value)
     {
@@ -287,7 +287,7 @@ var Bob = new Class({
      * @param {boolean} x - The horizontal flipped state. `false` for no flip, or `true` to be flipped.
      * @param {boolean} y - The horizontal flipped state. `false` for no flip, or `true` to be flipped.
      *
-     * @return {Phaser.GameObjects.Bob} This Bob Game Object.
+     * @return {this} This Bob Game Object.
      */
     setFlip: function (x, y)
     {
@@ -307,7 +307,7 @@ var Bob = new Class({
      *
      * @param {boolean} value - The visible state of the Game Object.
      *
-     * @return {Phaser.GameObjects.Bob} This Bob Game Object.
+     * @return {this} This Bob Game Object.
      */
     setVisible: function (value)
     {
@@ -327,7 +327,7 @@ var Bob = new Class({
      *
      * @param {number} value - The alpha value used for this Bob. Between 0 and 1.
      *
-     * @return {Phaser.GameObjects.Bob} This Bob Game Object.
+     * @return {this} This Bob Game Object.
      */
     setAlpha: function (value)
     {
@@ -344,7 +344,7 @@ var Bob = new Class({
      *
      * @param {number} value - The tint value used for this Bob. Between 0 and 0xffffff.
      *
-     * @return {Phaser.GameObjects.Bob} This Bob Game Object.
+     * @return {this} This Bob Game Object.
      */
     setTint: function (value)
     {

--- a/src/gameobjects/components/PathFollower.js
+++ b/src/gameobjects/components/PathFollower.js
@@ -110,7 +110,7 @@ var PathFollower = {
      * @param {Phaser.Curves.Path} path - The Path this PathFollower is following. It can only follow one Path at a time.
      * @param {(number|Phaser.Types.GameObjects.PathFollower.PathConfig|Phaser.Types.Tweens.NumberTweenBuilderConfig)} [config] - Settings for the PathFollower.
      *
-     * @return {Phaser.GameObjects.PathFollower} This Game Object.
+     * @return {this} This Game Object.
      */
     setPath: function (path, config)
     {
@@ -142,7 +142,7 @@ var PathFollower = {
      * @param {boolean} value - Whether the PathFollower should automatically rotate to point in the direction of the Path.
      * @param {number} [offset=0] - Rotation offset in degrees.
      *
-     * @return {Phaser.GameObjects.PathFollower} This Game Object.
+     * @return {this} This Game Object.
      */
     setRotateToPath: function (value, offset)
     {
@@ -181,7 +181,7 @@ var PathFollower = {
      * @param {(number|Phaser.Types.GameObjects.PathFollower.PathConfig|Phaser.Types.Tweens.NumberTweenBuilderConfig)} [config={}] - The duration of the follow, or a PathFollower config object.
      * @param {number} [startAt=0] - Optional start position of the follow, between 0 and 1.
      *
-     * @return {Phaser.GameObjects.PathFollower} This Game Object.
+     * @return {this} This Game Object.
      */
     startFollow: function (config, startAt)
     {
@@ -271,7 +271,7 @@ var PathFollower = {
      * @method Phaser.GameObjects.Components.PathFollower#pauseFollow
      * @since 3.3.0
      *
-     * @return {Phaser.GameObjects.PathFollower} This Game Object.
+     * @return {this} This Game Object.
      */
     pauseFollow: function ()
     {
@@ -293,7 +293,7 @@ var PathFollower = {
      * @method Phaser.GameObjects.Components.PathFollower#resumeFollow
      * @since 3.3.0
      *
-     * @return {Phaser.GameObjects.PathFollower} This Game Object.
+     * @return {this} This Game Object.
      */
     resumeFollow: function ()
     {
@@ -315,7 +315,7 @@ var PathFollower = {
      * @method Phaser.GameObjects.Components.PathFollower#stopFollow
      * @since 3.3.0
      *
-     * @return {Phaser.GameObjects.PathFollower} This Game Object.
+     * @return {this} This Game Object.
      */
     stopFollow: function ()
     {

--- a/src/gameobjects/components/TransformMatrix.js
+++ b/src/gameobjects/components/TransformMatrix.js
@@ -438,7 +438,7 @@ var TransformMatrix = new Class({
      * @param {Phaser.GameObjects.Components.TransformMatrix} rhs - The Matrix to multiply by.
      * @param {Phaser.GameObjects.Components.TransformMatrix} [out] - An optional Matrix to store the results in.
      *
-     * @return {Phaser.GameObjects.Components.TransformMatrix} Either this TransformMatrix, or the `out` Matrix, if given in the arguments.
+     * @return {this|Phaser.GameObjects.Components.TransformMatrix} Either this TransformMatrix, or the `out` Matrix, if given in the arguments.
      */
     multiply: function (rhs, out)
     {

--- a/src/gameobjects/components/TransformMatrix.js
+++ b/src/gameobjects/components/TransformMatrix.js
@@ -438,7 +438,7 @@ var TransformMatrix = new Class({
      * @param {Phaser.GameObjects.Components.TransformMatrix} rhs - The Matrix to multiply by.
      * @param {Phaser.GameObjects.Components.TransformMatrix} [out] - An optional Matrix to store the results in.
      *
-     * @return {this|Phaser.GameObjects.Components.TransformMatrix} Either this TransformMatrix, or the `out` Matrix, if given in the arguments.
+     * @return {(this|Phaser.GameObjects.Components.TransformMatrix)} Either this TransformMatrix, or the `out` Matrix, if given in the arguments.
      */
     multiply: function (rhs, out)
     {

--- a/src/gameobjects/container/Container.js
+++ b/src/gameobjects/container/Container.js
@@ -347,7 +347,7 @@ var Container = new Class({
      *
      * @param {boolean} [value=true] - The exclusive state of this Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container.
+     * @return {this} This Container.
      */
     setExclusive: function (value)
     {
@@ -508,7 +508,7 @@ var Container = new Class({
      *
      * @param {Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[]} child - The Game Object, or array of Game Objects, to add to the Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     add: function (child)
     {
@@ -530,7 +530,7 @@ var Container = new Class({
      * @param {Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[]} child - The Game Object, or array of Game Objects, to add to the Container.
      * @param {integer} [index=0] - The position to insert the Game Object/s at.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     addAt: function (child, index)
     {
@@ -579,7 +579,7 @@ var Container = new Class({
      * @param {string} property - The property to lexically sort by.
      * @param {function} [handler] - Provide your own custom handler function. Will receive 2 children which it should compare and return a boolean.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     sort: function (property, handler)
     {
@@ -721,7 +721,7 @@ var Container = new Class({
      * @param {Phaser.GameObjects.GameObject} child1 - The first Game Object to swap.
      * @param {Phaser.GameObjects.GameObject} child2 - The second Game Object to swap.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     swap: function (child1, child2)
     {
@@ -744,7 +744,7 @@ var Container = new Class({
      * @param {Phaser.GameObjects.GameObject} child - The Game Object to move.
      * @param {integer} index - The new position of the Game Object in this Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     moveTo: function (child, index)
     {
@@ -766,7 +766,7 @@ var Container = new Class({
      * @param {Phaser.GameObjects.GameObject|Phaser.GameObjects.GameObject[]} child - The Game Object, or array of Game Objects, to be removed from the Container.
      * @param {boolean} [destroyChild=false] - Optionally call `destroy` on each child successfully removed from this Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     remove: function (child, destroyChild)
     {
@@ -799,7 +799,7 @@ var Container = new Class({
      * @param {integer} index - The index of the Game Object to be removed.
      * @param {boolean} [destroyChild=false] - Optionally call `destroy` on the Game Object if successfully removed from this Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     removeAt: function (index, destroyChild)
     {
@@ -825,7 +825,7 @@ var Container = new Class({
      * @param {integer} [endIndex=Container.length] - An optional end index to search up to (but not included)
      * @param {boolean} [destroyChild=false] - Optionally call `destroy` on each Game Object successfully removed from this Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     removeBetween: function (startIndex, endIndex, destroyChild)
     {
@@ -852,7 +852,7 @@ var Container = new Class({
      *
      * @param {boolean} [destroyChild=false] - Optionally call `destroy` on each Game Object successfully removed from this Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     removeAll: function (destroyChild)
     {
@@ -878,7 +878,7 @@ var Container = new Class({
      *
      * @param {Phaser.GameObjects.GameObject} child - The Game Object to bring to the top of the Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     bringToTop: function (child)
     {
@@ -896,7 +896,7 @@ var Container = new Class({
      *
      * @param {Phaser.GameObjects.GameObject} child - The Game Object to send to the bottom of the Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     sendToBack: function (child)
     {
@@ -913,7 +913,7 @@ var Container = new Class({
      *
      * @param {Phaser.GameObjects.GameObject} child - The Game Object to be moved in the Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     moveUp: function (child)
     {
@@ -930,7 +930,7 @@ var Container = new Class({
      *
      * @param {Phaser.GameObjects.GameObject} child - The Game Object to be moved in the Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     moveDown: function (child)
     {
@@ -945,7 +945,7 @@ var Container = new Class({
      * @method Phaser.GameObjects.Container#reverse
      * @since 3.4.0
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     reverse: function ()
     {
@@ -960,7 +960,7 @@ var Container = new Class({
      * @method Phaser.GameObjects.Container#shuffle
      * @since 3.4.0
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     shuffle: function ()
     {
@@ -980,7 +980,7 @@ var Container = new Class({
      * @param {Phaser.GameObjects.GameObject} newChild - The Game Object to be added to this Container.
      * @param {boolean} [destroyChild=false] - Optionally call `destroy` on the Game Object if successfully removed from this Container.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     replace: function (oldChild, newChild, destroyChild)
     {
@@ -1032,7 +1032,7 @@ var Container = new Class({
      * @param {integer} [startIndex=0] - An optional start index to search from.
      * @param {integer} [endIndex=Container.length] - An optional end index to search up to (but not included)
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     setAll: function (property, value, startIndex, endIndex)
     {
@@ -1065,7 +1065,7 @@ var Container = new Class({
      * @param {object} [context] - Value to use as `this` when executing callback.
      * @param {...*} [args] - Additional arguments that will be passed to the callback, after the child.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     each: function (callback, context)
     {
@@ -1102,7 +1102,7 @@ var Container = new Class({
      * @param {object} [context] - Value to use as `this` when executing callback.
      * @param {...*} [args] - Additional arguments that will be passed to the callback, after the child.
      *
-     * @return {Phaser.GameObjects.Container} This Container instance.
+     * @return {this} This Container instance.
      */
     iterate: function (callback, context)
     {

--- a/src/gameobjects/graphics/Graphics.js
+++ b/src/gameobjects/graphics/Graphics.js
@@ -243,7 +243,7 @@ var Graphics = new Class({
      *
      * @param {Phaser.Types.GameObjects.Graphics.Styles} options - The styles to set as defaults.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     setDefaultStyles: function (options)
     {
@@ -277,7 +277,7 @@ var Graphics = new Class({
      * @param {number} color - The stroke color.
      * @param {number} [alpha=1] - The stroke alpha.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     lineStyle: function (lineWidth, color, alpha)
     {
@@ -302,7 +302,7 @@ var Graphics = new Class({
      * @param {number} color - The fill color.
      * @param {number} [alpha=1] - The fill alpha.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillStyle: function (color, alpha)
     {
@@ -341,7 +341,7 @@ var Graphics = new Class({
      * @param {integer} bottomRight - The tint being applied to the bottom-right of the Game Object.
      * @param {number} [alpha=1] - The fill alpha.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillGradientStyle: function (topLeft, topRight, bottomLeft, bottomRight, alpha)
     {
@@ -379,7 +379,7 @@ var Graphics = new Class({
      * @param {integer} bottomRight - The tint being applied to the bottom-right of the Game Object.
      * @param {number} [alpha=1] - The fill alpha.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     lineGradientStyle: function (lineWidth, topLeft, topRight, bottomLeft, bottomRight, alpha)
     {
@@ -455,7 +455,7 @@ var Graphics = new Class({
      * @method Phaser.GameObjects.Graphics#beginPath
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     beginPath: function ()
     {
@@ -472,7 +472,7 @@ var Graphics = new Class({
      * @method Phaser.GameObjects.Graphics#closePath
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     closePath: function ()
     {
@@ -489,7 +489,7 @@ var Graphics = new Class({
      * @method Phaser.GameObjects.Graphics#fillPath
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillPath: function ()
     {
@@ -509,7 +509,7 @@ var Graphics = new Class({
      * @method Phaser.GameObjects.Graphics#fill
      * @since 3.16.0
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fill: function ()
     {
@@ -526,7 +526,7 @@ var Graphics = new Class({
      * @method Phaser.GameObjects.Graphics#strokePath
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokePath: function ()
     {
@@ -546,7 +546,7 @@ var Graphics = new Class({
      * @method Phaser.GameObjects.Graphics#stroke
      * @since 3.16.0
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     stroke: function ()
     {
@@ -565,7 +565,7 @@ var Graphics = new Class({
      *
      * @param {Phaser.Geom.Circle} circle - The circle to fill.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillCircleShape: function (circle)
     {
@@ -580,7 +580,7 @@ var Graphics = new Class({
      *
      * @param {Phaser.Geom.Circle} circle - The circle to stroke.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokeCircleShape: function (circle)
     {
@@ -597,7 +597,7 @@ var Graphics = new Class({
      * @param {number} y - The y coordinate of the center of the circle.
      * @param {number} radius - The radius of the circle.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillCircle: function (x, y, radius)
     {
@@ -618,7 +618,7 @@ var Graphics = new Class({
      * @param {number} y - The y coordinate of the center of the circle.
      * @param {number} radius - The radius of the circle.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokeCircle: function (x, y, radius)
     {
@@ -637,7 +637,7 @@ var Graphics = new Class({
      *
      * @param {Phaser.Geom.Rectangle} rect - The rectangle to fill.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillRectShape: function (rect)
     {
@@ -652,7 +652,7 @@ var Graphics = new Class({
      *
      * @param {Phaser.Geom.Rectangle} rect - The rectangle to stroke.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokeRectShape: function (rect)
     {
@@ -670,7 +670,7 @@ var Graphics = new Class({
      * @param {number} width - The width of the rectangle.
      * @param {number} height - The height of the rectangle.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillRect: function (x, y, width, height)
     {
@@ -693,7 +693,7 @@ var Graphics = new Class({
      * @param {number} width - The width of the rectangle.
      * @param {number} height - The height of the rectangle.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokeRect: function (x, y, width, height)
     {
@@ -736,7 +736,7 @@ var Graphics = new Class({
      * @param {number} height - The height of the rectangle.
      * @param {(Phaser.Types.GameObjects.Graphics.RoundedRectRadius|number)} [radius=20] - The corner radius; It can also be an object to specify different radii for corners.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillRoundedRect: function (x, y, width, height, radius)
     {
@@ -782,7 +782,7 @@ var Graphics = new Class({
      * @param {number} height - The height of the rectangle.
      * @param {(Phaser.Types.GameObjects.Graphics.RoundedRectRadius|number)} [radius=20] - The corner radius; It can also be an object to specify different radii for corners.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokeRoundedRect: function (x, y, width, height, radius)
     {
@@ -827,7 +827,7 @@ var Graphics = new Class({
      * @param {(Phaser.Geom.Point|Phaser.Math.Vector2|object)} point - The point to fill.
      * @param {number} [size=1] - The size of the square to draw.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillPointShape: function (point, size)
     {
@@ -846,7 +846,7 @@ var Graphics = new Class({
      * @param {number} y - The y coordinate of the point.
      * @param {number} [size=1] - The size of the square to draw.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillPoint: function (x, y, size)
     {
@@ -876,7 +876,7 @@ var Graphics = new Class({
      *
      * @param {Phaser.Geom.Triangle} triangle - The triangle to fill.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillTriangleShape: function (triangle)
     {
@@ -891,7 +891,7 @@ var Graphics = new Class({
      *
      * @param {Phaser.Geom.Triangle} triangle - The triangle to stroke.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokeTriangleShape: function (triangle)
     {
@@ -911,7 +911,7 @@ var Graphics = new Class({
      * @param {number} x2 - The x coordinate of the third point.
      * @param {number} y2 - The y coordinate of the third point.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillTriangle: function (x0, y0, x1, y1, x2, y2)
     {
@@ -936,7 +936,7 @@ var Graphics = new Class({
      * @param {number} x2 - The x coordinate of the third point.
      * @param {number} y2 - The y coordinate of the third point.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokeTriangle: function (x0, y0, x1, y1, x2, y2)
     {
@@ -956,7 +956,7 @@ var Graphics = new Class({
      *
      * @param {Phaser.Geom.Line} line - The line to stroke.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokeLineShape: function (line)
     {
@@ -974,7 +974,7 @@ var Graphics = new Class({
      * @param {number} x2 - The x coordinate of the end point of the line.
      * @param {number} y2 - The y coordinate of the end point of the line.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     lineBetween: function (x1, y1, x2, y2)
     {
@@ -997,7 +997,7 @@ var Graphics = new Class({
      * @param {number} x - The x coordinate to draw the line to.
      * @param {number} y - The y coordinate to draw the line to.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     lineTo: function (x, y)
     {
@@ -1018,7 +1018,7 @@ var Graphics = new Class({
      * @param {number} x - The x coordinate to move to.
      * @param {number} y - The y coordinate to move to.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     moveTo: function (x, y)
     {
@@ -1045,7 +1045,7 @@ var Graphics = new Class({
      * @param {boolean} [closePath=false] - When `true`, the path is closed before being stroked.
      * @param {integer} [endIndex] - The index of `points` to stop drawing at. Defaults to `points.length`.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokePoints: function (points, closeShape, closePath, endIndex)
     {
@@ -1092,7 +1092,7 @@ var Graphics = new Class({
      * @param {boolean} [closePath=false] - When `true`, the path is closed before being stroked.
      * @param {integer} [endIndex] - The index of `points` to stop at. Defaults to `points.length`.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillPoints: function (points, closeShape, closePath, endIndex)
     {
@@ -1133,7 +1133,7 @@ var Graphics = new Class({
      * @param {Phaser.Geom.Ellipse} ellipse - The ellipse to stroke.
      * @param {integer} [smoothness=32] - The number of points to draw the ellipse with.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokeEllipseShape: function (ellipse, smoothness)
     {
@@ -1156,7 +1156,7 @@ var Graphics = new Class({
      * @param {number} height - The height of the ellipse.
      * @param {integer} [smoothness=32] - The number of points to draw the ellipse with.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     strokeEllipse: function (x, y, width, height, smoothness)
     {
@@ -1178,7 +1178,7 @@ var Graphics = new Class({
      * @param {Phaser.Geom.Ellipse} ellipse - The ellipse to fill.
      * @param {integer} [smoothness=32] - The number of points to draw the ellipse with.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillEllipseShape: function (ellipse, smoothness)
     {
@@ -1201,7 +1201,7 @@ var Graphics = new Class({
      * @param {number} height - The height of the ellipse.
      * @param {integer} [smoothness=32] - The number of points to draw the ellipse with.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     fillEllipse: function (x, y, width, height, smoothness)
     {
@@ -1240,7 +1240,7 @@ var Graphics = new Class({
      * @param {boolean} [anticlockwise=false] - Whether the drawing should be anticlockwise or clockwise.
      * @param {number} [overshoot=0] - This value allows you to increase the segment iterations in WebGL rendering. Useful if the arc has a thick stroke and needs to overshoot to join-up cleanly. Use small numbers such as 0.01 to start with and increase as needed.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     arc: function (x, y, radius, startAngle, endAngle, anticlockwise, overshoot)
     {
@@ -1276,7 +1276,7 @@ var Graphics = new Class({
      * @param {boolean} [anticlockwise=false] - Whether the drawing should be anticlockwise or clockwise.
      * @param {number} [overshoot=0] - This value allows you to overshoot the endAngle by this amount. Useful if the arc has a thick stroke and needs to overshoot to join-up cleanly.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     slice: function (x, y, radius, startAngle, endAngle, anticlockwise, overshoot)
     {
@@ -1302,7 +1302,7 @@ var Graphics = new Class({
      * @method Phaser.GameObjects.Graphics#save
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     save: function ()
     {
@@ -1323,7 +1323,7 @@ var Graphics = new Class({
      * @method Phaser.GameObjects.Graphics#restore
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     restore: function ()
     {
@@ -1349,7 +1349,7 @@ var Graphics = new Class({
      * @param {number} x - The horizontal translation to apply.
      * @param {number} y - The vertical translation to apply.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     translateCanvas: function (x, y)
     {
@@ -1376,7 +1376,7 @@ var Graphics = new Class({
      * @param {number} x - The horizontal scale to apply.
      * @param {number} y - The vertical scale to apply.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     scaleCanvas: function (x, y)
     {
@@ -1402,7 +1402,7 @@ var Graphics = new Class({
      *
      * @param {number} radians - The rotation angle, in radians.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     rotateCanvas: function (radians)
     {
@@ -1420,7 +1420,7 @@ var Graphics = new Class({
      * @method Phaser.GameObjects.Graphics#clear
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     clear: function ()
     {
@@ -1455,7 +1455,7 @@ var Graphics = new Class({
      * @param {integer} [width] - The width of the graphics to generate.
      * @param {integer} [height] - The height of the graphics to generate.
      *
-     * @return {Phaser.GameObjects.Graphics} This Game Object.
+     * @return {this} This Game Object.
      */
     generateTexture: function (key, width, height)
     {

--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -521,7 +521,7 @@ var Group = new Class({
      * @param {Phaser.GameObjects.GameObject} child - The Game Object to add.
      * @param {boolean} [addToScene=false] - Also add the Game Object to the scene.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     add: function (child, addToScene)
     {
@@ -570,7 +570,7 @@ var Group = new Class({
      * @param {Phaser.GameObjects.GameObject[]} children - The Game Objects to add.
      * @param {boolean} [addToScene=false] - Also add the Game Objects to the scene.
      *
-     * @return {Phaser.GameObjects.Group} This group.
+     * @return {this} This group.
      */
     addMultiple: function (children, addToScene)
     {
@@ -599,7 +599,7 @@ var Group = new Class({
      * @param {boolean} [removeFromScene=false] - Optionally remove the Group member from the Scene it belongs to.
      * @param {boolean} [destroyChild=false] - Optionally call destroy on the removed Group member.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     remove: function (child, removeFromScene, destroyChild)
     {
@@ -653,7 +653,7 @@ var Group = new Class({
      * @param {boolean} [removeFromScene=false] - Optionally remove each Group member from the Scene.
      * @param {boolean} [destroyChild=false] - Optionally call destroy on the removed Group members.
      *
-     * @return {Phaser.GameObjects.Group} This group.
+     * @return {this} This group.
      */
     clear: function (removeFromScene, destroyChild)
     {
@@ -1016,7 +1016,7 @@ var Group = new Class({
      * @param {string} key - The string-based key of the animation to play.
      * @param {string} [startFrame=0] - Optionally start the animation playing from this frame index.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     playAnimation: function (key, startFrame)
     {
@@ -1115,7 +1115,7 @@ var Group = new Class({
      * @param {integer} [index=0] - An optional offset to start searching from within the items array.
      * @param {integer} [direction=1] - The direction to iterate through the array. 1 is from beginning to end, -1 from end to beginning.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     propertyValueSet: function (key, value, step, index, direction)
     {
@@ -1136,7 +1136,7 @@ var Group = new Class({
      * @param {integer} [index=0] - An optional offset to start searching from within the items array.
      * @param {integer} [direction=1] - The direction to iterate through the array. 1 is from beginning to end, -1 from end to beginning.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     propertyValueInc: function (key, value, step, index, direction)
     {
@@ -1154,7 +1154,7 @@ var Group = new Class({
      * @param {number} value - The amount to set the property to.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     setX: function (value, step)
     {
@@ -1172,7 +1172,7 @@ var Group = new Class({
      * @param {number} value - The amount to set the property to.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     setY: function (value, step)
     {
@@ -1192,7 +1192,7 @@ var Group = new Class({
      * @param {number} [stepX=0] - This is added to the `x` amount, multiplied by the iteration counter.
      * @param {number} [stepY=0] - This is added to the `y` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     setXY: function (x, y, stepX, stepY)
     {
@@ -1210,7 +1210,7 @@ var Group = new Class({
      * @param {number} value - The amount to be added to the `x` property.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     incX: function (value, step)
     {
@@ -1228,7 +1228,7 @@ var Group = new Class({
      * @param {number} value - The amount to be added to the `y` property.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     incY: function (value, step)
     {
@@ -1248,7 +1248,7 @@ var Group = new Class({
      * @param {number} [stepX=0] - This is added to the `x` amount, multiplied by the iteration counter.
      * @param {number} [stepY=0] - This is added to the `y` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     incXY: function (x, y, stepX, stepY)
     {
@@ -1270,7 +1270,7 @@ var Group = new Class({
      * @param {number} y - The y coordinate to place the first item in the array at.
      * @param {integer} [direction=0] - The iteration direction. 0 = first to last and 1 = last to first.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     shiftPosition: function (x, y, direction)
     {
@@ -1288,7 +1288,7 @@ var Group = new Class({
      * @param {number} value - The amount to set the angle to, in degrees.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     angle: function (value, step)
     {
@@ -1306,7 +1306,7 @@ var Group = new Class({
      * @param {number} value - The amount to set the rotation to, in radians.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     rotate: function (value, step)
     {
@@ -1324,7 +1324,7 @@ var Group = new Class({
      * @param {Phaser.Types.Math.Vector2Like} point - Any object with public `x` and `y` properties.
      * @param {number} angle - The angle to rotate by, in radians.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     rotateAround: function (point, angle)
     {
@@ -1343,7 +1343,7 @@ var Group = new Class({
      * @param {number} angle - The angle to rotate by, in radians.
      * @param {number} distance - The distance from the point of rotation in pixels.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     rotateAroundDistance: function (point, angle, distance)
     {
@@ -1361,7 +1361,7 @@ var Group = new Class({
      * @param {number} value - The amount to set the alpha to.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     setAlpha: function (value, step)
     {
@@ -1381,7 +1381,7 @@ var Group = new Class({
      * @param {number} [bottomLeft] - The tint to be applied to the bottom-left corner of item.
      * @param {number} [bottomRight] - The tint to be applied to the bottom-right corner of item.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     setTint: function (topLeft, topRight, bottomLeft, bottomRight)
     {
@@ -1401,7 +1401,7 @@ var Group = new Class({
      * @param {number} [stepX=0] - This is added to the `originX` amount, multiplied by the iteration counter.
      * @param {number} [stepY=0] - This is added to the `originY` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     setOrigin: function (originX, originY, stepX, stepY)
     {
@@ -1419,7 +1419,7 @@ var Group = new Class({
      * @param {number} value - The amount to set the property to.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     scaleX: function (value, step)
     {
@@ -1437,7 +1437,7 @@ var Group = new Class({
      * @param {number} value - The amount to set the property to.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     scaleY: function (value, step)
     {
@@ -1457,7 +1457,7 @@ var Group = new Class({
      * @param {number} [stepX=0] - This is added to the `scaleX` amount, multiplied by the iteration counter.
      * @param {number} [stepY=0] - This is added to the `scaleY` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     scaleXY: function (scaleX, scaleY, stepX, stepY)
     {
@@ -1475,7 +1475,7 @@ var Group = new Class({
      * @param {number} value - The amount to set the property to.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     setDepth: function (value, step)
     {
@@ -1492,7 +1492,7 @@ var Group = new Class({
      *
      * @param {number} value - The amount to set the property to.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     setBlendMode: function (value)
     {
@@ -1510,7 +1510,7 @@ var Group = new Class({
      * @param {*} hitArea - Either an input configuration object, or a geometric shape that defines the hit area for the Game Object. If not specified a Rectangle will be used.
      * @param {Phaser.Types.Input.HitAreaCallback} hitAreaCallback - A callback to be invoked when the Game Object is interacted with. If you provide a shape you must also provide a callback.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     setHitArea: function (hitArea, hitAreaCallback)
     {
@@ -1525,7 +1525,7 @@ var Group = new Class({
      * @method Phaser.GameObjects.Group#shuffle
      * @since 3.21.0
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     shuffle: function ()
     {
@@ -1577,7 +1577,7 @@ var Group = new Class({
      * @param {integer} [index=0] - An optional offset to start searching from within the items array.
      * @param {integer} [direction=1] - The direction to iterate through the array. 1 is from beginning to end, -1 from end to beginning.
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     setVisible: function (value, index, direction)
     {
@@ -1592,7 +1592,7 @@ var Group = new Class({
      * @method Phaser.GameObjects.Group#toggleVisible
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Group} This Group object.
+     * @return {this} This Group object.
      */
     toggleVisible: function ()
     {

--- a/src/gameobjects/lights/Light.js
+++ b/src/gameobjects/lights/Light.js
@@ -135,7 +135,7 @@ var Light = new Class({
      * @param {number} b - The blue color. A value between 0 and 1.
      * @param {number} intensity - The intensity of the light.
      *
-     * @return {Phaser.GameObjects.Light} This Light object.
+     * @return {this} This Light object.
      */
     set: function (x, y, radius, r, g, b, intensity)
     {
@@ -165,7 +165,7 @@ var Light = new Class({
      * @param {number} x - The horizontal scroll factor of the light.
      * @param {number} y - The vertical scroll factor of the light.
      *
-     * @return {Phaser.GameObjects.Light} This Light object.
+     * @return {this} This Light object.
      */
     setScrollFactor: function (x, y)
     {
@@ -186,7 +186,7 @@ var Light = new Class({
      *
      * @param {number} rgb - The integer RGB color of the light.
      *
-     * @return {Phaser.GameObjects.Light} This Light object.
+     * @return {this} This Light object.
      */
     setColor: function (rgb)
     {
@@ -207,7 +207,7 @@ var Light = new Class({
      *
      * @param {number} intensity - The intensity of the light.
      *
-     * @return {Phaser.GameObjects.Light} This Light object.
+     * @return {this} This Light object.
      */
     setIntensity: function (intensity)
     {
@@ -225,7 +225,7 @@ var Light = new Class({
      * @param {number} x - The horizontal position of the light.
      * @param {number} y - The vertical position of the light.
      *
-     * @return {Phaser.GameObjects.Light} This Light object.
+     * @return {this} This Light object.
      */
     setPosition: function (x, y)
     {
@@ -243,7 +243,7 @@ var Light = new Class({
      *
      * @param {number} radius - The radius of the light.
      *
-     * @return {Phaser.GameObjects.Light} This Light object.
+     * @return {this} This Light object.
      */
     setRadius: function (radius)
     {

--- a/src/gameobjects/particles/EmitterOp.js
+++ b/src/gameobjects/particles/EmitterOp.js
@@ -209,7 +209,7 @@ var EmitterOp = new Class({
      *
      * @param {number} value - The value of the property.
      *
-     * @return {Phaser.GameObjects.Particles.EmitterOp} This Emitter Op object.
+     * @return {this} This Emitter Op object.
      */
     onChange: function (value)
     {
@@ -226,7 +226,7 @@ var EmitterOp = new Class({
      * @method Phaser.GameObjects.Particles.EmitterOp#setMethods
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Particles.EmitterOp} This Emitter Op object.
+     * @return {this} This Emitter Op object.
      */
     setMethods: function ()
     {

--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -770,7 +770,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.ParticleEmitterConfig} config - Settings for this emitter.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     fromJSON: function (config)
     {
@@ -927,7 +927,7 @@ var ParticleEmitter = new Class({
      * @param {number} [offsetY=0] - Vertical offset of the particle origin from the Game Object.
      * @param {boolean} [trackVisible=false] - Whether the emitter's visible state will track the target's visible state.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     startFollow: function (target, offsetX, offsetY, trackVisible)
     {
@@ -948,7 +948,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#stopFollow
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     stopFollow: function ()
     {
@@ -1009,7 +1009,7 @@ var ParticleEmitter = new Class({
      * @param {boolean} [pickRandom=true] - Whether frames should be assigned at random from `frames`.
      * @param {integer} [quantity=1] - The number of consecutive particles that will receive each frame.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setFrame: function (frames, pickRandom, quantity)
     {
@@ -1064,7 +1064,7 @@ var ParticleEmitter = new Class({
      *
      * @param {boolean} [value=true] - Radial mode (true) or point mode (true).
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setRadial: function (value)
     {
@@ -1085,7 +1085,7 @@ var ParticleEmitter = new Class({
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} x - The x-coordinate of the particle origin.
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} y - The y-coordinate of the particle origin.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setPosition: function (x, y)
     {
@@ -1108,7 +1108,7 @@ var ParticleEmitter = new Class({
      * @param {number} width - The width of the boundary.
      * @param {number} height - The height of the boundary.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setBounds: function (x, y, width, height)
     {
@@ -1143,7 +1143,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} value - The speed, in pixels per second.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setSpeedX: function (value)
     {
@@ -1164,7 +1164,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} value - The speed, in pixels per second.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setSpeedY: function (value)
     {
@@ -1188,7 +1188,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} value - The speed, in pixels per second.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setSpeed: function (value)
     {
@@ -1209,7 +1209,7 @@ var ParticleEmitter = new Class({
      *
      * @param {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} value - The scale, relative to 1.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setScaleX: function (value)
     {
@@ -1226,7 +1226,7 @@ var ParticleEmitter = new Class({
      *
      * @param {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} value - The scale, relative to 1.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setScaleY: function (value)
     {
@@ -1243,7 +1243,7 @@ var ParticleEmitter = new Class({
      *
      * @param {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} value - The scale, relative to 1.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setScale: function (value)
     {
@@ -1261,7 +1261,7 @@ var ParticleEmitter = new Class({
      *
      * @param {number} value - Acceleration due to gravity, in pixels per second squared.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setGravityX: function (value)
     {
@@ -1278,7 +1278,7 @@ var ParticleEmitter = new Class({
      *
      * @param {number} value - Acceleration due to gravity, in pixels per second squared.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setGravityY: function (value)
     {
@@ -1296,7 +1296,7 @@ var ParticleEmitter = new Class({
      * @param {number} x - Horizontal acceleration due to gravity, in pixels per second squared.
      * @param {number} y - Vertical acceleration due to gravity, in pixels per second squared.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setGravity: function (x, y)
     {
@@ -1314,7 +1314,7 @@ var ParticleEmitter = new Class({
      *
      * @param {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} value - A value between 0 (transparent) and 1 (opaque).
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setAlpha: function (value)
     {
@@ -1331,7 +1331,7 @@ var ParticleEmitter = new Class({
      *
      * @param {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} value - A value between 0 and 0xffffff.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setTint: function (value)
     {
@@ -1348,7 +1348,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} value - The angle of the initial velocity of emitted particles.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setEmitterAngle: function (value)
     {
@@ -1365,7 +1365,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} value - The angle of the initial velocity of emitted particles.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setAngle: function (value)
     {
@@ -1382,7 +1382,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} value - The particle lifespan, in ms.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setLifespan: function (value)
     {
@@ -1399,7 +1399,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} quantity - The number of particles to release at each flow cycle or explosion.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setQuantity: function (quantity)
     {
@@ -1418,7 +1418,7 @@ var ParticleEmitter = new Class({
      * @param {number} frequency - The time interval (>= 0) of each flow cycle, in ms; or -1 to put the emitter in explosion mode.
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [quantity] - The number of particles to release at each flow cycle or explosion.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setFrequency: function (frequency, quantity)
     {
@@ -1446,7 +1446,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.ParticleEmitterEdgeZoneConfig|Phaser.Types.GameObjects.Particles.ParticleEmitterRandomZoneConfig} [zoneConfig] - An object describing the zone, or `undefined` to remove any current emit zone.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setEmitZone: function (zoneConfig)
     {
@@ -1495,7 +1495,7 @@ var ParticleEmitter = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.ParticleEmitterDeathZoneConfig} [zoneConfig] - An object describing the zone, or `undefined` to remove any current death zone.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     setDeathZone: function (zoneConfig)
     {
@@ -1531,7 +1531,7 @@ var ParticleEmitter = new Class({
      *
      * @param {integer} particleCount - The number of particles to create.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     reserve: function (particleCount)
     {
@@ -1606,7 +1606,7 @@ var ParticleEmitter = new Class({
      * @param {Phaser.Types.GameObjects.Particles.ParticleEmitterCallback} callback - The function.
      * @param {*} [context] - The calling context.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     onParticleEmit: function (callback, context)
     {
@@ -1638,7 +1638,7 @@ var ParticleEmitter = new Class({
      * @param {Phaser.Types.GameObjects.Particles.ParticleDeathCallback} callback - The function.
      * @param {*} [context] - The function's calling context.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     onParticleDeath: function (callback, context)
     {
@@ -1667,7 +1667,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#killAll
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     killAll: function ()
     {
@@ -1691,7 +1691,7 @@ var ParticleEmitter = new Class({
      * @param {Phaser.Types.GameObjects.Particles.ParticleEmitterCallback} callback - The function.
      * @param {*} context - The function's calling context.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     forEachAlive: function (callback, context)
     {
@@ -1716,7 +1716,7 @@ var ParticleEmitter = new Class({
      * @param {Phaser.Types.GameObjects.Particles.ParticleEmitterCallback} callback - The function.
      * @param {*} context - The function's calling context.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     forEachDead: function (callback, context)
     {
@@ -1743,7 +1743,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#start
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     start: function ()
     {
@@ -1760,7 +1760,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#stop
      * @since 3.11.0
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     stop: function ()
     {
@@ -1775,7 +1775,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#pause
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     pause: function ()
     {
@@ -1790,7 +1790,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#resume
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     resume: function ()
     {
@@ -1805,7 +1805,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#remove
      * @since 3.22.0
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     remove: function ()
     {
@@ -1820,7 +1820,7 @@ var ParticleEmitter = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitter#depthSort
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     depthSort: function ()
     {
@@ -1840,7 +1840,7 @@ var ParticleEmitter = new Class({
      * @param {number} frequency - The time interval (>= 0) of each flow cycle, in ms.
      * @param {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [count=1] - The number of particles to emit at each flow cycle.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitter} This Particle Emitter.
+     * @return {this} This Particle Emitter.
      */
     flow: function (frequency, count)
     {

--- a/src/gameobjects/particles/ParticleEmitterManager.js
+++ b/src/gameobjects/particles/ParticleEmitterManager.js
@@ -160,7 +160,7 @@ var ParticleEmitterManager = new Class({
      * @param {string} key - The key of the texture to be used, as stored in the Texture Manager.
      * @param {(string|integer)} [frame] - The name or index of the frame within the Texture.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitterManager} This Emitter Manager.
+     * @return {this} This Emitter Manager.
      */
     setTexture: function (key, frame)
     {
@@ -181,7 +181,7 @@ var ParticleEmitterManager = new Class({
      *
      * @param {(string|integer)} [frame] - The name or index of the frame within the Texture.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitterManager} This Emitter Manager.
+     * @return {this} This Emitter Manager.
      */
     setFrame: function (frame)
     {
@@ -212,7 +212,7 @@ var ParticleEmitterManager = new Class({
      * @param {(Phaser.Textures.Frame|Phaser.Textures.Frame[])} frames - The texture frames.
      * @param {Phaser.GameObjects.Particles.ParticleEmitter} emitter - The particle emitter to modify.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitterManager} This Emitter Manager.
+     * @return {this} This Emitter Manager.
      */
     setEmitterFrames: function (frames, emitter)
     {
@@ -332,7 +332,7 @@ var ParticleEmitterManager = new Class({
      * @param {number} [x] - The x-coordinate to to emit particles from. The default is the x-coordinate of the emitter's current location.
      * @param {number} [y] - The y-coordinate to to emit particles from. The default is the y-coordinate of the emitter's current location.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitterManager} This Emitter Manager.
+     * @return {this} This Emitter Manager.
      */
     emitParticle: function (count, x, y)
     {
@@ -361,7 +361,7 @@ var ParticleEmitterManager = new Class({
      * @param {number} [y] - The y-coordinate to to emit particles from. The default is the y-coordinate of the emitter's current location.
      * @param {integer} [count] - The number of particles to release from each emitter. The default is the emitter's own {@link Phaser.GameObjects.Particles.ParticleEmitter#quantity}.
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitterManager} This Emitter Manager.
+     * @return {this} This Emitter Manager.
      */
     emitParticleAt: function (x, y, count)
     {
@@ -378,7 +378,7 @@ var ParticleEmitterManager = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitterManager#pause
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitterManager} This Emitter Manager.
+     * @return {this} This Emitter Manager.
      */
     pause: function ()
     {
@@ -393,7 +393,7 @@ var ParticleEmitterManager = new Class({
      * @method Phaser.GameObjects.Particles.ParticleEmitterManager#resume
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Particles.ParticleEmitterManager} This Emitter Manager.
+     * @return {this} This Emitter Manager.
      */
     resume: function ()
     {

--- a/src/gameobjects/particles/zones/EdgeZone.js
+++ b/src/gameobjects/particles/zones/EdgeZone.js
@@ -131,7 +131,7 @@ var EdgeZone = new Class({
      * @method Phaser.GameObjects.Particles.Zones.EdgeZone#updateSource
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Particles.Zones.EdgeZone} This Edge Zone.
+     * @return {this} This Edge Zone.
      */
     updateSource: function ()
     {
@@ -170,7 +170,7 @@ var EdgeZone = new Class({
      *
      * @param {Phaser.Types.GameObjects.Particles.EdgeZoneSource} source - An object instance with a `getPoints(quantity, stepRate)` method returning an array of points.
      *
-     * @return {Phaser.GameObjects.Particles.Zones.EdgeZone} This Edge Zone.
+     * @return {this} This Edge Zone.
      */
     changeSource: function (source)
     {

--- a/src/gameobjects/quad/Quad.js
+++ b/src/gameobjects/quad/Quad.js
@@ -499,7 +499,7 @@ var Quad = new Class({
      * @param {number} x - The horizontal coordinate of the vertex.
      * @param {number} y - The vertical coordinate of the vertex.
      *
-     * @return {Phaser.GameObjects.Quad} This Game Object.
+     * @return {this} This Game Object.
      */
     setTopLeft: function (x, y)
     {
@@ -518,7 +518,7 @@ var Quad = new Class({
      * @param {number} x - The horizontal coordinate of the vertex.
      * @param {number} y - The vertical coordinate of the vertex.
      *
-     * @return {Phaser.GameObjects.Quad} This Game Object.
+     * @return {this} This Game Object.
      */
     setTopRight: function (x, y)
     {
@@ -537,7 +537,7 @@ var Quad = new Class({
      * @param {number} x - The horizontal coordinate of the vertex.
      * @param {number} y - The vertical coordinate of the vertex.
      *
-     * @return {Phaser.GameObjects.Quad} This Game Object.
+     * @return {this} This Game Object.
      */
     setBottomLeft: function (x, y)
     {
@@ -556,7 +556,7 @@ var Quad = new Class({
      * @param {number} x - The horizontal coordinate of the vertex.
      * @param {number} y - The vertical coordinate of the vertex.
      *
-     * @return {Phaser.GameObjects.Quad} This Game Object.
+     * @return {this} This Game Object.
      */
     setBottomRight: function (x, y)
     {
@@ -572,7 +572,7 @@ var Quad = new Class({
      * @method Phaser.GameObjects.Quad#resetPosition
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Quad} This Game Object.
+     * @return {this} This Game Object.
      */
     resetPosition: function ()
     {
@@ -595,7 +595,7 @@ var Quad = new Class({
      * @method Phaser.GameObjects.Quad#resetAlpha
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Quad} This Game Object.
+     * @return {this} This Game Object.
      */
     resetAlpha: function ()
     {
@@ -617,7 +617,7 @@ var Quad = new Class({
      * @method Phaser.GameObjects.Quad#resetColors
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Quad} This Game Object.
+     * @return {this} This Game Object.
      */
     resetColors: function ()
     {
@@ -639,7 +639,7 @@ var Quad = new Class({
      * @method Phaser.GameObjects.Quad#reset
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Quad} This Game Object.
+     * @return {this} This Game Object.
      */
     reset: function ()
     {

--- a/src/gameobjects/sprite/Sprite.js
+++ b/src/gameobjects/sprite/Sprite.js
@@ -127,7 +127,7 @@ var Sprite = new Class({
      * @param {boolean} [ignoreIfPlaying=false] - If an animation is already playing then ignore this call.
      * @param {integer} [startFrame=0] - Optionally start the animation playing from this frame index.
      *
-     * @return {Phaser.GameObjects.Sprite} This Game Object.
+     * @return {this} This Game Object.
      */
     play: function (key, ignoreIfPlaying, startFrame)
     {

--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -588,7 +588,7 @@ var Text = new Class({
      *
      * @param {(string|string[])} value - The string, or array of strings, to be set as the content of this Text object.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setText: function (value)
     {
@@ -629,7 +629,7 @@ var Text = new Class({
      *
      * @param {object} style - The style settings to set.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setStyle: function (style)
     {
@@ -663,7 +663,7 @@ var Text = new Class({
      *
      * @param {string} font - The font family or font settings to set.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setFont: function (font)
     {
@@ -692,7 +692,7 @@ var Text = new Class({
      *
      * @param {string} family - The font family.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setFontFamily: function (family)
     {
@@ -707,7 +707,7 @@ var Text = new Class({
      *
      * @param {number} size - The font size.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setFontSize: function (size)
     {
@@ -722,7 +722,7 @@ var Text = new Class({
      *
      * @param {string} style - The font style.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setFontStyle: function (style)
     {
@@ -740,7 +740,7 @@ var Text = new Class({
      * @param {number} width - The fixed width to set. `0` disables fixed width.
      * @param {number} height - The fixed height to set. `0` disables fixed height.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setFixedSize: function (width, height)
     {
@@ -755,7 +755,7 @@ var Text = new Class({
      *
      * @param {string} color - The background color.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setBackgroundColor: function (color)
     {
@@ -775,7 +775,7 @@ var Text = new Class({
      *
      * @param {(string|any)} color - The text fill style. Can be any valid CanvasRenderingContext `fillStyle` value.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setFill: function (fillStyle)
     {
@@ -790,7 +790,7 @@ var Text = new Class({
      *
      * @param {string} color - The text fill color.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setColor: function (color)
     {
@@ -806,7 +806,7 @@ var Text = new Class({
      * @param {string} color - The stroke color.
      * @param {number} thickness - The stroke thickness.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setStroke: function (color, thickness)
     {
@@ -826,7 +826,7 @@ var Text = new Class({
      * @param {boolean} [shadowStroke=false] - Whether to stroke the shadow.
      * @param {boolean} [shadowFill=true] - Whether to fill the shadow.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setShadow: function (x, y, color, blur, shadowStroke, shadowFill)
     {
@@ -842,7 +842,7 @@ var Text = new Class({
      * @param {number} x - The horizontal shadow offset.
      * @param {number} y - The vertical shadow offset.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setShadowOffset: function (x, y)
     {
@@ -857,7 +857,7 @@ var Text = new Class({
      *
      * @param {string} color - The shadow color.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setShadowColor: function (color)
     {
@@ -872,7 +872,7 @@ var Text = new Class({
      *
      * @param {number} blur - The shadow blur radius.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setShadowBlur: function (blur)
     {
@@ -887,7 +887,7 @@ var Text = new Class({
      *
      * @param {boolean} enabled - Whether shadow stroke is enabled or not.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setShadowStroke: function (enabled)
     {
@@ -902,7 +902,7 @@ var Text = new Class({
      *
      * @param {boolean} enabled - Whether shadow fill is enabled or not.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setShadowFill: function (enabled)
     {
@@ -920,7 +920,7 @@ var Text = new Class({
      * algorithm. If true, spaces are collapsed and whitespace is trimmed from lines. If false,
      * spaces and whitespace are left as is.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setWordWrapWidth: function (width, useAdvancedWrap)
     {
@@ -939,7 +939,7 @@ var Text = new Class({
      * newline characters in place to indicate where breaks should happen.
      * @param {object} [scope=null] - The scope that will be applied when the callback is invoked.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setWordWrapCallback: function (callback, scope)
     {
@@ -958,7 +958,7 @@ var Text = new Class({
      *
      * @param {string} [align='left'] - The text alignment for multi-line text.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setAlign: function (align)
     {
@@ -981,7 +981,7 @@ var Text = new Class({
      *
      * @param {number} value - The resolution for this Text object to use.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setResolution: function (value)
     {
@@ -999,7 +999,7 @@ var Text = new Class({
      *
      * @param {number} value - The amount to add to the font height to achieve the overall line height.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setLineSpacing: function (value)
     {
@@ -1023,7 +1023,7 @@ var Text = new Class({
      * @param {number} right - The right padding value.
      * @param {number} bottom - The bottom padding value.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setPadding: function (left, top, right, bottom)
     {
@@ -1082,7 +1082,7 @@ var Text = new Class({
      *
      * @param {integer} [max=0] - The maximum number of lines to draw.
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     setMaxLines: function (max)
     {
@@ -1095,7 +1095,7 @@ var Text = new Class({
      * @method Phaser.GameObjects.Text#updateText
      * @since 3.0.0
      *
-     * @return {Phaser.GameObjects.Text} This Text object.
+     * @return {this} This Text object.
      */
     updateText: function ()
     {

--- a/src/gameobjects/zone/Zone.js
+++ b/src/gameobjects/zone/Zone.js
@@ -156,7 +156,7 @@ var Zone = new Class({
      * @param {number} height - The height of this Game Object.
      * @param {boolean} [resizeInput=true] - If this Zone has a Rectangle for a hit area this argument will resize the hit area as well.
      *
-     * @return {Phaser.GameObjects.Zone} This Game Object.
+     * @return {this} This Game Object.
      */
     setSize: function (width, height, resizeInput)
     {
@@ -188,7 +188,7 @@ var Zone = new Class({
      * @param {number} width - The width of this Game Object.
      * @param {number} height - The height of this Game Object.
      *
-     * @return {Phaser.GameObjects.Zone} This Game Object.
+     * @return {this} This Game Object.
      */
     setDisplaySize: function (width, height)
     {
@@ -207,7 +207,7 @@ var Zone = new Class({
      *
      * @param {number} radius - The radius of the Circle that will form the Drop Zone.
      *
-     * @return {Phaser.GameObjects.Zone} This Game Object.
+     * @return {this} This Game Object.
      */
     setCircleDropZone: function (radius)
     {
@@ -224,7 +224,7 @@ var Zone = new Class({
      * @param {number} width - The width of the rectangle drop zone.
      * @param {number} height - The height of the rectangle drop zone.
      *
-     * @return {Phaser.GameObjects.Zone} This Game Object.
+     * @return {this} This Game Object.
      */
     setRectangleDropZone: function (width, height)
     {
@@ -240,7 +240,7 @@ var Zone = new Class({
      * @param {object} shape - A Geometry shape instance, such as Phaser.Geom.Ellipse, or your own custom shape.
      * @param {Phaser.Types.Input.HitAreaCallback} callback - A function that will return `true` if the given x/y coords it is sent are within the shape.
      *
-     * @return {Phaser.GameObjects.Zone} This Game Object.
+     * @return {this} This Game Object.
      */
     setDropZone: function (shape, callback)
     {

--- a/src/loader/LoaderPlugin.js
+++ b/src/loader/LoaderPlugin.js
@@ -368,7 +368,7 @@ var LoaderPlugin = new Class({
      *
      * @param {string} [url] - The URL to use. Leave empty to reset.
      *
-     * @return {Phaser.Loader.LoaderPlugin} This Loader object.
+     * @return {this} This Loader object.
      */
     setBaseURL: function (url)
     {
@@ -408,7 +408,7 @@ var LoaderPlugin = new Class({
      *
      * @param {string} [path] - The path to use. Leave empty to reset.
      *
-     * @return {Phaser.Loader.LoaderPlugin} This Loader object.
+     * @return {this} This Loader object.
      */
     setPath: function (path)
     {
@@ -437,7 +437,7 @@ var LoaderPlugin = new Class({
      *
      * @param {string} [prefix] - The prefix to use. Leave empty to reset.
      *
-     * @return {Phaser.Loader.LoaderPlugin} This Loader object.
+     * @return {this} This Loader object.
      */
     setPrefix: function (prefix)
     {
@@ -463,7 +463,7 @@ var LoaderPlugin = new Class({
      *
      * @param {string} [crossOrigin] - The value to use for the `crossOrigin` property in the load request.
      *
-     * @return {Phaser.Loader.LoaderPlugin} This Loader object.
+     * @return {this} This Loader object.
      */
     setCORS: function (crossOrigin)
     {
@@ -952,7 +952,7 @@ var LoaderPlugin = new Class({
      * @param {*} data - The JSON data, ready parsed.
      * @param {string} [filename=file.json] - The name to save the JSON file as.
      *
-     * @return {Phaser.Loader.LoaderPlugin} This Loader plugin.
+     * @return {this} This Loader plugin.
      */
     saveJSON: function (data, filename)
     {
@@ -972,7 +972,7 @@ var LoaderPlugin = new Class({
      * @param {string} [filename=file.json] - The filename to save the file as.
      * @param {string} [filetype=application/json] - The file type to use when saving the file. Defaults to JSON.
      *
-     * @return {Phaser.Loader.LoaderPlugin} This Loader plugin.
+     * @return {this} This Loader plugin.
      */
     save: function (data, filename, filetype)
     {

--- a/src/loader/filetypes/AnimationJSONFile.js
+++ b/src/loader/filetypes/AnimationJSONFile.js
@@ -171,7 +171,7 @@ var AnimationJSONFile = new Class({
  * @param {string} [dataKey] - When the Animation JSON file loads only this property will be stored in the Cache and used to create animation data.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('animation', function (key, url, dataKey, xhrSettings)
 {

--- a/src/loader/filetypes/AtlasJSONFile.js
+++ b/src/loader/filetypes/AtlasJSONFile.js
@@ -211,7 +211,7 @@ var AtlasJSONFile = new Class({
  * @param {Phaser.Types.Loader.XHRSettingsObject} [textureXhrSettings] - An XHR Settings configuration object for the atlas image file. Used in replacement of the Loaders default XHR Settings.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [atlasXhrSettings] - An XHR Settings configuration object for the atlas json file. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('atlas', function (key, textureURL, atlasURL, textureXhrSettings, atlasXhrSettings)
 {

--- a/src/loader/filetypes/AtlasXMLFile.js
+++ b/src/loader/filetypes/AtlasXMLFile.js
@@ -205,7 +205,7 @@ var AtlasXMLFile = new Class({
  * @param {Phaser.Types.Loader.XHRSettingsObject} [textureXhrSettings] - An XHR Settings configuration object for the atlas image file. Used in replacement of the Loaders default XHR Settings.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [atlasXhrSettings] - An XHR Settings configuration object for the atlas xml file. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('atlasXML', function (key, textureURL, atlasURL, textureXhrSettings, atlasXhrSettings)
 {

--- a/src/loader/filetypes/AudioFile.js
+++ b/src/loader/filetypes/AudioFile.js
@@ -220,7 +220,7 @@ AudioFile.getAudioURL = function (game, urls)
  * @param {any} [config] - An object containing an `instances` property for HTML5Audio. Defaults to 1.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('audio', function (key, urls, config, xhrSettings)
 {

--- a/src/loader/filetypes/AudioSpriteFile.js
+++ b/src/loader/filetypes/AudioSpriteFile.js
@@ -238,7 +238,7 @@ var AudioSpriteFile = new Class({
  * @param {Phaser.Types.Loader.XHRSettingsObject} [audioXhrSettings] - An XHR Settings configuration object for the audio file. Used in replacement of the Loaders default XHR Settings.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [jsonXhrSettings] - An XHR Settings configuration object for the json file. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader.
+ * @return {this} The Loader.
  */
 FileTypesManager.register('audioSprite', function (key, jsonURL, audioURL, audioConfig, audioXhrSettings, jsonXhrSettings)
 {

--- a/src/loader/filetypes/BinaryFile.js
+++ b/src/loader/filetypes/BinaryFile.js
@@ -153,7 +153,7 @@ var BinaryFile = new Class({
  * @param {any} [dataType] - Optional type to cast the binary file to once loaded. For example, `Uint8Array`.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('binary', function (key, url, dataType, xhrSettings)
 {

--- a/src/loader/filetypes/BitmapFontFile.js
+++ b/src/loader/filetypes/BitmapFontFile.js
@@ -205,7 +205,7 @@ var BitmapFontFile = new Class({
  * @param {Phaser.Types.Loader.XHRSettingsObject} [textureXhrSettings] - An XHR Settings configuration object for the font image file. Used in replacement of the Loaders default XHR Settings.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [fontDataXhrSettings] - An XHR Settings configuration object for the font data xml file. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('bitmapFont', function (key, textureURL, fontDataURL, textureXhrSettings, fontDataXhrSettings)
 {

--- a/src/loader/filetypes/CSSFile.js
+++ b/src/loader/filetypes/CSSFile.js
@@ -139,7 +139,7 @@ var CSSFile = new Class({
  * @param {string} [url] - The absolute or relative URL to load this file from. If undefined or `null` it will be set to `<key>.css`, i.e. if `key` was "alien" then the URL will be "alien.css".
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('css', function (key, url, xhrSettings)
 {

--- a/src/loader/filetypes/GLSLFile.js
+++ b/src/loader/filetypes/GLSLFile.js
@@ -382,7 +382,7 @@ var GLSLFile = new Class({
  * @param {string} [shaderType='fragment'] - The type of shader. Either `fragment` for a fragment shader, or `vertex` for a vertex shader. This is ignored if you load a shader bundle.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('glsl', function (key, url, shaderType, xhrSettings)
 {

--- a/src/loader/filetypes/HTMLFile.js
+++ b/src/loader/filetypes/HTMLFile.js
@@ -146,7 +146,7 @@ var HTMLFile = new Class({
  * @param {string} [url] - The absolute or relative URL to load this file from. If undefined or `null` it will be set to `<key>.html`, i.e. if `key` was "alien" then the URL will be "alien.html".
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('html', function (key, url, xhrSettings)
 {

--- a/src/loader/filetypes/HTMLTextureFile.js
+++ b/src/loader/filetypes/HTMLTextureFile.js
@@ -229,7 +229,7 @@ var HTMLTextureFile = new Class({
  * @param {integer} [height=512] - The height of the texture the HTML will be rendered to.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('htmlTexture', function (key, url, width, height, xhrSettings)
 {

--- a/src/loader/filetypes/ImageFile.js
+++ b/src/loader/filetypes/ImageFile.js
@@ -245,7 +245,7 @@ var ImageFile = new Class({
  * @param {string|string[]} [url] - The absolute or relative URL to load this file from. If undefined or `null` it will be set to `<key>.png`, i.e. if `key` was "alien" then the URL will be "alien.png".
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('image', function (key, url, xhrSettings)
 {

--- a/src/loader/filetypes/JSONFile.js
+++ b/src/loader/filetypes/JSONFile.js
@@ -201,7 +201,7 @@ var JSONFile = new Class({
  * @param {string} [dataKey] - When the JSON file loads only this property will be stored in the Cache.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('json', function (key, url, dataKey, xhrSettings)
 {

--- a/src/loader/filetypes/MultiAtlasFile.js
+++ b/src/loader/filetypes/MultiAtlasFile.js
@@ -295,7 +295,7 @@ var MultiAtlasFile = new Class({
  * @param {string} [baseURL] - Optional Base URL to use when loading the textures defined in the atlas data.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [atlasXhrSettings] - An XHR Settings configuration object for the atlas json file. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('multiatlas', function (key, atlasURL, path, baseURL, atlasXhrSettings)
 {

--- a/src/loader/filetypes/MultiScriptFile.js
+++ b/src/loader/filetypes/MultiScriptFile.js
@@ -179,7 +179,7 @@ var MultiScriptFile = new Class({
  * @param {string} [extension='js'] - The default file extension to use if no url is provided.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - Extra XHR Settings specifically for these files.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('scripts', function (key, url, xhrSettings)
 {

--- a/src/loader/filetypes/PackFile.js
+++ b/src/loader/filetypes/PackFile.js
@@ -186,7 +186,7 @@ var PackFile = new Class({
  * @param {string} [dataKey] - When the JSON file loads only this property will be stored in the Cache.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('pack', function (key, url, packKey, xhrSettings)
 {

--- a/src/loader/filetypes/PluginFile.js
+++ b/src/loader/filetypes/PluginFile.js
@@ -183,7 +183,7 @@ var PluginFile = new Class({
  * @param {string} [mapping] - If this plugin is to be injected into the Scene, this is the property key used.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('plugin', function (key, url, start, mapping, xhrSettings)
 {

--- a/src/loader/filetypes/SVGFile.js
+++ b/src/loader/filetypes/SVGFile.js
@@ -309,7 +309,7 @@ var SVGFile = new Class({
  * @param {Phaser.Types.Loader.FileTypes.SVGSizeConfig} [svgConfig] - The svg size configuration object.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('svg', function (key, url, svgConfig, xhrSettings)
 {

--- a/src/loader/filetypes/SceneFile.js
+++ b/src/loader/filetypes/SceneFile.js
@@ -192,7 +192,7 @@ var SceneFile = new Class({
  * @param {string} [url] - The absolute or relative URL to load this file from. If undefined or `null` it will be set to `<key>.js`, i.e. if `key` was "alien" then the URL will be "alien.js".
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('sceneFile', function (key, url, xhrSettings)
 {

--- a/src/loader/filetypes/ScenePluginFile.js
+++ b/src/loader/filetypes/ScenePluginFile.js
@@ -177,7 +177,7 @@ var ScenePluginFile = new Class({
  * @param {string} [sceneKey] - If this plugin is to be added to the Scene, this is the property key for it.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('scenePlugin', function (key, url, systemKey, sceneKey, xhrSettings)
 {

--- a/src/loader/filetypes/ScriptFile.js
+++ b/src/loader/filetypes/ScriptFile.js
@@ -142,7 +142,7 @@ var ScriptFile = new Class({
  * @param {string} [url] - The absolute or relative URL to load this file from. If undefined or `null` it will be set to `<key>.js`, i.e. if `key` was "alien" then the URL will be "alien.js".
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('script', function (key, url, xhrSettings)
 {

--- a/src/loader/filetypes/SpriteSheetFile.js
+++ b/src/loader/filetypes/SpriteSheetFile.js
@@ -162,7 +162,7 @@ var SpriteSheetFile = new Class({
  * @param {Phaser.Types.Loader.FileTypes.ImageFrameConfig} [frameConfig] - The frame configuration object. At a minimum it should have a `frameWidth` property.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('spritesheet', function (key, url, frameConfig, xhrSettings)
 {

--- a/src/loader/filetypes/TextFile.js
+++ b/src/loader/filetypes/TextFile.js
@@ -146,7 +146,7 @@ var TextFile = new Class({
  * @param {string} [url] - The absolute or relative URL to load this file from. If undefined or `null` it will be set to `<key>.txt`, i.e. if `key` was "alien" then the URL will be "alien.txt".
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('text', function (key, url, xhrSettings)
 {

--- a/src/loader/filetypes/TilemapCSVFile.js
+++ b/src/loader/filetypes/TilemapCSVFile.js
@@ -166,7 +166,7 @@ var TilemapCSVFile = new Class({
  * @param {string} [url] - The absolute or relative URL to load this file from. If undefined or `null` it will be set to `<key>.csv`, i.e. if `key` was "alien" then the URL will be "alien.csv".
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('tilemapCSV', function (key, url, xhrSettings)
 {

--- a/src/loader/filetypes/TilemapImpactFile.js
+++ b/src/loader/filetypes/TilemapImpactFile.js
@@ -127,7 +127,7 @@ var TilemapImpactFile = new Class({
  * @param {string} [url] - The absolute or relative URL to load this file from. If undefined or `null` it will be set to `<key>.json`, i.e. if `key` was "alien" then the URL will be "alien.json".
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('tilemapImpact', function (key, url, xhrSettings)
 {

--- a/src/loader/filetypes/TilemapJSONFile.js
+++ b/src/loader/filetypes/TilemapJSONFile.js
@@ -127,7 +127,7 @@ var TilemapJSONFile = new Class({
  * @param {string} [url] - The absolute or relative URL to load this file from. If undefined or `null` it will be set to `<key>.json`, i.e. if `key` was "alien" then the URL will be "alien.json".
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('tilemapTiledJSON', function (key, url, xhrSettings)
 {

--- a/src/loader/filetypes/UnityAtlasFile.js
+++ b/src/loader/filetypes/UnityAtlasFile.js
@@ -204,7 +204,7 @@ var UnityAtlasFile = new Class({
  * @param {Phaser.Types.Loader.XHRSettingsObject} [textureXhrSettings] - An XHR Settings configuration object for the atlas image file. Used in replacement of the Loaders default XHR Settings.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [atlasXhrSettings] - An XHR Settings configuration object for the atlas data file. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('unityAtlas', function (key, textureURL, atlasURL, textureXhrSettings, atlasXhrSettings)
 {

--- a/src/loader/filetypes/VideoFile.js
+++ b/src/loader/filetypes/VideoFile.js
@@ -350,7 +350,7 @@ VideoFile.getVideoURL = function (game, urls)
  * @param {boolean} [noAudio=false] - Does the video have an audio track? If not you can enable auto-playing on it.
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('video', function (key, urls, loadEvent, asBlob, noAudio, xhrSettings)
 {

--- a/src/loader/filetypes/XMLFile.js
+++ b/src/loader/filetypes/XMLFile.js
@@ -156,7 +156,7 @@ var XMLFile = new Class({
  * @param {string} [url] - The absolute or relative URL to load this file from. If undefined or `null` it will be set to `<key>.xml`, i.e. if `key` was "alien" then the URL will be "alien.xml".
  * @param {Phaser.Types.Loader.XHRSettingsObject} [xhrSettings] - An XHR Settings configuration object. Used in replacement of the Loaders default XHR Settings.
  *
- * @return {Phaser.Loader.LoaderPlugin} The Loader instance.
+ * @return {this} The Loader instance.
  */
 FileTypesManager.register('xml', function (key, url, xhrSettings)
 {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:

* Fixed `this` return types for `Phaser.GameObjects.Bob`.
* Fixed `this` return types for `Phaser.GameObjects.Components.PathFollower`.
* Fixed `this` return types for `Phaser.GameObjects.Components.TransformMatrix`.
* Fixed `this` return types for `Phaser.GameObjects.Container`.
* Fixed `this` return types for `Phaser.GameObjects.DynamicBitmapText`.
* Fixed `this` return types for `Phaser.GameObjects.Graphics`.
* Fixed `this` return types for `Phaser.GameObjects.Group`.
* Fixed `this` return types for `Phaser.GameObjects.Light`.
* Fixed `this` return types for `Phaser.GameObjects.Particles.EmitterOp`.
* Fixed `this` return types fro `Phaser.GameObjects.Particles.ParticleEmitter`.
* Fixed `this` return types for `Phaser.GameObjects.Particles.ParticleEmitterManager`.
* Fixed `this` return types for `Phaser.GameObjects.Particles.Zones.EdgeZone`.
* Fixed `this` return types for `Phaser.GameObjects.Quad`.
* Fixed `this` return types for `Phaser.GameObjects.Sprite`.
* Fixed `this` return types for `Phaser.GameObjects.Text`.
* Fixed `this` return types for `Phaser.GameObjects.Zone`.
* Fixed `this` return types for `Phaser.Loader.LoaderPlugin`.