### PR TITLE
Fix camera's fadeIn/fadeOut effects

### DIFF
--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -1923,6 +1923,8 @@ var WebGLRenderer = new Class({
      */
     postRenderCamera: function (camera)
     {
+        this.setPipeline(this.pipelines.TextureTintPipeline);
+        
         var TextureTintPipeline = this.pipelines.TextureTintPipeline;
 
         camera.flashEffect.postRenderWebGL(TextureTintPipeline, Utils.getTintFromFloats);


### PR DESCRIPTION
This PR

* Fixes a bug

If any object is using the Light2D pipeline (or any other I think), it will not be affected by camera effects.
Set the `TextureTintPipeline` pipeline before rendering camera effects.