### PR TITLE
Fix up tiled json parsing.

### DIFF
--- a/src/tilemaps/parsers/tiled/ParseWangsets.js
+++ b/src/tilemaps/parsers/tiled/ParseWangsets.js
@@ -1,0 +1,120 @@
+/**
+ * @author       Richard Davey <rich@photonstorm.com>
+ * @copyright    2020 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+/**
+ * Tilesets and Image Collections
+ *
+ * @function Phaser.Tilemaps.Parsers.Tiled.ParseTilesets
+ * @since 3.0.0
+ *
+ * @param {Array.<object>} wangsets - The array of wangset objects (parsed from JSON)
+ * @param {object} datas - The field into which to put wangset data from Tiled.
+ *
+ * @return {object} An object containing the tileset and image collection data.
+ */
+var ParseWangsets = function (wangsets, datas)
+{
+    // Since Tiled 1.1.5+
+    // Since a given tile can be in more than one wangset, the resulting properties
+    // are nested -- `tile.data.wangid[someWangsetName]` gets you the
+    // array-based wangid in this implementation.
+    // TODO: structure wangset metadata -- especially color info.
+    // We're not guaranteed that there will be any "normal" tiles if the only
+    // thing in the tileset are wangtile definitions, so this has to be parsed
+    // separately.
+    // See https://doc.mapeditor.org/en/latest/manual/using-wang-tiles/
+    // for more information.
+    for (var w = 0; w < wangsets.length; w++)
+    {
+        var wangset = wangsets[w];
+        var identifier = w;
+        if (wangset.name && wangset.name !== '')
+        {
+            identifier = wangset.name;
+        }
+        if (Array.isArray(wangset.wangtiles) && wangset.wangtiles.length > 0)
+        {
+            var edgeColors = {};
+            var cornerColors = {};
+            var c = undefined;
+            var colorIndex = undefined;
+            var color = undefined;
+
+            // Tiled before v2020.09.09
+            if (Array.isArray(wangset.edgecolors))
+            {
+                for (c = 0; c < wangset.edgecolors.length; c++)
+                {
+                    colorIndex = 1 + c;
+                    color = wangset.edgecolors[c];
+                    if (color.name !== '')
+                    {
+                        edgeColors[colorIndex] = color.name;
+                    }
+                }
+            }
+            if (Array.isArray(wangset.cornercolors))
+            {
+                for (c = 0; c < wangset.cornercolors.length; c++)
+                {
+                    colorIndex = 1 + c;
+                    color = wangset.cornercolors[c];
+                    if (color.name !== '')
+                    {
+                        cornerColors[colorIndex] = color.name;
+                    }
+                }
+            }
+
+            // Tiled after v2020.09.09
+            if (Array.isArray(wangset.colors))
+            {
+                for (c = 0; c < wangset.colors.length; c++)
+                {
+                    color = wangset.colors[c];
+                    colorIndex = 1 + c;
+                    if (color.name !== '')
+                    {
+                        edgeColors[colorIndex] = cornerColors[colorIndex] = color.name;
+                    }
+                }
+            }
+
+            // The wangid layout is north, northeast, east, southeast, etc.
+            var idLayout = [
+                edgeColors, cornerColors, edgeColors, cornerColors,
+                edgeColors, cornerColors, edgeColors, cornerColors
+            ];
+
+            for (var t = 0; t < wangset.wangtiles.length; t++)
+            {
+                var wangtile = wangset.wangtiles[t];
+                var obj = (datas[wangtile.tileid] || (datas[wangtile.tileid] = {}));
+                obj = (obj.wangid || (obj.wangid = {}));
+                var wangid = [];
+                for (var i = 0; i < Math.min(idLayout.length, wangtile.wangid.length); i++)
+                {
+                    color = wangtile.wangid[i];
+                    if (color === 0)
+                    {
+                        wangid.push(undefined);
+                        continue;
+                    }
+                    var renamed = idLayout[i][color];
+                    if (renamed !== undefined)
+                    {
+                        wangid.push(renamed);
+                        continue;
+                    }
+                    wangid.push(color);
+                }
+                obj[identifier] = wangid;
+            }
+        }
+    }
+};
+
+module.exports = ParseWangsets;

--- a/src/tilemaps/typedefs/TiledObject.js
+++ b/src/tilemaps/typedefs/TiledObject.js
@@ -4,7 +4,7 @@
  *
  * @property {integer} id - The unique object ID.
  * @property {string} name - The name this object was assigned in Tiled.
- * @property {string} type - The type, as assigned in Tiled.
+ * @property {string} type - The string type of this instance, as assigned in Tiled. Tiled supports inheriting instance types from tilesets; in that case, the type will be set in the tile's data, but will be `''` here; use the `gid` to fetch the tile data or properties.
  * @property {boolean} [visible] - The visible state of this object.
  * @property {number} [x] - The horizontal position of this object, in pixels, relative to the tilemap.
  * @property {number} [y] - The vertical position of this object, in pixels, relative to the tilemap.


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation
* Fixes a bug

Describe the changes below:

Phaser currently discards the tiled `type` field (which is very useful for objects-from-tiles, as well as somewhat useful for handling tile variants).
It also discards wang set information, which is somewhat meaningful.

This diff adds both back; let me know if it goes too far and I can restrict it to only including `type`.