### PR TITLE
Fix centering in Body#setSize()

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1233,10 +1233,10 @@ var Body = new Class({
 
         if (center && gameObject.getCenter)
         {
-            var ox = gameObject.displayWidth / 2;
-            var oy = gameObject.displayHeight / 2;
+            var ox = (gameObject.width - width) / 2;
+            var oy = (gameObject.height - height) / 2;
 
-            this.offset.set(ox - this.halfWidth, oy - this.halfHeight);
+            this.offset.set(ox, oy);
         }
 
         this.isCircle = false;


### PR DESCRIPTION
This PR

* Fixes a bug

When calling `Body#setSize(…, center = true)` for a scaled sprite, the calculated offset was wrong.

https://codepen.io/samme/pen/ZEYZJBa

