### PR TITLE
Allow setting alpha for 2D camera flash effect

### DIFF
--- a/src/cameras/2d/effects/Flash.js
+++ b/src/cameras/2d/effects/Flash.js
@@ -314,7 +314,7 @@ var Flash = new Class({
      */
     effectComplete: function ()
     {
-        this._alpha = this.alpha
+        this.alpha = this._alpha
         this._onUpdate = null;
         this._onUpdateScope = null;
 

--- a/src/cameras/2d/effects/Flash.js
+++ b/src/cameras/2d/effects/Flash.js
@@ -104,10 +104,9 @@ var Flash = new Class({
          *
          * @name Phaser.Cameras.Scene2D.Effects.Flash#alpha
          * @type {number}
-         * @private
          * @since 3.5.0
          */
-        this.alpha = 0;
+        this.alpha = 1;
 
         /**
          * If this effect is running this holds the current percentage of the progress, a value between 0 and 1.
@@ -127,6 +126,17 @@ var Flash = new Class({
          * @since 3.5.0
          */
         this._elapsed = 0;
+
+        /**
+         * This is an internal copy of the initial value of `this.alpha`, used to calculate the current alpha value of the fade effect.
+         *
+         * @name Phaser.Cameras.Scene2D.Effects.Flash#_alpha
+         * @type {number}
+         * @private
+         * @readonly
+         * @since 3.50.0
+         */
+        this._alpha;
 
         /**
          * This callback is invoked every frame for the duration of the effect.
@@ -191,8 +201,8 @@ var Flash = new Class({
         this.red = red;
         this.green = green;
         this.blue = blue;
-        this.alpha = 1;
 
+        this._alpha = this.alpha;
         this._elapsed = 0;
 
         this._onUpdate = callback;
@@ -230,7 +240,7 @@ var Flash = new Class({
 
         if (this._elapsed < this.duration)
         {
-            this.alpha = 1 - this.progress;
+            this.alpha = this._alpha * (1 - this.progress);
         }
         else
         {
@@ -304,6 +314,7 @@ var Flash = new Class({
      */
     effectComplete: function ()
     {
+        this._alpha = this.alpha
         this._onUpdate = null;
         this._onUpdateScope = null;
 


### PR DESCRIPTION
Adds a new feature:

Allow the overriding of `this.alpha` value for the camera flash effect. 

Previously the alpha value was always set to 1 in the update loop. This allows the user to set the `alpha` value on the camera effect before running it.

Ideally this would be a value you can pass in to the `start` function, but if that were the case I feel like it should go after the `blue` argument. I didn't know if this change warrants the breaking of any previous usage of this function, so I left it at this.

