### PR TITLE
Fix destroying NoAudioSound and add missing methods

### DIFF
--- a/src/sound/noaudio/NoAudioSound.js
+++ b/src/sound/noaudio/NoAudioSound.js
@@ -10,6 +10,21 @@ var Class = require('../../utils/Class');
 var EventEmitter = require('eventemitter3');
 var Extend = require('../../utils/object/Extend');
 
+var returnFalse = function ()
+{
+    return false;
+};
+
+var returnNull = function ()
+{
+    return null;
+};
+
+var returnThis = function ()
+{
+    return this;
+};
+
 /**
  * @classdesc
  * No audio implementation of the sound. It is used if audio has been
@@ -71,51 +86,103 @@ var NoAudioSound = new Class({
         this.pendingRemove = false;
     },
 
+    /**
+     * @method Phaser.Sound.NoAudioSound#addMarker
+     * @since 3.0.0
+     *
+     * @param {Phaser.Types.Sound.SoundMarker} marker - Marker object.
+     *
+     * @return {boolean} false
+     */
     // eslint-disable-next-line no-unused-vars
-    addMarker: function (marker)
-    {
-        return false;
-    },
+    addMarker: returnFalse,
 
+    /**
+     * @method Phaser.Sound.NoAudioSound#updateMarker
+     * @since 3.0.0
+     *
+     * @param {Phaser.Types.Sound.SoundMarker} marker - Marker object with updated values.
+     *
+     * @return {boolean} false
+     */
     // eslint-disable-next-line no-unused-vars
-    updateMarker: function (marker)
-    {
-        return false;
-    },
+    updateMarker: returnFalse,
 
-    // eslint-disable-next-line no-unused-vars
-    removeMarker: function (markerName)
-    {
-        return null;
-    },
+    /**
+     * @method Phaser.Sound.NoAudioSound#removeMarker
+     * @since 3.0.0
+     *
+     * @param {string} markerName - The name of the marker to remove.
+     *
+     * @return {null} null
+     */
+    removeMarker: returnNull,
 
-    // eslint-disable-next-line no-unused-vars
-    play: function (markerName, config)
-    {
-        return false;
-    },
+    /**
+     * @method Phaser.Sound.NoAudioSound#play
+     * @since 3.0.0
+     *
+     * @param {(string|Phaser.Types.Sound.SoundConfig)} [markerName=''] - If you want to play a marker then provide the marker name here. Alternatively, this parameter can be a SoundConfig object.
+     * @param {Phaser.Types.Sound.SoundConfig} [config] - Optional sound config object to be applied to this marker or entire sound if no marker name is provided. It gets memorized for future plays of current section of the sound.
+     *
+     * @return {boolean} false
+     */
+    play: returnFalse,
 
-    pause: function ()
-    {
-        return false;
-    },
+    /**
+     * @method Phaser.Sound.NoAudioSound#pause
+     * @since 3.0.0
+     *
+     * @return {boolean} false
+     */
+    pause: returnFalse,
 
-    resume: function ()
-    {
-        return false;
-    },
+    /**
+     * Resumes the sound.
+     *
+     * @method Phaser.Sound.NoAudioSound#resume
+     * @since 3.0.0
+     *
+     * @return {boolean} false
+     */
+    resume: returnFalse,
 
-    stop: function ()
-    {
-        return false;
-    },
+    /**
+     * Stop playing this sound.
+     *
+     * @method Phaser.Sound.NoAudioSound#stop
+     * @since 3.0.0
+     *
+     * @return {boolean} false
+     */
+    stop: returnFalse,
 
+    /**
+     * Destroys this sound and all associated events and marks it for removal from the sound manager.
+     *
+     * @method Phaser.Sound.NoAudioSound#destroy
+     * @fires Phaser.Sound.Events#DESTROY
+     * @since 3.0.0
+     */
     destroy: function ()
     {
         this.manager.remove(this);
 
         BaseSound.prototype.destroy.call(this);
-    }
+    },
+
+    setMute: returnThis,
+
+    setVolume: returnThis,
+
+    setRate: returnThis,
+
+    setDetune: returnThis,
+
+    setSeek: returnThis,
+
+    setLoop: returnThis
+
 });
 
 module.exports = NoAudioSound;

--- a/src/sound/noaudio/NoAudioSound.js
+++ b/src/sound/noaudio/NoAudioSound.js
@@ -35,7 +35,6 @@ var returnThis = function ()
  * breaking on devices that don't support any audio playback technologies.
  *
  * @class NoAudioSound
- * @extends Phaser.Sound.BaseSound
  * @memberof Phaser.Sound
  * @constructor
  * @since 3.0.0

--- a/src/sound/noaudio/NoAudioSound.js
+++ b/src/sound/noaudio/NoAudioSound.js
@@ -166,8 +166,6 @@ var NoAudioSound = new Class({
      */
     destroy: function ()
     {
-        this.manager.remove(this);
-
         BaseSound.prototype.destroy.call(this);
     },
 


### PR DESCRIPTION
This PR

* Updates the Documentation
* Fixes a bug

Calling NoAudioSound#destroy() would error (Maximum call stack size exceeded).

NoAudioSound was missing 6 setter methods of HTML5AudioSound/WebAudioSound.
