### PR TITLE
Fixes to JSON texture parsers

### DIFF
--- a/src/textures/parsers/JSONArray.js
+++ b/src/textures/parsers/JSONArray.js
@@ -66,11 +66,12 @@ var JSONArray = function (texture, sourceIndex, json)
             newFrame.updateUVsInverted();
         }
 
-        if (src.anchor)
+        var pivot = src.anchor || src.pivot;
+        if (pivot)
         {
             newFrame.customPivot = true;
-            newFrame.pivotX = src.anchor.x;
-            newFrame.pivotY = src.anchor.y;
+            newFrame.pivotX = pivot.x;
+            newFrame.pivotY = pivot.y;
         }
 
         //  Copy over any extra data

--- a/src/textures/parsers/JSONHash.js
+++ b/src/textures/parsers/JSONHash.js
@@ -36,7 +36,7 @@ var JSONHash = function (texture, sourceIndex, json)
     texture.add('__BASE', sourceIndex, 0, 0, source.width, source.height);
 
     //  By this stage frames is a fully parsed Object
-    var frames = json['frames'];
+    var frames = json.frames;
     var newFrame;
 
     for (var key in frames)
@@ -63,6 +63,14 @@ var JSONHash = function (texture, sourceIndex, json)
         {
             newFrame.rotated = true;
             newFrame.updateUVsInverted();
+        }
+
+        var pivot = src.anchor || src.pivot;
+        if (pivot)
+        {
+            newFrame.customPivot = true;
+            newFrame.pivotX = pivot.x;
+            newFrame.pivotY = pivot.y;
         }
 
         //  Copy over any extra data


### PR DESCRIPTION
This PR

* Adds a new feature
* Fixes a bug

Describe the changes below:

JSONHash doesn't load custom pivot information but JSONArray does.  Duplicating that functionality for JSONHash.
JSONArray documentation states the format should match that returned by Texture Packer, but texture packer outputs a `pivot` property when using JSONHash or JSONArray (available in the free version of Texture Packer), but uses `anchor` with the Phaser texture data object.  This updates JSONHash (and adds to JSONArray) the ability to read from `anchor` or `pivot` if that's not available.