### PR TITLE
Fix add.existing bug

### DIFF
--- a/src/gameobjects/GameObjectFactory.js
+++ b/src/gameobjects/GameObjectFactory.js
@@ -134,6 +134,10 @@ var GameObjectFactory = new Class({
         {
             this.displayList.add(child);
         }
+        else if (child.preUpdate)
+        {
+            this.updateList.add(child);
+        }
 
         return child;
     },


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Add game object to updateList if it dose not add to displayList.
( Group game object dose not have `renderCanvas` or `renderWebGL` method #5304 )

