### PR TITLE
Allow chaining of multible animations

### DIFF
--- a/src/gameobjects/components/Animation.js
+++ b/src/gameobjects/components/Animation.js
@@ -88,15 +88,6 @@ var Animation = new Class({
         this.nextAnim = null;
 
         /**
-         * A queue of chained keys of the next Animations to be loaded into this Animation Controller when the current animation completes.
-         *
-         * @name Phaser.GameObjects.Components.Animation#nextAnim
-         * @type {Array}
-         * @default []
-         */
-        this.nextAnimsQueue = [];
-
-        /**
          * Time scale factor.
          *
          * @name Phaser.GameObjects.Components.Animation#_timeScale
@@ -330,11 +321,7 @@ var Animation = new Class({
             key = key.key;
         }
 
-        if(this.nextAnim === null){
-          this.nextAnim = key;
-        }else{
-          this.nextAnimsQueue.push(key);
-        }
+        this.nextAnim = key;
 
         return this.parent;
     },
@@ -863,7 +850,7 @@ var Animation = new Class({
         {
             var key = this.nextAnim;
 
-            this.nextAnim = this.nextAnimsQueue.length > 0 ? this.nextAnimsQueue.shift() : null;
+            this.nextAnim = null;
 
             this.play(key);
         }

--- a/src/gameobjects/components/Animation.js
+++ b/src/gameobjects/components/Animation.js
@@ -88,6 +88,15 @@ var Animation = new Class({
         this.nextAnim = null;
 
         /**
+         * A queue of chained keys of the next Animations to be loaded into this Animation Controller when the current animation completes.
+         *
+         * @name Phaser.GameObjects.Components.Animation#nextAnim
+         * @type {Array}
+         * @default []
+         */
+        this.nextAnimsQueue = [];
+
+        /**
          * Time scale factor.
          *
          * @name Phaser.GameObjects.Components.Animation#_timeScale
@@ -321,7 +330,11 @@ var Animation = new Class({
             key = key.key;
         }
 
-        this.nextAnim = key;
+        if(this.nextAnim === null){
+          this.nextAnim = key;
+        }else{
+          this.nextAnimsQueue.push(key);
+        }
 
         return this.parent;
     },
@@ -850,7 +863,7 @@ var Animation = new Class({
         {
             var key = this.nextAnim;
 
-            this.nextAnim = null;
+            this.nextAnim = this.nextAnimsQueue.length > 0 ? this.nextAnimsQueue.shift() : null;
 
             this.play(key);
         }

--- a/src/gameobjects/components/Animation.js
+++ b/src/gameobjects/components/Animation.js
@@ -88,6 +88,15 @@ var Animation = new Class({
         this.nextAnim = null;
 
         /**
+         * A queue of keys of the next Animations to be loaded into this Animation Controller when the current animation completes.
+         *
+         * @name Phaser.GameObjects.Components.Animation#nextAnimsQueue
+         * @type {Array}
+         * @default []
+         */
+        this.nextAnimsQueue = [];
+
+        /**
          * Time scale factor.
          *
          * @name Phaser.GameObjects.Components.Animation#_timeScale
@@ -321,7 +330,11 @@ var Animation = new Class({
             key = key.key;
         }
 
-        this.nextAnim = key;
+        if(this.nextAnim === null){
+          this.nextAnim = key;
+        } else {
+          this.nextAnimsQueue.push(key);
+        }
 
         return this.parent;
     },
@@ -850,7 +863,7 @@ var Animation = new Class({
         {
             var key = this.nextAnim;
 
-            this.nextAnim = null;
+            this.nextAnim = this.nextAnimsQueue.length > 0 ? this.nextAnimsQueue.shift() : null;
 
             this.play(key);
         }


### PR DESCRIPTION
This PR

* Adds a new feature

Describe the changes below:
With this commit it is possible to chain more than one animation together for example:
this.mole.anims.play('digging',true).anims.chain('lifting').anims.chain('looking').anims.chain('lowering');

This commit introduces a property nextAnimsQueue. It holds all additional nextAnim-Keys in the order the chain()-method was called. It is handed over to the nextAnim-Property in the stop()-method.
