### PR TITLE
Set Phaser.Loader.File.url type to string

### DIFF
--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -85,7 +85,7 @@ var File = new Class({
          * Automatically has Loader.path prepended to it.
          *
          * @name Phaser.Loader.File#url
-         * @type {(function|object|string)}
+         * @type {string}
          * @since 3.0.0
          */
         this.url = GetFastValue(fileConfig, 'url');


### PR DESCRIPTION
This PR

* Updates the Documentation
* Fixes a bug

Description:

`Phaser.Loader.File.url` currently (3.24.0) has type of `function|object|string`.
Previously (3.23.0) it was `string`. It breaks my project and I think the previous one is the correct one.