### PR TITLE
Fix wrong Container.getBounds with child container

### DIFF
--- a/src/gameobjects/container/Container.js
+++ b/src/gameobjects/container/Container.js
@@ -384,12 +384,20 @@ var Container = new Class({
 
         output.setTo(this.x, this.y, 0, 0);
 
+        if (this.parentContainer) {
+            var parentMatrix = this.parentContainer.getBoundsTransformMatrix();
+            var transformedPosition = parentMatrix.transformPoint(this.x, this.y);
+            output.setTo(transformedPosition.x, transformedPosition.y, 0, 0);
+        }
+
         if (this.list.length > 0)
         {
             var children = this.list;
             var tempRect = new Rectangle();
 
-            for (var i = 0; i < children.length; i++)
+            var firstChildBounds = children[0].getBounds();
+            output.setTo(firstChildBounds.x, firstChildBounds.y, firstChildBounds.width, firstChildBounds.height);
+            for (var i = 1; i < children.length; i++)
             {
                 var entry = children[i];
 

--- a/src/gameobjects/container/Container.js
+++ b/src/gameobjects/container/Container.js
@@ -476,7 +476,9 @@ var Container = new Class({
 
         if (this.parentContainer)
         {
-            return this.parentContainer.pointToContainer(source, output);
+            this.parentContainer.pointToContainer(source, output);
+        } else {
+            output = new Vector2(source.x, source.y);
         }
 
         var tempMatrix = this.tempTransformMatrix;

--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -2468,6 +2468,9 @@ var InputPlugin = new Class({
                 debug.setScrollFactor(gameObject.scrollFactorX, gameObject.scrollFactorY);
             };
 
+            if(gameObject.parentContainer)
+                gameObject.parentContainer.add(debug);
+
             updateList.add(debug);
 
             input.hitAreaDebug = debug;


### PR DESCRIPTION
This PR

* Fixes a bug

- Get transformed position for child container relative to its parent (lines 387-392)
- Don't include parent origin as part of the bounds (lines 398-400)

Fixes #4580 
