### PR TITLE
Remove Sound Manager's game event listeners when destroyed

### DIFF
--- a/src/sound/BaseSoundManager.js
+++ b/src/sound/BaseSoundManager.js
@@ -147,21 +147,8 @@ var BaseSoundManager = new Class({
          */
         this.unlocked = false;
 
-        game.events.on(GameEvents.BLUR, function ()
-        {
-            if (this.pauseOnBlur)
-            {
-                this.onBlur();
-            }
-        }, this);
-
-        game.events.on(GameEvents.FOCUS, function ()
-        {
-            if (this.pauseOnBlur)
-            {
-                this.onFocus();
-            }
-        }, this);
+        game.events.on(GameEvents.BLUR, this.onGameBlur, this);
+        game.events.on(GameEvents.FOCUS, this.onGameFocus, this);
 
         game.events.on(GameEvents.PRE_STEP, this.update, this);
         game.events.once(GameEvents.DESTROY, this.destroy, this);
@@ -434,6 +421,36 @@ var BaseSoundManager = new Class({
     onFocus: NOOP,
 
     /**
+     * Internal handler for Phaser.Core.Events#BLUR.
+     *
+     * @method Phaser.Sound.BaseSoundManager#onGameBlur
+     * @private
+     * @since 3.23.0
+     */
+    onGameBlur: function ()
+    {
+        if (this.pauseOnBlur)
+        {
+            this.onBlur();
+        }
+    },
+
+    /**
+     * Internal handler for Phaser.Core.Events#FOCUS.
+     *
+     * @method Phaser.Sound.BaseSoundManager#onGameFocus
+     * @private
+     * @since 3.23.0
+     */
+    onGameFocus: function ()
+    {
+        if (this.pauseOnBlur)
+        {
+            this.onFocus();
+        }
+    },
+
+    /**
      * Update method called on every game step.
      * Removes destroyed sounds and updates every active sound in the game.
      *
@@ -478,6 +495,10 @@ var BaseSoundManager = new Class({
     destroy: function ()
     {
         this.removeAllListeners();
+
+        this.game.events.off(GameEvents.BLUR, this.onGameBlur, this);
+        this.game.events.off(GameEvents.FOCUS, this.onGameFocus, this);
+        this.game.events.off(GameEvents.PRE_STEP, this.update, this);
 
         this.forEachActiveSound(function (sound)
         {


### PR DESCRIPTION
This PR

* Fixes a bug

Sound Managers were still listening to Game BLUR, FOCUS, and PRE_STEP events after being destroyed. Wouldn't really cause problems unless you destroy a Sound Manager separately from destroying the game.

I extracted into two new, protected methods:

- Phaser.Sound.BaseSoundManager#onGameBlur
- Phaser.Sound.BaseSoundManager#onGameFocus

