### PR TITLE
[types] allow Text#setPadding to receive an object

### DIFF
--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -1022,9 +1022,9 @@ var Text = new Class({
      * @since 3.0.0
      *
      * @param {(number|Phaser.Types.GameObjects.Text.TextPadding)} left - The left padding value, or a padding config object.
-     * @param {number} top - The top padding value.
-     * @param {number} right - The right padding value.
-     * @param {number} bottom - The bottom padding value.
+     * @param {[number]} top - The top padding value.
+     * @param {[number]} right - The right padding value.
+     * @param {[number]} bottom - The bottom padding value.
      *
      * @return {this} This Text object.
      */

--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -1022,9 +1022,9 @@ var Text = new Class({
      * @since 3.0.0
      *
      * @param {(number|Phaser.Types.GameObjects.Text.TextPadding)} left - The left padding value, or a padding config object.
-     * @param {[number]} top - The top padding value.
-     * @param {[number]} right - The right padding value.
-     * @param {[number]} bottom - The bottom padding value.
+     * @param {number} [top] - The top padding value.
+     * @param {number} [right] - The right padding value.
+     * @param {number} [bottom] - The bottom padding value.
      *
      * @return {this} This Text object.
      */


### PR DESCRIPTION
This PR
* Fixes a bug

Previously, when using TypeScript, `Text#setPadding` only allowed 4 numbers as arguments, despite the docs stating you could also pass an object as a first and only argument.

