### PR TITLE
fix #5059

### DIFF
--- a/src/loader/filetypes/AnimationJSONFile.js
+++ b/src/loader/filetypes/AnimationJSONFile.js
@@ -70,8 +70,6 @@ var AnimationJSONFile = new Class({
     onLoadComplete: function ()
     {
         this.loader.systems.anims.fromJSON(this.data);
-
-        this.pendingDestroy();
     }
 
 });


### PR DESCRIPTION

* Fixes a bug

Description:
When an animation is loaded from JSON file, the method <code>Phaser.Loader.File#pendingDestroy</code> is called two times:
1º) From <code>Phaser.Loader.File#addToCache</code>
2º) From <code>Phaser.Loader.FileTypes.AnimationJSONFile#onLoadComplete</code>

I think the second is not necessary, so this pull request erase that call.

This fix issue #5059 

