### PR TITLE
Arcade Physics collisions optimizations

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1341,12 +1341,14 @@ var World = new Class({
      * @param {ArcadePhysicsCallback} [processCallback] - The process callback.
      * @param {*} [callbackContext] - The context in which to invoke the callback.
      * @param {boolean} [overlapOnly] - If this a collide or overlap check?
+     * @param {boolean} [intersects] - Assert that the bodies intersect and should not be tested before separation.
      *
      * @return {boolean} True if separation occurred, otherwise false.
      */
-    separate: function (body1, body2, processCallback, callbackContext, overlapOnly)
+    separate: function (body1, body2, processCallback, callbackContext, overlapOnly, intersects)
     {
         if (
+            !intersects &&
             !body1.enable ||
             !body2.enable ||
             body1.checkCollision.none ||
@@ -1983,7 +1985,7 @@ var World = new Class({
                     continue;
                 }
 
-                if (this.separate(bodyA, bodyB, processCallback, callbackContext, overlapOnly))
+                if (this.separate(bodyA, bodyB, processCallback, callbackContext, overlapOnly, true))
                 {
                     if (collideCallback)
                     {

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1398,8 +1398,14 @@ var World = new Class({
         var resultX = false;
         var resultY = false;
 
-        //  Do we separate on x or y first?
-        if (this.forceX || Math.abs(this.gravity.y + body1.gravity.y) < Math.abs(this.gravity.x + body1.gravity.x))
+        //  Do we separate on x first or y first or both?
+        if (overlapOnly)
+        {
+            //  No separation but we need to calculate overlapX, overlapY, etc.
+            resultX = SeparateX(body1, body2, overlapOnly, this.OVERLAP_BIAS);
+            resultY = SeparateY(body1, body2, overlapOnly, this.OVERLAP_BIAS);
+        }
+        else if (this.forceX || Math.abs(this.gravity.y + body1.gravity.y) < Math.abs(this.gravity.x + body1.gravity.x))
         {
             resultX = SeparateX(body1, body2, overlapOnly, this.OVERLAP_BIAS);
 


### PR DESCRIPTION
This PR

* Adds a new feature

1. When colliding physics groups with the search tree enabled, there was an unnecessary intersection test for each body returned by the search.

2. When doing an overlap collision, there was an unnecessary intersection test for each pair of overlapping bodies.

