### PR TITLE
Add Phaser.Types.Loader.FileTypes.PackFileSection

### DIFF
--- a/src/loader/filetypes/typedefs/PackFileSection.js
+++ b/src/loader/filetypes/typedefs/PackFileSection.js
@@ -1,0 +1,29 @@
+/**
+ * @typedef {object} Phaser.Types.Loader.FileTypes.PackFileSection
+ *
+ * @property {Phaser.Types.Loader.FileConfig[]} files - The files to load. See {@link Phaser.Types.Loader.FileTypes}.
+ * @property {string} [baseURL] - A URL used to resolve paths in `files`. Example: 'http://labs.phaser.io/assets/'.
+ * @property {string} [defaultType] - The default {@link Phaser.Types.Loader.FileConfig} `type`.
+ * @property {string} [path] - A URL path used to resolve relative paths in `files`. Example: 'images/sprites/'.
+ * @property {prefix} [prefix] - An optional prefix that is automatically prepended to each file key.
+ *
+ * @example
+ * var packFileSection = {
+ *      "prefix": "TEST2.",
+ *      "path": "assets/pics",
+ *      "defaultType": "image",
+ *      "files": [
+ *          {
+ *              "key": "donuts",
+ *              "extension": "jpg"
+ *          },
+ *          {
+ *              "key": "ayu"
+ *          }
+ *      ]
+ *  }
+ * // Result:
+ * // --------------------------------------------
+ * // assets/pics/ayu.png    -> image TEST2.ayu
+ * // assets/pics/donuts.jpg -> image TEST2.donuts
+ */

--- a/src/scene/typedefs/SettingsConfig.js
+++ b/src/scene/typedefs/SettingsConfig.js
@@ -5,7 +5,7 @@
  * @property {string} [key] - The unique key of this Scene. Must be unique within the entire Game instance.
  * @property {boolean} [active=false] - Does the Scene start as active or not? An active Scene updates each step.
  * @property {boolean} [visible=true] - Does the Scene start as visible or not? A visible Scene renders each step.
- * @property {(false|Phaser.Types.Loader.FileTypes.PackFileSection)} [pack=false] - An optional Loader Packfile to be loaded before the Scene begins.
+ * @property {(false|Phaser.Types.Loader.FileTypes.PackFileSection)} [pack=false] - Files to be loaded before the Scene begins.
  * @property {?(Phaser.Types.Cameras.Scene2D.JSONCamera|Phaser.Types.Cameras.Scene2D.JSONCamera[])} [cameras=null] - An optional Camera configuration object.
  * @property {Object.<string, string>} [map] - Overwrites the default injection map for a scene.
  * @property {Object.<string, string>} [mapAdd] - Extends the injection map for a scene.

--- a/src/scene/typedefs/SettingsConfig.js
+++ b/src/scene/typedefs/SettingsConfig.js
@@ -5,7 +5,7 @@
  * @property {string} [key] - The unique key of this Scene. Must be unique within the entire Game instance.
  * @property {boolean} [active=false] - Does the Scene start as active or not? An active Scene updates each step.
  * @property {boolean} [visible=true] - Does the Scene start as visible or not? A visible Scene renders each step.
- * @property {(false|Phaser.Types.Loader.FileTypes.PackFileConfig)} [pack=false] - An optional Loader Packfile to be loaded before the Scene begins.
+ * @property {(false|Phaser.Types.Loader.FileTypes.PackFileSection)} [pack=false] - An optional Loader Packfile to be loaded before the Scene begins.
  * @property {?(Phaser.Types.Cameras.Scene2D.JSONCamera|Phaser.Types.Cameras.Scene2D.JSONCamera[])} [cameras=null] - An optional Camera configuration object.
  * @property {Object.<string, string>} [map] - Overwrites the default injection map for a scene.
  * @property {Object.<string, string>} [mapAdd] - Extends the injection map for a scene.

--- a/src/scene/typedefs/SettingsObject.js
+++ b/src/scene/typedefs/SettingsObject.js
@@ -12,7 +12,7 @@
  * @property {integer} transitionDuration - The duration of the transition, if set.
  * @property {boolean} transitionAllowInput - Is this Scene allowed to receive input during transitions?
  * @property {object} data - a data bundle passed to this Scene from the Scene Manager.
- * @property {(false|Phaser.Types.Loader.FileTypes.PackFileConfig)} pack - The Loader Packfile to be loaded before the Scene begins.
+ * @property {(false|Phaser.Types.Loader.FileTypes.PackFileSection)} pack - The Loader Packfile to be loaded before the Scene begins.
  * @property {?(Phaser.Types.Cameras.Scene2D.JSONCamera|Phaser.Types.Cameras.Scene2D.JSONCamera[])} cameras - The Camera configuration object.
  * @property {Object.<string, string>} map - The Scene's Injection Map.
  * @property {Phaser.Types.Core.PhysicsConfig} physics - The physics configuration object for the Scene.

--- a/src/scene/typedefs/SettingsObject.js
+++ b/src/scene/typedefs/SettingsObject.js
@@ -12,7 +12,7 @@
  * @property {integer} transitionDuration - The duration of the transition, if set.
  * @property {boolean} transitionAllowInput - Is this Scene allowed to receive input during transitions?
  * @property {object} data - a data bundle passed to this Scene from the Scene Manager.
- * @property {(false|Phaser.Types.Loader.FileTypes.PackFileSection)} pack - The Loader Packfile to be loaded before the Scene begins.
+ * @property {(false|Phaser.Types.Loader.FileTypes.PackFileSection)} pack - Files to be loaded before the Scene begins.
  * @property {?(Phaser.Types.Cameras.Scene2D.JSONCamera|Phaser.Types.Cameras.Scene2D.JSONCamera[])} cameras - The Camera configuration object.
  * @property {Object.<string, string>} map - The Scene's Injection Map.
  * @property {Phaser.Types.Core.PhysicsConfig} physics - The physics configuration object for the Scene.


### PR DESCRIPTION
This PR

* Updates the Documentation

Corrects types for [Phaser.Types.Scenes.SettingsConfig](https://photonstorm.github.io/phaser3-docs/Phaser.Types.Scenes.html#.SettingsConfig).pack and [Phaser.Types.Scenes.SettingsObject](https://photonstorm.github.io/phaser3-docs/Phaser.Types.Scenes.html#.SettingsObject).pack

Fixes #5046

