### PR TITLE
Fix error stopping HTML5AudioSound after page blur

### DIFF
--- a/src/sound/html5/HTML5AudioSound.js
+++ b/src/sound/html5/HTML5AudioSound.js
@@ -382,11 +382,15 @@ var HTML5AudioSound = new Class({
      */
     stopAndReleaseAudioTag: function ()
     {
-        this.audio.pause();
-        this.audio.dataset.used = 'false';
-        this.audio = null;
         this.startTime = 0;
         this.previousTime = 0;
+
+        if (this.audio)
+        {
+            this.audio.pause();
+            this.audio.dataset.used = 'false';
+            this.audio = null;
+        }
     },
 
     /**


### PR DESCRIPTION
This PR

* Fixes a bug

If you're using HTML5 Audio with `pauseOnBlur` (the default), play a sound, schedule stopping the sound (e.g., timer, tween complete callback), leave the page, and return to the page, sound `stop()` will error.

