### PR TITLE
Arcade Physics fixes

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -33,8 +33,8 @@ var Body = new Class({
 
     function Body (world, gameObject)
     {
-        var width = (gameObject.width) ? gameObject.width : 64;
-        var height = (gameObject.height) ? gameObject.height : 64;
+        var width = (gameObject.displayWidth) ? gameObject.displayWidth : 64;
+        var height = (gameObject.displayHeight) ? gameObject.displayHeight : 64;
 
         /**
          * The Arcade Physics simulation this Body belongs to.

--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -148,7 +148,10 @@ var Body = new Class({
          * @type {Phaser.Math.Vector2}
          * @since 3.0.0
          */
-        this.position = new Vector2(gameObject.x, gameObject.y);
+        this.position = new Vector2(
+            gameObject.x - gameObject.scaleX * gameObject.displayOriginX,
+            gameObject.y - gameObject.scaleY * gameObject.displayOriginY
+        );
 
         /**
          * The position of this Body during the previous step.

--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -281,7 +281,7 @@ var Body = new Class({
          * @type {Phaser.Math.Vector2}
          * @since 3.0.0
          */
-        this.center = new Vector2(gameObject.x + this.halfWidth, gameObject.y + this.halfHeight);
+        this.center = new Vector2(this.position.x + this.halfWidth, this.position.y + this.halfHeight);
 
         /**
          * The Body's velocity, in pixels per second.

--- a/src/physics/arcade/StaticBody.js
+++ b/src/physics/arcade/StaticBody.js
@@ -35,8 +35,8 @@ var StaticBody = new Class({
 
     function StaticBody (world, gameObject)
     {
-        var width = (gameObject.width) ? gameObject.width : 64;
-        var height = (gameObject.height) ? gameObject.height : 64;
+        var width = (gameObject.displayWidth) ? gameObject.displayWidth : 64;
+        var height = (gameObject.displayHeight) ? gameObject.displayHeight : 64;
 
         /**
          * The Arcade Physics simulation this Static Body belongs to.

--- a/src/physics/arcade/StaticBody.js
+++ b/src/physics/arcade/StaticBody.js
@@ -173,7 +173,7 @@ var StaticBody = new Class({
          * @type {Phaser.Math.Vector2}
          * @since 3.0.0
          */
-        this.center = new Vector2(gameObject.x + this.halfWidth, gameObject.y + this.halfHeight);
+        this.center = new Vector2(this.position.x + this.halfWidth, this.position.y + this.halfHeight);
 
         /**
          * A constant zero velocity used by the Arcade Physics simulation for calculations.

--- a/src/physics/arcade/StaticBody.js
+++ b/src/physics/arcade/StaticBody.js
@@ -15,7 +15,7 @@ var Vector2 = require('../../math/Vector2');
  * A Static Arcade Physics Body.
  *
  * A Static Body never moves, and isn't automatically synchronized with its parent Game Object.
- * That means if you make any change to the parent's origin, position, or scale after creating or adding the body, you'll need to update the Body manually.
+ * That means if you make any change to the parent's origin, position, or scale after creating or adding the body, you'll need to update the Static Body manually.
  *
  * A Static Body can collide with other Bodies, but is never moved by collisions.
  *
@@ -95,8 +95,8 @@ var StaticBody = new Class({
         this.isCircle = false;
 
         /**
-         * If this Static Body is circular, this is the unscaled radius of the Static Body's boundary, as set by {@link #setCircle}, in source pixels.
-         * The true radius is equal to `halfWidth`.
+         * If this Static Body is circular, this is the radius of the boundary, as set by {@link Phaser.Physics.Arcade.StaticBody#setCircle}, in pixels.
+         * Equal to `halfWidth`.
          *
          * @name Phaser.Physics.Arcade.StaticBody#radius
          * @type {number}
@@ -106,12 +106,13 @@ var StaticBody = new Class({
         this.radius = 0;
 
         /**
-         * The offset of this Static Body's actual position from any updated position.
+         * The offset set by {@link Phaser.Physics.Arcade.StaticBody#setCircle} or {@link Phaser.Physics.Arcade.StaticBody#setSize}.
          *
-         * Unlike a dynamic Body, a Static Body does not follow its Game Object. As such, this offset is only applied when resizing the Static Body.
+         * This doesn't affect the Static Body's position, because a Static Body does not follow its Game Object.
          *
          * @name Phaser.Physics.Arcade.StaticBody#offset
          * @type {Phaser.Math.Vector2}
+         * @readonly
          * @since 3.0.0
          */
         this.offset = new Vector2();
@@ -389,7 +390,7 @@ var StaticBody = new Class({
         this.physicsType = CONST.STATIC_BODY;
 
         /**
-         * The calculated change in the Body's horizontal position during the current step.
+         * The calculated change in the Static Body's horizontal position during the current step.
          * For a static body this is always zero.
          *
          * @name Phaser.Physics.Arcade.StaticBody#_dx
@@ -401,7 +402,7 @@ var StaticBody = new Class({
         this._dx = 0;
 
         /**
-         * The calculated change in the Body's vertical position during the current step.
+         * The calculated change in the Static Body's vertical position during the current step.
          * For a static body this is always zero.
          *
          * @name Phaser.Physics.Arcade.StaticBody#_dy
@@ -450,7 +451,7 @@ var StaticBody = new Class({
     },
 
     /**
-     * Syncs the Body's position and size with its parent Game Object.
+     * Syncs the Static Body's position and size with its parent Game Object.
      *
      * @method Phaser.Physics.Arcade.StaticBody#updateFromGameObject
      * @since 3.1.0
@@ -479,13 +480,13 @@ var StaticBody = new Class({
     },
 
     /**
-     * Sets the offset of the body.
+     * Positions the Static Body at an offset from its Game Object.
      *
      * @method Phaser.Physics.Arcade.StaticBody#setOffset
      * @since 3.4.0
      *
-     * @param {number} x - The horizontal offset of the Body from the Game Object's center.
-     * @param {number} y - The vertical offset of the Body from the Game Object's center.
+     * @param {number} x - The horizontal offset of the Static Body from the Game Object's `x`.
+     * @param {number} y - The vertical offset of the Static Body from the Game Object's `y`.
      *
      * @return {Phaser.Physics.Arcade.StaticBody} This Static Body object.
      */
@@ -511,15 +512,16 @@ var StaticBody = new Class({
     },
 
     /**
-     * Sets the size of the body.
+     * Sets the size of the Static Body.
+     * When `center` is true, also repositions it.
      * Resets the width and height to match current frame, if no width and height provided and a frame is found.
      *
      * @method Phaser.Physics.Arcade.StaticBody#setSize
      * @since 3.0.0
      *
-     * @param {integer} [width] - The width of the Body in pixels. Cannot be zero. If not given, and the parent Game Object has a frame, it will use the frame width.
-     * @param {integer} [height] - The height of the Body in pixels. Cannot be zero. If not given, and the parent Game Object has a frame, it will use the frame height.
-     * @param {boolean} [center=true] - Modify the Body's `offset`, placing the Body's center on its Game Object's center. Only works if the Game Object has the `getCenter` method.
+     * @param {integer} [width] - The width of the Static Body in pixels. Cannot be zero. If not given, and the parent Game Object has a frame, it will use the frame width.
+     * @param {integer} [height] - The height of the Static Body in pixels. Cannot be zero. If not given, and the parent Game Object has a frame, it will use the frame height.
+     * @param {boolean} [center=true] - Place the Static Body's center on its Game Object's center. Only works if the Game Object has the `getCenter` method.
      *
      * @return {Phaser.Physics.Arcade.StaticBody} This Static Body object.
      */
@@ -572,7 +574,7 @@ var StaticBody = new Class({
     },
 
     /**
-     * Sets this Static Body to have a circular body and sets its sizes and position.
+     * Sets this Static Body to have a circular body and sets its size and position.
      *
      * @method Phaser.Physics.Arcade.StaticBody#setCircle
      * @since 3.0.0


### PR DESCRIPTION
This PR

- Updates the Documentation
- Fixes a bug

### Bug Fixes

- If you created a `Body` from a scaled game object, [the body's width and height were incorrect](https://codepen.io/samme/pen/NWPQNvp), even after `preUpdate()`.
- `StaticBody`'s `center` was incorrect after construction. Probably caused problems with circle collisions (#4770).
- `StaticBody` was constructed with its game object's `width` and `height` instead of `displayWidth` and `displayHeight`.

### Changes

- `Body`'s `center` and `position` are now correct after construction and before `preUpdate()`, for any game object origin or scale.

### Docs

- `StaticBody`
