### PR TITLE
Fix Phaser.Time is undefined in Phaser.Time.Clock#addEvent

### DIFF
--- a/src/time/Clock.js
+++ b/src/time/Clock.js
@@ -170,7 +170,7 @@ var Clock = new Class({
     {
         var event;
 
-        if (config instanceof Phaser.Time.TimerEvent)
+        if (config instanceof TimerEvent)
         {
             event = config;
 


### PR DESCRIPTION
This PR

* Fixes a bug

Fixes #5294

