### PR TITLE
Fix types for Text, TextFactory and TextCreator

### DIFF
--- a/src/gameobjects/text/static/Text.js
+++ b/src/gameobjects/text/static/Text.js
@@ -191,7 +191,7 @@ var Text = new Class({
          * Allows you to add extra spacing if the browser is unable to accurately determine the true font dimensions.
          *
          * @name Phaser.GameObjects.Text#padding
-         * @type {{left:number,right:number,top:number,bottom:number}}
+         * @type {Phaser.Types.GameObjects.Text.TextPadding}
          * @since 3.0.0
          */
         this.padding = { left: 0, right: 0, top: 0, bottom: 0 };

--- a/src/gameobjects/text/static/TextCreator.js
+++ b/src/gameobjects/text/static/TextCreator.js
@@ -17,7 +17,7 @@ var Text = require('./Text');
  * @method Phaser.GameObjects.GameObjectCreator#text
  * @since 3.0.0
  *
- * @param {object} config - The configuration object this Game Object will use to create itself.
+ * @param {Phaser.Types.GameObjects.Text.TextConfig} config - The configuration object this Game Object will use to create itself.
  * @param {boolean} [addToScene] - Add this Game Object to the Scene after creating it? If set this argument overrides the `add` property in the config object.
  *
  * @return {Phaser.GameObjects.Text} The Game Object that was created.

--- a/src/gameobjects/text/static/TextFactory.js
+++ b/src/gameobjects/text/static/TextFactory.js
@@ -41,7 +41,7 @@ var GameObjectFactory = require('../../GameObjectFactory');
  * @param {number} x - The horizontal position of this Game Object in the world.
  * @param {number} y - The vertical position of this Game Object in the world.
  * @param {(string|string[])} text - The text this Text object will display.
- * @param {object} [style] - The Text style configuration object.
+ * @param {Phaser.Types.GameObjects.Text.TextStyle} [style] - The Text style configuration object.
  *
  * @return {Phaser.GameObjects.Text} The Game Object that was created.
  */

--- a/src/gameobjects/text/typedefs/TextConfig.js
+++ b/src/gameobjects/text/typedefs/TextConfig.js
@@ -1,0 +1,9 @@
+/**
+ * @typedef {object} Phaser.Types.GameObjects.Text.TextConfig
+ * @extends Phaser.Types.GameObjects.GameObjectConfig
+ * @since 3.0.0
+ *
+ * @property {(string|string[])} [text] - The text this Text object will display.
+ * @property {Phaser.Types.GameObjects.Text.TextStyle} [style] - The Text style configuration object.
+ * @property {Phaser.Types.GameObjects.Text.TextPadding} [padding] - A Text Padding object.
+ */


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:
The TextCreator was lacking types for its config parameter, so I added a TextConfig type. The TextFactory typed its style parameter as 'object', I changed it to TextStyle. Lastly, I changed the type of Text's padding property to TextPadding, as that type is used other places (like in TextStyle, which can be used to set that padding property).

Let me know if I missed something with regards to TextConfig, I tried typing it similar to how it was done with for instance TileSprite and TileSpriteConfig, based on what object properties TextCreator seemed to use.