### PR TITLE
Add Phaser.Geom.Rectangle.FromXY()

### DIFF
--- a/src/geom/rectangle/FromXY.js
+++ b/src/geom/rectangle/FromXY.js
@@ -1,0 +1,37 @@
+/**
+ * @author       samme
+ * @copyright    2020 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+var Rectangle = require('./Rectangle');
+
+/**
+ * Create the smallest Rectangle containing two coordinate pairs.
+ *
+ * @function Phaser.Geom.Rectangle.FromXY
+ * @since 3.23.0
+ *
+ * @generic {Phaser.Geom.Rectangle} O - [out,$return]
+ *
+ * @param {number} x1 - The X coordinate of the first point.
+ * @param {number} y1 - The Y coordinate of the first point.
+ * @param {number} x2 - The X coordinate of the second point.
+ * @param {number} y2 - The Y coordinate of the second point.
+ * @param {Phaser.Geom.Rectangle} [out] - Optional Rectangle to adjust.
+ *
+ * @return {Phaser.Geom.Rectangle} The adjusted `out` Rectangle, or a new Rectangle if none was provided.
+ */
+var FromXY = function (x1, y1, x2, y2, out)
+{
+    if (out === undefined) { out = new Rectangle(); }
+
+    return out.setTo(
+        Math.min(x1, x2),
+        Math.min(y1, y2),
+        Math.abs(x1 - x2),
+        Math.abs(y1 - y2)
+    );
+};
+
+module.exports = FromXY;

--- a/src/geom/rectangle/index.js
+++ b/src/geom/rectangle/index.js
@@ -22,6 +22,7 @@ Rectangle.FitOutside = require('./FitOutside');
 Rectangle.Floor = require('./Floor');
 Rectangle.FloorAll = require('./FloorAll');
 Rectangle.FromPoints = require('./FromPoints');
+Rectangle.FromXY = require('./FromXY');
 Rectangle.GetAspectRatio = require('./GetAspectRatio');
 Rectangle.GetCenter = require('./GetCenter');
 Rectangle.GetPoint = require('./GetPoint');


### PR DESCRIPTION
This PR

* Adds a new feature

> Create the smallest Rectangle containing two coordinate pairs.

This is useful for creating dynamic Rectangles (e.g., marquees) as it ensures positive dimensions.

[FromPoints()](https://photonstorm.github.io/phaser3-docs/Phaser.Geom.Rectangle.html#.FromPoints) can accomplish the same, but this new method is a little simpler.
