### PR TITLE
Add default value for Phaser.Core.Config#audio

### DIFF
--- a/src/core/Config.js
+++ b/src/core/Config.js
@@ -293,7 +293,7 @@ var Config = new Class({
         /**
          * @const {Phaser.Types.Core.AudioConfig} Phaser.Core.Config#audio - The Audio Configuration object.
          */
-        this.audio = GetValue(config, 'audio');
+        this.audio = GetValue(config, 'audio', {});
 
         //  If you do: { banner: false } it won't display any banner at all
 

--- a/src/core/DebugHeader.js
+++ b/src/core/DebugHeader.js
@@ -41,11 +41,11 @@ var DebugHeader = function (game)
 
     var audioType;
 
-    if (deviceAudio.webAudio && !(audioConfig && audioConfig.disableWebAudio))
+    if (deviceAudio.webAudio && !audioConfig.disableWebAudio)
     {
         audioType = 'Web Audio';
     }
-    else if ((audioConfig && audioConfig.noAudio) || (!deviceAudio.webAudio && !deviceAudio.audioData))
+    else if (audioConfig.noAudio || (!deviceAudio.webAudio && !deviceAudio.audioData))
     {
         audioType = 'No Audio';
     }

--- a/src/loader/filetypes/AudioFile.js
+++ b/src/loader/filetypes/AudioFile.js
@@ -122,7 +122,7 @@ AudioFile.create = function (loader, key, urls, config, xhrSettings)
     // https://developers.google.com/web/updates/2012/02/HTML5-audio-and-the-Web-Audio-API-are-BFFs
     // var stream = GetFastValue(config, 'stream', false);
 
-    if (deviceAudio.webAudio && !(audioConfig && audioConfig.disableWebAudio))
+    if (deviceAudio.webAudio && !audioConfig.disableWebAudio)
     {
         return new AudioFile(loader, key, urlConfig, xhrSettings, game.sound.context);
     }
@@ -231,7 +231,7 @@ FileTypesManager.register('audio', function (key, urls, config, xhrSettings)
     var audioConfig = game.config.audio;
     var deviceAudio = game.device.audio;
 
-    if ((audioConfig && audioConfig.noAudio) || (!deviceAudio.webAudio && !deviceAudio.audioData))
+    if (audioConfig.noAudio || (!deviceAudio.webAudio && !deviceAudio.audioData))
     {
         //  Sounds are disabled, so skip loading audio
         return this;

--- a/src/sound/SoundManagerCreator.js
+++ b/src/sound/SoundManagerCreator.js
@@ -18,7 +18,7 @@ var WebAudioSoundManager = require('./webaudio/WebAudioSoundManager');
  * @since 3.0.0
  *
  * @param {Phaser.Game} game - Reference to the current game instance.
- * 
+ *
  * @return {(Phaser.Sound.HTML5AudioSoundManager|Phaser.Sound.WebAudioSoundManager|Phaser.Sound.NoAudioSoundManager)} The Sound Manager instance that was created.
  */
 var SoundManagerCreator = {
@@ -28,12 +28,12 @@ var SoundManagerCreator = {
         var audioConfig = game.config.audio;
         var deviceAudio = game.device.audio;
 
-        if ((audioConfig && audioConfig.noAudio) || (!deviceAudio.webAudio && !deviceAudio.audioData))
+        if (audioConfig.noAudio || (!deviceAudio.webAudio && !deviceAudio.audioData))
         {
             return new NoAudioSoundManager(game);
         }
 
-        if (deviceAudio.webAudio && !(audioConfig && audioConfig.disableWebAudio))
+        if (deviceAudio.webAudio && !audioConfig.disableWebAudio)
         {
             return new WebAudioSoundManager(game);
         }

--- a/src/sound/webaudio/WebAudioSoundManager.js
+++ b/src/sound/webaudio/WebAudioSoundManager.js
@@ -108,7 +108,7 @@ var WebAudioSoundManager = new Class({
     {
         var audioConfig = game.config.audio;
 
-        if (audioConfig && audioConfig.context)
+        if (audioConfig.context)
         {
             audioConfig.context.resume();
 
@@ -355,7 +355,7 @@ var WebAudioSoundManager = new Class({
         this.masterMuteNode.disconnect();
         this.masterMuteNode = null;
 
-        if (this.game.config.audio && this.game.config.audio.context)
+        if (this.game.config.audio.context)
         {
             this.context.suspend();
         }


### PR DESCRIPTION
This PR

* Adds a new feature?

Changes the default value from `undefined` to `{}` and refactors Phaser's use of it.

I think this is more correct (per the docs) and it simplifies later access to `game.config.audio`.
