### PR TITLE
Fix typo for documentation on create method of AnimationManager

### DIFF
--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -187,7 +187,7 @@ var AnimationManager = new Class({
      *
      * @param {Phaser.Types.Animations.Animation} config - The configuration settings for the Animation.
      *
-     * @return {(Phaser.Animations.Animation|false)} The Animation that was created, or `false` is the key is already in use.
+     * @return {(Phaser.Animations.Animation|false)} The Animation that was created, or `false` if the key is already in use.
      */
     create: function (config)
     {


### PR DESCRIPTION
This PR:

* Updates the Documentation

Describe the changes below:

- Fixes typo on line 190 of `src\animations\AnimationManager.js` from "is" to "if" for grammatical correctness
