### PR TITLE
added down key to types for SmoothedKeyControlConfig

### DIFF
--- a/src/cameras/controls/typedefs/SmoothedKeyControlConfig.js
+++ b/src/cameras/controls/typedefs/SmoothedKeyControlConfig.js
@@ -6,6 +6,7 @@
  * @property {Phaser.Input.Keyboard.Key} [left] - The Key to be pressed that will move the Camera left.
  * @property {Phaser.Input.Keyboard.Key} [right] - The Key to be pressed that will move the Camera right.
  * @property {Phaser.Input.Keyboard.Key} [up] - The Key to be pressed that will move the Camera up.
+ * @property {Phaser.Input.Keyboard.Key} [down] - The Key to be pressed that will move the Camera down.
  * @property {Phaser.Input.Keyboard.Key} [zoomIn] - The Key to be pressed that will zoom the Camera in.
  * @property {Phaser.Input.Keyboard.Key} [zoomOut] - The Key to be pressed that will zoom the Camera out.
  * @property {number} [zoomSpeed=0.01] - The speed at which the camera will zoom if the `zoomIn` or `zoomOut` keys are pressed.


### PR DESCRIPTION
I noticed the types for SmoothedKeyControlConfig were missing the "down" key definition.

Fixes #5102