### PR TITLE
using canvas pixel height value in  LightsManager.js culling

### DIFF
--- a/src/gameobjects/lights/LightsManager.js
+++ b/src/gameobjects/lights/LightsManager.js
@@ -153,7 +153,7 @@ var LightsManager = new Class({
         var cameraRadius = (camera.width + camera.height) / 2.0;
         var point = { x: 0, y: 0 };
         var cameraMatrix = camera.matrix;
-        var viewportHeight = this.systems.game.config.height;
+        var viewportHeight = this.systems.game.canvas.height;
 
         culledLights.length = 0;
 


### PR DESCRIPTION
fixes silent lights2d pipeline failure when providing height as a percentage in the game config

Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)


* Fixes a bug

Describe the changes below:

