### PR TITLE
Update TextStyle to have jsdocs for word wrap related properties

### DIFF
--- a/src/gameobjects/text/TextStyle.js
+++ b/src/gameobjects/text/TextStyle.js
@@ -295,6 +295,57 @@ var TextStyle = new Class({
         this.baselineY;
 
         /**
+         * The maximum width of a line of text in pixels. Null means no line wrapping. Setting this
+         * property directly will not re-run the word wrapping algorithm. To change the width and
+         * re-wrap, use {@link Phaser.GameObjects.TextStyle#setWordWrapWidth}.
+         *
+         * @name Phaser.GameObjects.TextStyle#wordWrapWidth
+         * @type {number | null}
+         * @default null
+         * @since 3.23.0
+         */
+        this.wordWrapWidth;
+
+        /**
+         * A custom function that will be responsible for wrapping the text. It will receive two
+         * arguments: text (the string to wrap), textObject (this Text instance). It should return
+         * the wrapped lines either as an array of lines or as a string with newline characters in
+         * place to indicate where breaks should happen. Setting this directly will not re-run the
+         * word wrapping algorithm. To change the callback and re-wrap, use
+         * {@link Phaser.GameObjects.TextStyle#setWordWrapCallback}.
+         * 
+         * @name Phaser.GameObjects.TextStyle#wordWrapCallback
+         * @type {TextStyleWordWrapCallback | null}
+         * @default null
+         * @since 3.23.0
+         */
+        this.wordWrapCallback;
+
+        /**
+         * The scope that will be applied when the wordWrapCallback is invoked. Setting this directly will not re-run the
+         * word wrapping algorithm. To change the callback and re-wrap, use
+         * {@link Phaser.GameObjects.TextStyle#setWordWrapCallback}.
+         * 
+         * @name Phaser.GameObjects.TextStyle#wordWrapCallbackScope
+         * @type {object | null}
+         * @default null
+         * @since 3.23.0
+         */
+        this.wordWrapCallbackScope;
+
+        /**
+         * Whether or not to use the advanced wrapping algorithm. If true, spaces are collapsed and
+         * whitespace is trimmed from lines. If false, spaces and whitespace are left as is. Setting
+         * this property directly will not re-run the word wrapping algorithm. To change the
+         * advanced setting and re-wrap, use {@link Phaser.GameObjects.TextStyle#setWordWrapWidth}.
+         * @name Phaser.GameObjects.TextStyle#wordWrapUseAdvanced
+         * @type {boolean}
+         * @default false
+         * @since 3.23.0
+         */
+        this.wordWrapUseAdvanced;
+
+        /**
          * The font style, size and family.
          *
          * @name Phaser.GameObjects.TextStyle#_font

--- a/src/gameobjects/text/TextStyle.js
+++ b/src/gameobjects/text/TextStyle.js
@@ -338,6 +338,7 @@ var TextStyle = new Class({
          * whitespace is trimmed from lines. If false, spaces and whitespace are left as is. Setting
          * this property directly will not re-run the word wrapping algorithm. To change the
          * advanced setting and re-wrap, use {@link Phaser.GameObjects.TextStyle#setWordWrapWidth}.
+         * 
          * @name Phaser.GameObjects.TextStyle#wordWrapUseAdvanced
          * @type {boolean}
          * @default false


### PR DESCRIPTION
This PR:
* Updates the Documentation

Describe the changes below:
I updated TextStyle to have jsdoc tags for: wordWrapWidth, wordWrapCallback, wordWrapCallbackScope, wordWrapUseAdvanced. These properties are already there, they just aren't recognized in the docs or in the types. The rationale to expose them in the docs/types is that these are useful to have access to when running your own custom wrapping. E.g. you can read the wordWrapWidth in your wordWrapCallback so that your Text can change width without needing to apply a new callback - all you need to do is change the wordWrapWidth (something I was doing in a project). I tested the jsdocs tags by building the doc repo.