### PR TITLE
Fix nested mask behaviour for Phaser.CANVAS mode

### DIFF
--- a/src/gameobjects/container/ContainerCanvasRenderer.js
+++ b/src/gameobjects/container/ContainerCanvasRenderer.js
@@ -54,7 +54,12 @@ var ContainerCanvasRenderer = function (renderer, container, interpolationPercen
 
     var alpha = container._alpha;
     var scrollFactorX = container.scrollFactorX;
-    var scrollFactorY = container.scrollFactorY;
+	var scrollFactorY = container.scrollFactorY;
+	
+	if (container.mask) {
+		container.mask.preRenderCanvas(renderer, null, camera);
+	}
+
 
     for (var i = 0; i < children.length; i++)
     {
@@ -85,7 +90,11 @@ var ContainerCanvasRenderer = function (renderer, container, interpolationPercen
         //  Restore original values
         child.setAlpha(childAlpha);
         child.setScrollFactor(childScrollFactorX, childScrollFactorY);
-    }
+	}
+	
+	if (container.mask) {
+		container.mask.postRenderCanvas(renderer);
+	}	
 };
 
 module.exports = ContainerCanvasRenderer;

--- a/src/gameobjects/container/ContainerCanvasRenderer.js
+++ b/src/gameobjects/container/ContainerCanvasRenderer.js
@@ -53,13 +53,12 @@ var ContainerCanvasRenderer = function (renderer, container, interpolationPercen
     }
 
     var alpha = container._alpha;
-    var scrollFactorX = container.scrollFactorX;
+	var scrollFactorX = container.scrollFactorX;
 	var scrollFactorY = container.scrollFactorY;
 	
 	if (container.mask) {
 		container.mask.preRenderCanvas(renderer, null, camera);
 	}
-
 
     for (var i = 0; i < children.length; i++)
     {

--- a/src/gameobjects/container/ContainerCanvasRenderer.js
+++ b/src/gameobjects/container/ContainerCanvasRenderer.js
@@ -53,7 +53,7 @@ var ContainerCanvasRenderer = function (renderer, container, interpolationPercen
     }
 
     var alpha = container._alpha;
-	var scrollFactorX = container.scrollFactorX;
+    var scrollFactorX = container.scrollFactorX;
     var scrollFactorY = container.scrollFactorY;
     
     if (container.mask) {

--- a/src/gameobjects/container/ContainerCanvasRenderer.js
+++ b/src/gameobjects/container/ContainerCanvasRenderer.js
@@ -93,7 +93,8 @@ var ContainerCanvasRenderer = function (renderer, container, interpolationPercen
 	
 	if (container.mask) {
 		container.mask.postRenderCanvas(renderer);
-	}	
+	}
+	
 };
 
 module.exports = ContainerCanvasRenderer;

--- a/src/gameobjects/container/ContainerCanvasRenderer.js
+++ b/src/gameobjects/container/ContainerCanvasRenderer.js
@@ -54,12 +54,12 @@ var ContainerCanvasRenderer = function (renderer, container, interpolationPercen
 
     var alpha = container._alpha;
 	var scrollFactorX = container.scrollFactorX;
-	var scrollFactorY = container.scrollFactorY;
-	
-	if (container.mask) {
-		container.mask.preRenderCanvas(renderer, null, camera);
-	}
-
+    var scrollFactorY = container.scrollFactorY;
+    
+    if (container.mask) {
+        container.mask.preRenderCanvas(renderer, null, camera);
+    }
+    
     for (var i = 0; i < children.length; i++)
     {
         var child = children[i];
@@ -89,12 +89,12 @@ var ContainerCanvasRenderer = function (renderer, container, interpolationPercen
         //  Restore original values
         child.setAlpha(childAlpha);
         child.setScrollFactor(childScrollFactorX, childScrollFactorY);
-	}
-	
-	if (container.mask) {
-		container.mask.postRenderCanvas(renderer);
-	}
-	
+    }
+    
+    if (container.mask) {
+        container.mask.postRenderCanvas(renderer);
+    }
+
 };
 
 module.exports = ContainerCanvasRenderer;

--- a/src/renderer/canvas/CanvasRenderer.js
+++ b/src/renderer/canvas/CanvasRenderer.js
@@ -765,9 +765,17 @@ var CanvasRenderer = new Class({
 
         ctx.globalAlpha = alpha;
 
-        ctx.imageSmoothingEnabled = !(!this.antialias || frame.source.scaleMode);
+		ctx.imageSmoothingEnabled = !(!this.antialias || frame.source.scaleMode);
+		
+		if (sprite.mask) {
+			sprite.mask.preRenderCanvas(this, sprite, camera);
+		}
 
         ctx.drawImage(frame.source.image, frameX, frameY, frameWidth, frameHeight, x, y, frameWidth / res, frameHeight / res);
+
+		if (sprite.mask) {
+			sprite.mask.postRenderCanvas(this, sprite, camera);
+		}  
 
         ctx.restore();
     },

--- a/src/renderer/canvas/CanvasRenderer.js
+++ b/src/renderer/canvas/CanvasRenderer.js
@@ -765,16 +765,16 @@ var CanvasRenderer = new Class({
 
         ctx.globalAlpha = alpha;
 
-		ctx.imageSmoothingEnabled = !(!this.antialias || frame.source.scaleMode);
-		
-	    if (sprite.mask) {
-		    sprite.mask.preRenderCanvas(this, sprite, camera);
-	    }
+        ctx.imageSmoothingEnabled = !(!this.antialias || frame.source.scaleMode);
+        
+        if (sprite.mask) {
+            sprite.mask.preRenderCanvas(this, sprite, camera);
+        }
 
         ctx.drawImage(frame.source.image, frameX, frameY, frameWidth, frameHeight, x, y, frameWidth / res, frameHeight / res);
 
-	    if (sprite.mask) {
-		    sprite.mask.postRenderCanvas(this, sprite, camera);
+        if (sprite.mask) {
+            sprite.mask.postRenderCanvas(this, sprite, camera);
         }
         
         ctx.restore();

--- a/src/renderer/canvas/CanvasRenderer.js
+++ b/src/renderer/canvas/CanvasRenderer.js
@@ -767,15 +767,16 @@ var CanvasRenderer = new Class({
 
 		ctx.imageSmoothingEnabled = !(!this.antialias || frame.source.scaleMode);
 		
-		if (sprite.mask) {
-			sprite.mask.preRenderCanvas(this, sprite, camera);
-		}
+	    if (sprite.mask) {
+		    sprite.mask.preRenderCanvas(this, sprite, camera);
+	    }
 
         ctx.drawImage(frame.source.image, frameX, frameY, frameWidth, frameHeight, x, y, frameWidth / res, frameHeight / res);
 
-		if (sprite.mask) {
-			sprite.mask.postRenderCanvas(this, sprite, camera);
-		}
+	    if (sprite.mask) {
+		    sprite.mask.postRenderCanvas(this, sprite, camera);
+        }
+        
         ctx.restore();
     },
 

--- a/src/renderer/canvas/CanvasRenderer.js
+++ b/src/renderer/canvas/CanvasRenderer.js
@@ -775,8 +775,7 @@ var CanvasRenderer = new Class({
 
 		if (sprite.mask) {
 			sprite.mask.postRenderCanvas(this, sprite, camera);
-		}  
-
+		}
         ctx.restore();
     },
 


### PR DESCRIPTION
This PR
* Fixes a bug

Describe the changes below:

in #3673, The nested mask only works properly in `Phaser.WEBGL`, this PR fix it for `Phaser.CANVAS`.
