### PR TITLE
Fix incorrect event names in ProcessQueue.js#205, 222

### DIFF
--- a/src/structs/ProcessQueue.js
+++ b/src/structs/ProcessQueue.js
@@ -11,7 +11,7 @@ var Events = require('./events');
 /**
  * @classdesc
  * A Process Queue maintains three internal lists.
- * 
+ *
  * The `pending` list is a selection of items which are due to be made 'active' in the next update.
  * The `active` list is a selection of items which are considered active and should be updated.
  * The `destroy` list is a selection of items that were active and are awaiting being destroyed in the next update.
@@ -92,7 +92,7 @@ var ProcessQueue = new Class({
 
     /**
      * Adds a new item to the Process Queue.
-     * 
+     *
      * The item is added to the pending list and made active in the next update.
      *
      * @method Phaser.Structs.ProcessQueue#add
@@ -116,7 +116,7 @@ var ProcessQueue = new Class({
 
     /**
      * Removes an item from the Process Queue.
-     * 
+     *
      * The item is added to the pending destroy and fully removed in the next update.
      *
      * @method Phaser.Structs.ProcessQueue#remove
@@ -140,7 +140,7 @@ var ProcessQueue = new Class({
 
     /**
      * Removes all active items from this Process Queue.
-     * 
+     *
      * All the items are marked as 'pending destroy' and fully removed in the next update.
      *
      * @method Phaser.Structs.ProcessQueue#removeAll
@@ -166,7 +166,7 @@ var ProcessQueue = new Class({
 
     /**
      * Update this queue. First it will process any items awaiting destruction, and remove them.
-     * 
+     *
      * Then it will check to see if there are any items pending insertion, and move them to an
      * active state. Finally, it will return a list of active items for further processing.
      *
@@ -202,7 +202,7 @@ var ProcessQueue = new Class({
             {
                 active.splice(idx, 1);
 
-                this.emit(Events.REMOVE, item);
+                this.emit(Events.PROCESS_QUEUE_REMOVE, item);
             }
         }
 
@@ -219,7 +219,7 @@ var ProcessQueue = new Class({
 
             this._active.push(item);
 
-            this.emit(Events.ADD, item);
+            this.emit(Events.PROCESS_QUEUE_ADD, item);
         }
 
         list.length = 0;
@@ -232,7 +232,7 @@ var ProcessQueue = new Class({
 
     /**
      * Returns the current list of active items.
-     * 
+     *
      * This method returns a reference to the active list array, not a copy of it.
      * Therefore, be careful to not modify this array outside of the ProcessQueue.
      *


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

ProcessQueue.js#205 and 222, had incorrect event names.
