### PR TITLE
New property Arcade.World.fixedStep

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -155,6 +155,16 @@ var World = new Class({
         this.fps = GetValue(config, 'fps', 60);
 
         /**
+         * Physics/Render synchronisation. This property disables fps and timeScale properties. 
+         *
+         * @name Phaser.Physics.Arcade.World#syncToRender
+         * @type {boolean}
+         * @default false
+         * @since 3.23.0
+         */
+        this.syncToRender = false;
+
+        /**
          * The amount of elapsed ms since the last frame.
          *
          * @name Phaser.Physics.Arcade.World#_elapsed
@@ -926,6 +936,13 @@ var World = new Class({
 
         //  Will a step happen this frame?
         var willStep = (this._elapsed >= msPerFrame);
+
+        if(this.syncToRender)
+        {
+            fixedDelta = delta * 0.001;
+            willStep = true;
+            this._elapsed = 0;
+        }
 
         for (i = 0; i < bodies.length; i++)
         {

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -155,14 +155,15 @@ var World = new Class({
         this.fps = GetValue(config, 'fps', 60);
 
         /**
-         * Physics/Render synchronisation. This property disables fps and timeScale properties. 
+         * Should Physics use a fixed update time-step (true) or sync to the render fps (false)?. 
+         * False value of this property disables fps and timeScale properties. 
          *
-         * @name Phaser.Physics.Arcade.World#syncToRender
+         * @name Phaser.Physics.Arcade.World#fixedStep
          * @type {boolean}
-         * @default false
+         * @default true
          * @since 3.23.0
          */
-        this.syncToRender = false;
+        this.fixedStep = true;
 
         /**
          * The amount of elapsed ms since the last frame.
@@ -937,7 +938,7 @@ var World = new Class({
         //  Will a step happen this frame?
         var willStep = (this._elapsed >= msPerFrame);
 
-        if(this.syncToRender)
+        if(!this.fixedStep)
         {
             fixedDelta = delta * 0.001;
             willStep = true;


### PR DESCRIPTION
This PR:

* Adds a new feature

Description:
The new **Phaser.Physics.Arcade.World.fixedStep** property synchronizes the physics fps to the rendering fps when its value is false.
In some cases annoying "glitches" occur in the movement of objects. These glitches are especially noticeable on objects that move at constant speed and the fps are not consistent. This property eliminates that kind of glitches.
This synchronization disables the **fps** and **timeScale** properties of the Arcade.World class.
Demo: https://codepen.io/jjcapellan/full/KKpKxpG

How to use:
```javascript
scene.physics.world.fixedStep = false; // activates sync
scene.physics.world.fixedStep = true; // deactivates sync (default)
```
Regards.