### PR TITLE
adding index to spine atlases when loading through asset pack

### DIFF
--- a/plugins/spine/src/SpineFile.js
+++ b/plugins/spine/src/SpineFile.js
@@ -86,7 +86,7 @@ var SpineFile = new Class({
             for (i = 0; i < atlasURL.length; i++)
             {
                 atlas = new TextFile(loader, {
-                    key: key,
+                    key: key + '_' + i,
                     url: atlasURL[i],
                     extension: GetFastValue(config, 'atlasExtension', 'atlas'),
                     xhrSettings: GetFastValue(config, 'atlasXhrSettings')


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

Appended the atlas index when loading spine atlases from asset packs, to match how they are loaded when manually calling load.spine.

Without this, the atlas is not loaded when a new SpineGameObject is initialized.
