### PR TITLE
Clamp audio tag volume in HTML5AudioSound

### DIFF
--- a/src/sound/html5/HTML5AudioSound.js
+++ b/src/sound/html5/HTML5AudioSound.js
@@ -8,6 +8,7 @@
 var BaseSound = require('../BaseSound');
 var Class = require('../../utils/Class');
 var Events = require('../events');
+var Clamp = require('../../math/Clamp');
 
 /**
  * @classdesc
@@ -552,7 +553,7 @@ var HTML5AudioSound = new Class({
     {
         if (this.audio)
         {
-            this.audio.volume = this.currentConfig.volume * this.manager.volume;
+            this.audio.volume = Clamp(this.currentConfig.volume * this.manager.volume, 0, 1);
         }
     },
 


### PR DESCRIPTION
This PR

* Fixes a bug

When using HTML5 Audio, setting game volume or sound volume outside [0, 1] would throw an error:

> IndexSizeError: The index is not in the allowed range

