### PR TITLE
Fix for issue #5069, where using lockOrientation breaks in firefox

### DIFF
--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -697,7 +697,7 @@ var ScaleManager = new Class({
 
         if (lock)
         {
-            return lock(orientation);
+            return lock.call(screen, orientation);
         }
 
         return false;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug #5069 

Describe the changes below:

Using **game.scale.lockOrientation('portrait');** in firefox gave the error **'TypeError: 'mozLockOrientation' called on an object that does not implement interface Screen.'**.

It was being caused as the method **screen.lockOrientation** was being stored in a variable and used. I wrote a patch that uses **screen.lockOrientation** directly if in firefox.