### PR TITLE
Add Tiled point object and change offset in createFromObjects()

### DIFF
--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -671,9 +671,10 @@ var Tilemap = new Class({
                 if (obj.height) { sprite.displayHeight = obj.height; }
 
                 // Origin is (0, 1) in Tiled, so find the offset that matches the Sprite's origin.
+                // Do not offset objects with zero dimensions (e.g. points).
                 var offset = {
-                    x: sprite.originX * sprite.displayWidth,
-                    y: (sprite.originY - 1) * sprite.displayHeight
+                    x: sprite.originX * obj.width,
+                    y: (sprite.originY - 1) * obj.height
                 };
 
                 // If the object is rotated, then the origin offset also needs to be rotated.

--- a/src/tilemaps/parsers/tiled/ParseObject.js
+++ b/src/tilemaps/parsers/tiled/ParseObject.js
@@ -58,6 +58,10 @@ var ParseObject = function (tiledObject, offsetX, offsetY)
     {
         parsedObject.text = tiledObject.text;
     }
+    else if (tiledObject.point)
+    {
+        parsedObject.point = true;
+    }
     else
     {
         // Otherwise, assume it is a rectangle

--- a/src/tilemaps/parsers/tiled/ParseObject.js
+++ b/src/tilemaps/parsers/tiled/ParseObject.js
@@ -53,21 +53,15 @@ var ParseObject = function (tiledObject, offsetX, offsetY)
     else if (tiledObject.ellipse)
     {
         parsedObject.ellipse = tiledObject.ellipse;
-        parsedObject.width = tiledObject.width;
-        parsedObject.height = tiledObject.height;
     }
     else if (tiledObject.text)
     {
-        parsedObject.width = tiledObject.width;
-        parsedObject.height = tiledObject.height;
         parsedObject.text = tiledObject.text;
     }
     else
     {
         // Otherwise, assume it is a rectangle
         parsedObject.rectangle = true;
-        parsedObject.width = tiledObject.width;
-        parsedObject.height = tiledObject.height;
     }
 
     return parsedObject;

--- a/src/tilemaps/typedefs/TiledObject.js
+++ b/src/tilemaps/typedefs/TiledObject.js
@@ -21,4 +21,5 @@
  * @property {any} [text] - Only set if a text object. Contains the text objects properties.
  * @property {boolean} [rectangle] - Only set, and set to `true`, if a rectangle object.
  * @property {boolean} [ellipse] - Only set, and set to `true`, if a ellipse object.
+ * @property {boolean} [point] - Only set, and set to `true`, if a ellipse object.
  */

--- a/src/tilemaps/typedefs/TiledObject.js
+++ b/src/tilemaps/typedefs/TiledObject.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {object} Phaser.Types.Tilemaps.TiledObject
  * @since 3.0.0
- * 
+ *
  * @property {integer} id - The unique object ID.
  * @property {string} name - The name this object was assigned in Tiled.
  * @property {string} type - The type, as assigned in Tiled.
@@ -21,5 +21,5 @@
  * @property {any} [text] - Only set if a text object. Contains the text objects properties.
  * @property {boolean} [rectangle] - Only set, and set to `true`, if a rectangle object.
  * @property {boolean} [ellipse] - Only set, and set to `true`, if a ellipse object.
- * @property {boolean} [point] - Only set, and set to `true`, if a ellipse object.
+ * @property {boolean} [point] - Only set, and set to `true`, if a point object.
  */


### PR DESCRIPTION
This PR

* Adds a new feature
* Fixes a bug?

### Current Behavior

[Tiled point objects](https://doc.mapeditor.org/en/latest/reference/json-map-format/#point-example) are parsed to

    { rectangle: true, width: 0, height: 0, … }

When creating a sprite from a Tiled object with `{ width: 0, height: 0 }, [createFromObjects()](https://photonstorm.github.io/phaser3-docs/Phaser.Tilemaps.Tilemap.html#createFromObjects) maps the Tiled object origin onto the sprite origin using the sprite's dimensions (which are not zero). This is [probably not what authors want](https://phaser.discourse.group/t/objects-in-group-created-via-createfromobjects-in-class-spawning-at-incorrect-coordinates/4868). 

### New Behavior

Tiled point objects are parsed to

    { point: true, width: 0, height: 0, … }

When creating a sprite from a zero-size object, createFromObjects() doesn't adjust the position at all. The new sprite is given coordinates identical to the object.

I think this is more sensible, but it is a "breaking" change for projects using createFromObjects() with zero-dimensioned Tiled objects.

### Internal Changes

I [removed some redundant assignments](https://github.com/photonstorm/phaser/pull/5051/commits/df1537fa366ea039c23306799ed44c294eea2709) in Tiled.ParseObject().