### PR TITLE
Proposed fix for the issue#4983

### DIFF
--- a/src/tilemaps/mapdata/LayerData.js
+++ b/src/tilemaps/mapdata/LayerData.js
@@ -149,10 +149,10 @@ var LayerData = new Class({
          * Layer specific properties (can be specified in Tiled)
          *
          * @name Phaser.Tilemaps.LayerData#properties
-         * @type {object}
+         * @type {object[]}
          * @since 3.0.0
          */
-        this.properties = GetFastValue(config, 'properties', {});
+        this.properties = GetFastValue(config, 'properties', []);
 
         /**
          * [description]

--- a/src/tilemaps/parsers/tiled/ParseTileLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseTileLayers.js
@@ -127,7 +127,7 @@ var ParseTileLayers = function (json, insertNull)
                 tileHeight: json.tileheight,
                 alpha: (curGroupState.opacity * curl.opacity),
                 visible: (curGroupState.visible && curl.visible),
-                properties: GetFastValue(curl, 'properties', {})
+                properties: GetFastValue(curl, 'properties', [])
             });
 
             for (var c = 0; c < curl.height; c++)
@@ -200,7 +200,7 @@ var ParseTileLayers = function (json, insertNull)
                 tileHeight: json.tileheight,
                 alpha: (curGroupState.opacity * curl.opacity),
                 visible: (curGroupState.visible && curl.visible),
-                properties: GetFastValue(curl, 'properties', {})
+                properties: GetFastValue(curl, 'properties', [])
             });
 
             var row = [];


### PR DESCRIPTION
Proposed fix for the issue with inconsistent type of 'properties' member of Tile Layer data.

This PR

* Fixes a bug

Describe the changes below:

See full description in the issue: https://github.com/photonstorm/phaser/issues/4983

Additional information: I did not include recompiled dist files and type definitions, so you will have to generate it yourself. The reason why I did not do it is that when I do it creates files with much more differences than I would expect (my best assumption is that master at the time of merge did not have latest changes compiled into dist either, thus when I do it I include also changes from other people, potentially unwanted.

Also, please note that this fix is only for Tile Layer Data - this issue I faced, fixed and checked - seems to be working. BUT there _might_ be similar issue with src/tilemaps/parsers/tiled/ParseImageLayers.js 'properties' - unfortunately I did not have a chance to confirm and fix it.

Fair warning - this is my first commit to the open source and while I did my best looking into it and testing the result, I can't guarantee that I tested every scenario.

Hope that helps.
