### PR TITLE
added stepRate check for GetPoints methods

### DIFF
--- a/src/geom/circle/GetPoints.js
+++ b/src/geom/circle/GetPoints.js
@@ -28,7 +28,7 @@ var GetPoints = function (circle, quantity, stepRate, out)
     if (out === undefined) { out = []; }
 
     //  If quantity is a falsey value (false, null, 0, undefined, etc) then we calculate it based on the stepRate instead.
-    if (!quantity)
+    if (!quantity && stepRate > 0)
     {
         quantity = Circumference(circle) / stepRate;
     }

--- a/src/geom/ellipse/GetPoints.js
+++ b/src/geom/ellipse/GetPoints.js
@@ -30,7 +30,7 @@ var GetPoints = function (ellipse, quantity, stepRate, out)
     if (out === undefined) { out = []; }
 
     //  If quantity is a falsey value (false, null, 0, undefined, etc) then we calculate it based on the stepRate instead.
-    if (!quantity)
+    if (!quantity && stepRate > 0)
     {
         quantity = Circumference(ellipse) / stepRate;
     }

--- a/src/geom/line/GetPoints.js
+++ b/src/geom/line/GetPoints.js
@@ -32,7 +32,7 @@ var GetPoints = function (line, quantity, stepRate, out)
     if (out === undefined) { out = []; }
 
     //  If quantity is a falsey value (false, null, 0, undefined, etc) then we calculate it based on the stepRate instead.
-    if (!quantity)
+    if (!quantity && stepRate > 0)
     {
         quantity = Length(line) / stepRate;
     }

--- a/src/geom/polygon/GetPoints.js
+++ b/src/geom/polygon/GetPoints.js
@@ -30,7 +30,7 @@ var GetPoints = function (polygon, quantity, stepRate, out)
     var perimeter = Perimeter(polygon);
 
     //  If quantity is a falsey value (false, null, 0, undefined, etc) then we calculate it based on the stepRate instead.
-    if (!quantity)
+    if (!quantity && stepRate > 0)
     {
         quantity = perimeter / stepRate;
     }

--- a/src/geom/rectangle/GetPoints.js
+++ b/src/geom/rectangle/GetPoints.js
@@ -30,7 +30,7 @@ var GetPoints = function (rectangle, quantity, stepRate, out)
     if (out === undefined) { out = []; }
 
     //  If quantity is a falsey value (false, null, 0, undefined, etc) then we calculate it based on the stepRate instead.
-    if (!quantity)
+    if (!quantity && stepRate > 0)
     {
         quantity = Perimeter(rectangle) / stepRate;
     }

--- a/src/geom/triangle/GetPoints.js
+++ b/src/geom/triangle/GetPoints.js
@@ -37,7 +37,7 @@ var GetPoints = function (triangle, quantity, stepRate, out)
     var perimeter = length1 + length2 + length3;
 
     //  If quantity is a falsey value (false, null, 0, undefined, etc) then we calculate it based on the stepRate instead.
-    if (!quantity)
+    if (!quantity && stepRate > 0)
     {
         quantity = perimeter / stepRate;
     }


### PR DESCRIPTION
This PR
* Fixes a bug

Describe the changes below:
If an emitter is initialized with an emitZone with a quantity and stepRate of 0, GetPoints() inside of the shape class divides quantity by 0 and it becomes infinity. This change will avoid the division in this case and leave quantity as 0.

You shouldn't pass quantity and stepRate as 0 at the same time in the first place, but no particles showing up is preferable to crashing in an infinite loop.