### PR TITLE
Fix 'Error decoding audio' message

### DIFF
--- a/src/loader/filetypes/AudioFile.js
+++ b/src/loader/filetypes/AudioFile.js
@@ -88,7 +88,7 @@ var AudioFile = new Class({
             function (e)
             {
                 // eslint-disable-next-line no-console
-                console.error('Error decoding audio: ' + this.key + ' - ', e ? e.message : null);
+                console.error('Error decoding audio: ' + _this.key + ' - ', e ? e.message : null);
 
                 _this.onProcessError();
             }


### PR DESCRIPTION
This PR

* Fixes a bug

The message always showed asset key `undefined`.

