### PR TITLE
Add `onCollide` argument to Arcade.Body#setCollideWorldBounds()

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1668,7 +1668,9 @@ var Body = new Class({
     /**
      * Sets whether this Body collides with the world boundary.
      *
-     * Optionally also sets the World Bounce values. If the `Body.worldBounce` is null, it's set to a new Phaser.Math.Vector2 first.
+     * Optionally also sets the World Bounce and `onCollide` values.
+     *
+     * If the `Body.worldBounce` is null, it's set to a new Phaser.Math.Vector2 first.
      *
      * @method Phaser.Physics.Arcade.Body#setCollideWorldBounds
      * @since 3.0.0

--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1676,10 +1676,11 @@ var Body = new Class({
      * @param {boolean} [value=true] - `true` if this body should collide with the world bounds, otherwise `false`.
      * @param {number} [bounceX] - If given this will be replace the `worldBounce.x` value.
      * @param {number} [bounceY] - If given this will be replace the `worldBounce.y` value.
+     * @param {boolean} [onCollide] - If given this will replace the `onCollide` value.
      *
      * @return {Phaser.Physics.Arcade.Body} This Body object.
      */
-    setCollideWorldBounds: function (value, bounceX, bounceY)
+    setCollideWorldBounds: function (value, bounceX, bounceY, onCollide)
     {
         if (value === undefined) { value = true; }
 
@@ -1704,6 +1705,11 @@ var Body = new Class({
             {
                 this.worldBounce.y = bounceY;
             }
+        }
+
+        if (onCollide !== undefined)
+        {
+            this.onCollide = onCollide;
         }
 
         return this;

--- a/src/physics/arcade/components/Bounce.js
+++ b/src/physics/arcade/components/Bounce.js
@@ -14,7 +14,7 @@ var Bounce = {
 
     /**
      * Sets the bounce values of this body.
-     * 
+     *
      * Bounce is the amount of restitution, or elasticity, the body has when it collides with another object.
      * A value of 1 means that it will retain its full velocity after the rebound. A value of 0 means it will not rebound at all.
      *
@@ -69,7 +69,7 @@ var Bounce = {
 
     /**
      * Sets whether this Body collides with the world boundary.
-     * 
+     *
      * Optionally also sets the World Bounce values. If the `Body.worldBounce` is null, it's set to a new Phaser.Math.Vector2 first.
      *
      * @method Phaser.Physics.Arcade.Components.Bounce#setCollideWorldBounds
@@ -78,12 +78,13 @@ var Bounce = {
      * @param {boolean} [value=true] - `true` if this body should collide with the world bounds, otherwise `false`.
      * @param {number} [bounceX] - If given this will be replace the `worldBounce.x` value.
      * @param {number} [bounceY] - If given this will be replace the `worldBounce.y` value.
+     * @param {boolean} [onCollide] - If given this will replace the `onCollide` value.
      *
      * @return {this} This Game Object.
      */
-    setCollideWorldBounds: function (value, bounceX, bounceY)
+    setCollideWorldBounds: function (value, bounceX, bounceY, onCollide)
     {
-        this.body.setCollideWorldBounds(value, bounceX, bounceY);
+        this.body.setCollideWorldBounds(value, bounceX, bounceY, onCollide);
 
         return this;
     }


### PR DESCRIPTION
This PR

* Adds a new feature

Lets you set [Arcade.Body.html#onCollide](https://photonstorm.github.io/phaser3-docs/Phaser.Physics.Arcade.Body.html#onCollide) as part of the call.

