### PR TITLE
Add ability to use custom easing function(s) with particle emitters

### DIFF
--- a/src/gameobjects/particles/EmitterOp.js
+++ b/src/gameobjects/particles/EmitterOp.js
@@ -316,7 +316,7 @@ var EmitterOp = new Class({
 
                 var easeType = this.has(value, 'ease') ? value.ease : 'Linear';
 
-                this.ease = GetEaseFunction(easeType);
+                this.ease = GetEaseFunction(easeType, value.easeParams);
 
                 if (!isRandom)
                 {

--- a/src/gameobjects/particles/typedefs/EmitterOpEaseConfig.js
+++ b/src/gameobjects/particles/typedefs/EmitterOpEaseConfig.js
@@ -1,10 +1,11 @@
 /**
  * Defines an operation yielding a value incremented continuously across a range.
- * 
+ *
  * @typedef {object} Phaser.Types.GameObjects.Particles.EmitterOpEaseConfig
  * @since 3.0.0
  *
  * @property {number} start - The starting value.
  * @property {number} end - The ending value.
- * @property {string} [ease='Linear'] - The name of the easing function.
+ * @property {(string|function)} [ease='Linear'] - The ease to find. This can be either a string from the EaseMap, or a custom function.
+ * @property {number[]} [easeParams] - An optional array of ease parameters to go with the ease.
  */


### PR DESCRIPTION
This PR

* Updates the Documentation
* Adds a new feature

Describe the changes below:
Internally EmitterOp uses `GetEaseFunction` which can handle eases as strings and as functions, and also can accept easeParams.