### PR TITLE
Fix TimeStep#wake() when running

### DIFF
--- a/src/core/TimeStep.js
+++ b/src/core/TimeStep.js
@@ -644,7 +644,7 @@ var TimeStep = new Class({
     {
         if (this.running)
         {
-            this.sleep();
+            return;
         }
         else if (seamless)
         {


### PR DESCRIPTION
This PR

* Fixes a bug?

Currently, if you call TimeStep#wake() while the loop is running it calls TimeStep#sleep() and then continues waking, which produces an extra loop step.

I changed it so that if you call TimeStep#wake() while the loop is running, nothing happens.
