### PR TITLE
Fix Path moveTo optional y param

### DIFF
--- a/src/curves/path/Path.js
+++ b/src/curves/path/Path.js
@@ -786,7 +786,7 @@ var Path = new Class({
      * @since 3.0.0
      *
      * @param {(number|Phaser.Math.Vector2)} x - The X coordinate of the position to move the path's end point to, or a `Vector2` containing the entire new end point.
-     * @param {number} y - The Y coordinate of the position to move the path's end point to, if a number was passed as the X coordinate.
+     * @param {number} [y] - The Y coordinate of the position to move the path's end point to, if a number was passed as the X coordinate.
      *
      * @return {this} This Path object.
      */


### PR DESCRIPTION
This PR:

* Fixes the `moveTo` method of the `Path` class.

Describe the changes below:

Make the `y` parameter optional in typescript typing in case the `x` parameter is a `Phaser.Math.Vector2` object.