### PR TITLE
Add browser entrypoint for tooling, bundlers, CDNs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "licenseUrl": "http://www.opensource.org/licenses/mit-license.php",
   "main": "./src/phaser.js",
   "types": "./types/phaser.d.ts",
+  "browser": "./dist/phaser.js",
   "repository": {
     "type": "git",
     "url": "https://photonstorm@github.com/photonstorm/phaser.git"


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Follow up from this conversation: https://github.com/sveltejs/svelte-repl/issues/108#issuecomment-620234154

Tooling looks at a package manifest to find a package's best entrypoint. Because you are already shipping a pre-build UMD distribution for browsers, it would be great if you could tell bundlers and other tools about it so that they can use it as needed.