### PR TITLE
KeyboardPlugin checkDown function - undefined parameter bugfix

### DIFF
--- a/src/input/keyboard/KeyboardPlugin.js
+++ b/src/input/keyboard/KeyboardPlugin.js
@@ -626,7 +626,7 @@ var KeyboardPlugin = new Class({
      * 
      * @return {boolean} `true` if the Key is down within the duration specified, otherwise `false`.
      */
-    checkDown: function (key, duration)
+    checkDown: function (key, duration = 0)
     {
         if (this.enabled && key.isDown)
         {

--- a/src/input/keyboard/KeyboardPlugin.js
+++ b/src/input/keyboard/KeyboardPlugin.js
@@ -626,10 +626,15 @@ var KeyboardPlugin = new Class({
      * 
      * @return {boolean} `true` if the Key is down within the duration specified, otherwise `false`.
      */
-    checkDown: function (key, duration = 0)
+    checkDown: function (key, duration)
     {
         if (this.enabled && key.isDown)
         {
+            if (duration === undefined)
+            {
+                duration = 0;
+            }
+
             var t = SnapFloor(this.time - key.timeDown, duration);
 
             if (t > key._tick)


### PR DESCRIPTION
This PR - Fixes a bug

Fixes #5146 - KeyboardPlugin.checkDown doesn't work if optional parameter left out 

Describe the changes below:

The checkDown method in question has an optional parameter of `duration`, that is said to default to 0 but doesn't. Leads to downstream problem with it being undefined and leads to a bug where trying to use the simple method with 1 parameter didn't work.

Below test case (from #5146) will now print the message:

```ts
    if (keyboard.checkDown(keyboard.addKey('W'))) {
      console.log('W was held down for 0ms but I wont print');
    }
```