### PR TITLE
Fix bug about setting xRadius/yRadius by width/height

### DIFF
--- a/src/curves/EllipseCurve.js
+++ b/src/curves/EllipseCurve.js
@@ -296,7 +296,7 @@ var EllipseCurve = new Class({
      */
     setWidth: function (value)
     {
-        this.xRadius = value * 2;
+        this.xRadius = value / 2;
 
         return this;
     },
@@ -313,7 +313,7 @@ var EllipseCurve = new Class({
      */
     setHeight: function (value)
     {
-        this.yRadius = value * 2;
+        this.yRadius = value / 2;
 
         return this;
     },


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

xRadius/yRadius is half of width/height
