### PR TITLE
Set file states FILE_LOADING and FILE_LOADED

### DIFF
--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -272,6 +272,8 @@ var File = new Class({
         }
         else
         {
+            this.state = CONST.FILE_LOADING;
+
             this.src = GetURL(this, this.loader.baseURL);
 
             if (this.src.indexOf('data:') === 0)
@@ -312,6 +314,8 @@ var File = new Class({
         {
             success = false;
         }
+
+        this.state = CONST.FILE_LOADED;
 
         this.resetXHR();
 


### PR DESCRIPTION
This PR

* Fixes a bug

[Phaser.Loader.File.html#state](https://photonstorm.github.io/phaser3-docs/Phaser.Loader.File.html#state) never showed states `FILE_LOADING` (while loading) or `FILE_LOADED` (after loading). That didn't cause any problems, but it seemed incorrect, so I added those states.

