### PR TITLE
bug fix: don't add path to url if it is absolute

### DIFF
--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -97,7 +97,7 @@ var File = new Class({
         {
             this.url = loader.path + loadKey + '.' + GetFastValue(fileConfig, 'extension', '');
         }
-        else if (typeof this.url === 'string' && this.url.indexOf('blob:') !== 0 && this.url.indexOf('data:') !== 0)
+        else if (typeof this.url === 'string' && this.url.indexOf('blob:') !== 0 && this.url.indexOf('data:') !== 0 && this.url.indexOf('http:') !== 0 && this.url.indexOf('https:') !== 0)
         {
             this.url = loader.path + this.url;
         }


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

don't add Loader.path to file url if it is absolute url
now Loader.path is added at the beginning of url even if the url is absolute, result: absolute url addresses are incorrect
