### PR TITLE
Renderer#snapshotGameObject function added

### DIFF
--- a/src/renderer/canvas/CanvasRenderer.js
+++ b/src/renderer/canvas/CanvasRenderer.js
@@ -553,6 +553,16 @@ var CanvasRenderer = new Class({
     },
 
     /**
+     * Schedules a snapshot of given gameObject.
+     * */
+    snapshotGameObject: function (gameObject, callback, type, encoderOptions)
+    {
+        var bounds = gameObject.getBounds();
+
+        return this.snapshotArea(bounds.x, bounds.y, bounds.width, bounds.height, callback, type, encoderOptions);
+    },
+
+    /**
      * Schedules a snapshot of the given area of the game viewport to be taken after the current frame is rendered.
      *
      * To capture the whole game viewport see the `snapshot` method. To capture a specific pixel, see `snapshotPixel`.

--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -2582,6 +2582,16 @@ var WebGLRenderer = new Class({
     },
 
     /**
+     * Schedules a snapshot of given gameObject.
+     * */
+    snapshotGameObject: function (gameObject, callback, type, encoderOptions)
+    {
+        var bounds = gameObject.getBounds();
+
+        return this.snapshotArea(bounds.x, bounds.y, bounds.width, bounds.height, callback, type, encoderOptions);
+    },
+
+    /**
      * Schedules a snapshot of the given area of the game viewport to be taken after the current frame is rendered.
      *
      * To capture the whole game viewport see the `snapshot` method. To capture a specific pixel, see `snapshotPixel`.


### PR DESCRIPTION
* Proposal to add a new function to renderers

Describe the changes below:

It add's a function called `snapshotGameObject` to WebGLRenderer.js and CanvasRenderer.js.

```javascript
    /**
     * Schedules a snapshot of given gameObject.
     * */
    snapshotGameObject: function (gameObject, callback, type, encoderOptions)
    {
        var bounds = gameObject.getBounds();

        return this.snapshotArea(bounds.x, bounds.y, bounds.width, bounds.height, callback, type, encoderOptions);
    },
```

It's only a shorthand to get to Image of a certain area actually, within the gameobject.

This is probably not the best way to create a snapshot of a gameObject,
When you think it should be without background but for temporary solution maybe?

(It is quite usefull if you just want to get an area of a Container =)