### PR TITLE
Add creator arguments to createFromObjects() and createFromTiles()

### DIFF
--- a/src/gameobjects/typedefs/MakeGameObjectCallback.js
+++ b/src/gameobjects/typedefs/MakeGameObjectCallback.js
@@ -1,0 +1,8 @@
+/**
+ * @callback Phaser.Types.GameObjects.MakeGameObjectCallback
+ * @since 3.50.0
+ *
+ * @param {Phaser.Types.GameObjects.GameObjectConfig} config - The config to make the GameObject from.
+ *
+ * @return {Phaser.GameObjects.GameObject} The newly-made Game Object.
+ */

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -692,7 +692,7 @@ var Tilemap = new Class({
                 sprite.x += offset.x;
                 sprite.y += offset.y;
 
-                if (obj.flippedHorizontal !== undefined || obj.flippedVertical !== undefined)
+                if (sprite.setFlip && (obj.flippedHorizontal !== undefined || obj.flippedVertical !== undefined))
                 {
                     sprite.setFlip(obj.flippedHorizontal, obj.flippedVertical);
                 }

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -729,16 +729,18 @@ var Tilemap = new Class({
      * @param {Phaser.Scene} [scene=scene the map is within] - The Scene to create the Sprites within.
      * @param {Phaser.Cameras.Scene2D.Camera} [camera=main camera] - The Camera to use when calculating the tile index from the world values.
      * @param {(string|integer|Phaser.Tilemaps.DynamicTilemapLayer|Phaser.Tilemaps.StaticTilemapLayer)} [layer] - The tile layer to use. If not given the current layer is used.
+     * @param {function} [make] - The Sprite creator. Default is `scene.make.sprite`. See {@link Phaser.GameObjects.GameObjectCreator}.
+     * @param {any} [makeContext] - The Sprite creator context. Default is `scene.make`.
      *
      * @return {?Phaser.GameObjects.Sprite[]} Returns an array of Tiles, or null if the layer given was invalid.
      */
-    createFromTiles: function (indexes, replacements, spriteConfig, scene, camera, layer)
+    createFromTiles: function (indexes, replacements, spriteConfig, scene, camera, layer, make, makeContext)
     {
         layer = this.getLayer(layer);
 
         if (layer === null) { return null; }
 
-        return TilemapComponents.CreateFromTiles(indexes, replacements, spriteConfig, scene, camera, layer);
+        return TilemapComponents.CreateFromTiles(indexes, replacements, spriteConfig, scene, camera, layer, make, makeContext);
     },
 
     /**

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -619,7 +619,7 @@ var Tilemap = new Class({
      * @param {Phaser.Types.GameObjects.GameObjectConfig} spriteConfig - The config object to pass into the Sprite creator (i.e.
      * scene.make.sprite).
      * @param {Phaser.Scene} [scene=the scene the map is within] - The Scene to create the Sprites within.
-     * @param {function} [make] - The Sprite creator. Default is `scene.make.sprite`. See {@link Phaser.GameObjects.GameObjectCreator}.
+     * @param {Phaser.Types.GameObjects.MakeGameObjectCallback} [make] - The Sprite creator. Default is `scene.make.sprite`. See {@link Phaser.GameObjects.GameObjectCreator}.
      * @param {any} [makeContext] - The Sprite creator context. Default is `scene.make`.
      *
      * @return {Phaser.GameObjects.Sprite[]} An array of the Sprites that were created.
@@ -733,7 +733,7 @@ var Tilemap = new Class({
      * @param {Phaser.Scene} [scene=scene the map is within] - The Scene to create the Sprites within.
      * @param {Phaser.Cameras.Scene2D.Camera} [camera=main camera] - The Camera to use when calculating the tile index from the world values.
      * @param {(string|integer|Phaser.Tilemaps.DynamicTilemapLayer|Phaser.Tilemaps.StaticTilemapLayer)} [layer] - The tile layer to use. If not given the current layer is used.
-     * @param {function} [make] - The Sprite creator. Default is `scene.make.sprite`. See {@link Phaser.GameObjects.GameObjectCreator}.
+     * @param {Phaser.Types.GameObjects.MakeGameObjectCallback} [make] - The Sprite creator. Default is `scene.make.sprite`. See {@link Phaser.GameObjects.GameObjectCreator}.
      * @param {any} [makeContext] - The Sprite creator context. Default is `scene.make`.
      *
      * @return {?Phaser.GameObjects.Sprite[]} Returns an array of Tiles, or null if the layer given was invalid.

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -616,16 +616,20 @@ var Tilemap = new Class({
      * @param {(integer|string)} id - Either the id (object), gid (tile object) or name (object or
      * tile object) from Tiled. Ids are unique in Tiled, but a gid is shared by all tile objects
      * with the same graphic. The same name can be used on multiple objects.
-     * @param {Phaser.Types.GameObjects.Sprite.SpriteConfig} spriteConfig - The config object to pass into the Sprite creator (i.e.
+     * @param {Phaser.Types.GameObjects.GameObjectConfig} spriteConfig - The config object to pass into the Sprite creator (i.e.
      * scene.make.sprite).
      * @param {Phaser.Scene} [scene=the scene the map is within] - The Scene to create the Sprites within.
+     * @param {function} [make] - The Sprite creator. Default is `scene.make.sprite`. See {@link Phaser.GameObjects.GameObjectCreator}.
+     * @param {any} [makeContext] - The Sprite creator context. Default is `scene.make`.
      *
      * @return {Phaser.GameObjects.Sprite[]} An array of the Sprites that were created.
      */
-    createFromObjects: function (name, id, spriteConfig, scene)
+    createFromObjects: function (name, id, spriteConfig, scene, make, makeContext)
     {
         if (spriteConfig === undefined) { spriteConfig = {}; }
         if (scene === undefined) { scene = this.scene; }
+        if (make === undefined) { make = scene.make.sprite; }
+        if (makeContext === undefined) { makeContext = scene.make; }
 
         var objectLayer = this.getObjectLayer(name);
 
@@ -663,7 +667,7 @@ var Tilemap = new Class({
                 config.x = obj.x;
                 config.y = obj.y;
 
-                var sprite = scene.make.sprite(config);
+                var sprite = make.call(makeContext, config);
 
                 sprite.name = obj.name;
 

--- a/src/tilemaps/components/CreateFromTiles.js
+++ b/src/tilemaps/components/CreateFromTiles.js
@@ -24,7 +24,7 @@ var ReplaceByIndex = require('./ReplaceByIndex');
  * @param {Phaser.Scene} [scene=scene the map is within] - The Scene to create the Sprites within.
  * @param {Phaser.Cameras.Scene2D.Camera} [camera=main camera] - The Camera to use when determining the world XY
  * @param {Phaser.Tilemaps.LayerData} layer - The Tilemap Layer to act upon.
- * @param {function} [make] - The Sprite creator. Default is `scene.make.sprite`. See {@link Phaser.GameObjects.GameObjectCreator}.
+ * @param {Phaser.Types.GameObjects.MakeGameObjectCallback} [make] - The Sprite creator. Default is `scene.make.sprite`. See {@link Phaser.GameObjects.GameObjectCreator}.
  * @param {any} [makeContext] - The Sprite creator context. Default is `scene.make`.
  *
  * @return {Phaser.GameObjects.Sprite[]} An array of the Sprites that were created.

--- a/src/tilemaps/components/CreateFromTiles.js
+++ b/src/tilemaps/components/CreateFromTiles.js
@@ -20,14 +20,16 @@ var ReplaceByIndex = require('./ReplaceByIndex');
  *
  * @param {(number|number[])} indexes - The tile index, or array of indexes, to create Sprites from.
  * @param {(number|number[])} replacements - The tile index, or array of indexes, to change a converted tile to. Set to `null` to leave the tiles unchanged. If an array is given, it is assumed to be a one-to-one mapping with the indexes array.
- * @param {Phaser.Types.GameObjects.Sprite.SpriteConfig} spriteConfig - The config object to pass into the Sprite creator (i.e. scene.make.sprite).
+ * @param {Phaser.Types.GameObjects.GameObjectConfig} spriteConfig - The config object to pass into the Sprite creator (i.e. scene.make.sprite).
  * @param {Phaser.Scene} [scene=scene the map is within] - The Scene to create the Sprites within.
  * @param {Phaser.Cameras.Scene2D.Camera} [camera=main camera] - The Camera to use when determining the world XY
  * @param {Phaser.Tilemaps.LayerData} layer - The Tilemap Layer to act upon.
+ * @param {function} [make] - The Sprite creator. Default is `scene.make.sprite`. See {@link Phaser.GameObjects.GameObjectCreator}.
+ * @param {any} [makeContext] - The Sprite creator context. Default is `scene.make`.
  *
  * @return {Phaser.GameObjects.Sprite[]} An array of the Sprites that were created.
  */
-var CreateFromTiles = function (indexes, replacements, spriteConfig, scene, camera, layer)
+var CreateFromTiles = function (indexes, replacements, spriteConfig, scene, camera, layer, make, makeContext)
 {
     if (spriteConfig === undefined) { spriteConfig = {}; }
 
@@ -40,6 +42,8 @@ var CreateFromTiles = function (indexes, replacements, spriteConfig, scene, came
 
     if (scene === undefined) { scene = tilemapLayer.scene; }
     if (camera === undefined) { camera = scene.cameras.main; }
+    if (make === undefined) { make = scene.make.sprite; }
+    if (makeContext === undefined) { makeContext = scene.make; }
 
     var tiles = GetTilesWithin(0, 0, layer.width, layer.height, null, layer);
     var sprites = [];
@@ -54,7 +58,7 @@ var CreateFromTiles = function (indexes, replacements, spriteConfig, scene, came
             spriteConfig.x = TileToWorldX(tile.x, camera, layer);
             spriteConfig.y = TileToWorldY(tile.y, camera, layer);
 
-            sprites.push(scene.make.sprite(spriteConfig));
+            sprites.push(make.call(makeContext, spriteConfig));
         }
     }
 


### PR DESCRIPTION
This PR

* Adds a new feature

This lets you create any game object using a [creator method](https://photonstorm.github.io/phaser3-docs/Phaser.GameObjects.GameObjectCreator.html) or your own method.

```js
var texts = map.createFromObjects(
    'Coin Object Layer',
    26,
    { text: 'coin', style: { font: 'caption', fill: 'aqua' } },
    this,
    this.make.text,
    this.make
);

var coins = map.createFromObjects(
    'Coin Object Layer',
    26,
    { key: 'coin' },
    this,
    function ({ x, y, key })
    {
        return this.physics.add.sprite(x, y, key);
    },
    this
);

var shapes = map.createFromObjects(
    'Coin Object Layer',
    26,
    {},
    this,
    function ({ x, y, radius, fillColor, fillAlpha })
    {
        return this.add.circle(x, y, radius, fillColor, fillAlpha);
    },
    this
);
```

