### PR TITLE
fix for GetPoints() not returning evenly spaced points along line

### DIFF
--- a/src/geom/line/GetPoints.js
+++ b/src/geom/line/GetPoints.js
@@ -45,7 +45,7 @@ var GetPoints = function (line, quantity, stepRate, out)
 
     for (var i = 0; i < quantity; i++)
     {
-        var position = i / quantity;
+        var position = quantity > 1 ? i / (quantity-1) : 0;
 
         var x = x1 + (x2 - x1) * position;
         var y = y1 + (y2 - y1) * position;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

This change corrects a bug in GetPoints that calculated incorrect spacing along a line:

before:
![image](https://user-images.githubusercontent.com/16840628/87463981-9829cd80-c5cf-11ea-9d57-1d962d622ddc.png)

after:
![image](https://user-images.githubusercontent.com/16840628/87464066-bbed1380-c5cf-11ea-90b3-3c97faf13984.png)

codepen demonstrating the problem:
https://codepen.io/snowbillr/pen/gOPdmvN?editors=0010

