### PR TITLE
Correct types for GameObject#body

### DIFF
--- a/src/gameobjects/GameObject.js
+++ b/src/gameobjects/GameObject.js
@@ -169,7 +169,7 @@ var GameObject = new Class({
          * If this Game Object is enabled for Arcade or Matter Physics then this property will contain a reference to a Physics Body.
          *
          * @name Phaser.GameObjects.GameObject#body
-         * @type {?(object|Phaser.Physics.Arcade.Body|MatterJS.BodyType)}
+         * @type {?(Phaser.Physics.Arcade.Body|Phaser.Physics.Arcade.StaticBody|MatterJS.BodyType)}
          * @default null
          * @since 3.0.0
          */


### PR DESCRIPTION
This PR

* Updates the Documentation

I removed type `{object}`.
