### PR TITLE
GameObjectFactory#existing Should always add to updatelist if have preUpdate function

### DIFF
--- a/src/gameobjects/GameObjectFactory.js
+++ b/src/gameobjects/GameObjectFactory.js
@@ -134,7 +134,8 @@ var GameObjectFactory = new Class({
         {
             this.displayList.add(child);
         }
-        else if (child.preUpdate)
+        
+        if (child.preUpdate)
         {
             this.updateList.add(child);
         }


### PR DESCRIPTION
* Fixes a bug

Describe the changes below:
"Phaser.GameObjects.GameObjectFactory#existing" 
could only add to either the display list or update list not both. Now it can add to both again

