### PR TITLE
Fix drag coordinates with camera zoom (issue #4755)

### DIFF
--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -1126,8 +1126,8 @@ var InputPlugin = new Class({
             input.dragStartX = gameObject.x;
             input.dragStartY = gameObject.y;
 
-            input.dragStartXGlobal = pointer.x;
-            input.dragStartYGlobal = pointer.y;
+            input.dragStartXGlobal = pointer.worldX;
+            input.dragStartYGlobal = pointer.worldY;
 
             input.dragX = input.dragStartXGlobal - input.dragStartX;
             input.dragY = input.dragStartYGlobal - input.dragStartY;
@@ -1330,13 +1330,13 @@ var InputPlugin = new Class({
 
             if (!gameObject.parentContainer)
             {
-                dragX = pointer.x - input.dragX;
-                dragY = pointer.y - input.dragY;
+                dragX = pointer.worldX - input.dragX;
+                dragY = pointer.worldY - input.dragY;
             }
             else
             {
-                var dx = pointer.x - input.dragStartXGlobal;
-                var dy = pointer.y - input.dragStartYGlobal;
+                var dx = pointer.worldX - input.dragStartXGlobal;
+                var dy = pointer.worldY - input.dragStartYGlobal;
 
                 var rotation = gameObject.getParentRotation();
 


### PR DESCRIPTION
This PR

* Fixes a bug

This fix addresses GitHub issue #4755 

The dragX and dragY passed to 'dragStart' and 'drag' events are supported to be in world coordinates (as specified by the docs) but the coordinates used (pointer.x and pointer.y) were not transformed by the camera into world space. The drags now use pointer.worldX and pointer.worldY which are the post-transform coordinates.