### PR TITLE
Fix undefined state during processing of AudioFile and VideoFile

### DIFF
--- a/src/loader/filetypes/AudioFile.js
+++ b/src/loader/filetypes/AudioFile.js
@@ -5,7 +5,7 @@
  */
 
 var Class = require('../../utils/Class');
-var CONST = require('../../const');
+var CONST = require('../const');
 var File = require('../File');
 var FileTypesManager = require('../FileTypesManager');
 var GetFastValue = require('../../utils/object/GetFastValue');

--- a/src/loader/filetypes/VideoFile.js
+++ b/src/loader/filetypes/VideoFile.js
@@ -5,7 +5,7 @@
  */
 
 var Class = require('../../utils/Class');
-var CONST = require('../../const');
+var CONST = require('../const');
 var File = require('../File');
 var FileTypesManager = require('../FileTypesManager');
 var GetURL = require('../GetURL');


### PR DESCRIPTION
This PR

* Fixes a bug

AudioFile and VideoFile had `state` undefined instead of FILE_PROCESSING.

