### PR TITLE
Add info to the scene manager method headers where optional data goes.

### DIFF
--- a/src/scene/SceneManager.js
+++ b/src/scene/SceneManager.js
@@ -314,7 +314,7 @@ var SceneManager = new Class({
      * @param {string} key - A unique key used to reference the Scene, i.e. `MainMenu` or `Level1`.
      * @param {(Phaser.Scene|Phaser.Types.Scenes.SettingsConfig|Phaser.Types.Scenes.CreateSceneFromObjectConfig|function)} sceneConfig - The config for the Scene
      * @param {boolean} [autoStart=false] - If `true` the Scene will be started immediately after being added.
-     * @param {object} [data] - Optional data object. This will be set as Scene.settings.data and passed to `Scene.init`.
+     * @param {object} [data] - Optional data object. This will be set as `Scene.settings.data` and passed to `Scene.init`, and `Scene.create`.
      *
      * @return {?Phaser.Scene} The added Scene, if it was added immediately, otherwise `null`.
      */
@@ -1139,7 +1139,7 @@ var SceneManager = new Class({
      * @since 3.0.0
      *
      * @param {string} key - The Scene to start.
-     * @param {object} [data] - Optional data object to pass to Scene.Settings and Scene.init.
+     * @param {object} [data] - Optional data object to pass to `Scene.Settings` and `Scene.init`, and `Scene.create`.
      *
      * @return {Phaser.Scenes.SceneManager} This SceneManager.
      */


### PR DESCRIPTION
* Updates the Documentation

Dived in to this code a bit to build up a table of what scene plugin methods do with the optional data param, and requested a table be added to Samme's already [great scene overview](https://gist.github.com/samme/01a33324a427f626254c1a4da7f9b6a3). 

Little change to some of the header docs in some scene manager methods to better reflect where the optional `data` params go. Specifically mentioning that `Scene.create` will also receive them.
