### PR TITLE
Update Container.js

### DIFF
--- a/src/gameobjects/container/Container.js
+++ b/src/gameobjects/container/Container.js
@@ -202,14 +202,14 @@ var Container = new Class({
          *
          * When a camera scrolls it will change the location at which this Container is rendered on-screen.
          * It does not change the Containers actual position values.
-         * 
+         *
          * For a Container, setting this value will only update the Container itself, not its children.
          * If you wish to change the scrollFactor of the children as well, use the `setScrollFactor` method.
          *
          * A value of 1 means it will move exactly in sync with a camera.
          * A value of 0 means it will not move at all, even if the camera moves.
          * Other values control the degree to which the camera movement is mapped to this Container.
-         * 
+         *
          * Please be aware that scroll factor values other than 1 are not taken in to consideration when
          * calculating physics collisions. Bodies always collide based on their world position, but changing
          * the scroll factor is a visual adjustment to where the textures are rendered, which can offset
@@ -229,14 +229,14 @@ var Container = new Class({
          *
          * When a camera scrolls it will change the location at which this Container is rendered on-screen.
          * It does not change the Containers actual position values.
-         * 
+         *
          * For a Container, setting this value will only update the Container itself, not its children.
          * If you wish to change the scrollFactor of the children as well, use the `setScrollFactor` method.
          *
          * A value of 1 means it will move exactly in sync with a camera.
          * A value of 0 means it will not move at all, even if the camera moves.
          * Other values control the degree to which the camera movement is mapped to this Container.
-         * 
+         *
          * Please be aware that scroll factor values other than 1 are not taken in to consideration when
          * calculating physics collisions. Bodies always collide based on their world position, but changing
          * the scroll factor is a visual adjustment to where the textures are rendered, which can offset
@@ -400,7 +400,8 @@ var Container = new Class({
             var children = this.list;
             var tempRect = new Rectangle();
 
-            var firstChildBounds = children[0].getBounds();
+            var firstChildWithBounds = children.find((child) => typeof child.getBounds === 'function');
+            var firstChildBounds = firstChildWithBounds.getBounds();
             output.setTo(firstChildBounds.x, firstChildBounds.y, firstChildBounds.width, firstChildBounds.height);
             for (var i = 1; i < children.length; i++)
             {
@@ -502,7 +503,7 @@ var Container = new Class({
 
     /**
      * Returns the world transform matrix as used for Bounds checks.
-     * 
+     *
      * The returned matrix is temporal and shouldn't be stored.
      *
      * @method Phaser.GameObjects.Container#getBoundsTransformMatrix
@@ -1152,7 +1153,7 @@ var Container = new Class({
      * A value of 1 means it will move exactly in sync with a camera.
      * A value of 0 means it will not move at all, even if the camera moves.
      * Other values control the degree to which the camera movement is mapped to this Game Object.
-     * 
+     *
      * Please be aware that scroll factor values other than 1 are not taken in to consideration when
      * calculating physics collisions. Bodies always collide based on their world position, but changing
      * the scroll factor is a visual adjustment to where the textures are rendered, which can offset


### PR DESCRIPTION
Get first children with available getBounds()

Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

Updates the Documentation
Adds a new feature
Fixes a bug
Describe the changes below:

Please excuse my ignorance, but shouldn't the getBounds() on the container be like this? I just faced this problem when my first child was actually a Graphic, which does not have a function getBounds(), so instead of getting the bounds from the first child, I'm trying to find the first one with bounds.