### PR TITLE
Docs: correct CursorKeys

### DIFF
--- a/src/input/keyboard/typedefs/CursorKeys.js
+++ b/src/input/keyboard/typedefs/CursorKeys.js
@@ -1,11 +1,11 @@
 /**
  * @typedef {object} Phaser.Types.Input.Keyboard.CursorKeys
  * @since 3.0.0
- * 
- * @property {Phaser.Input.Keyboard.Key} [up] - A Key object mapping to the UP arrow key.
- * @property {Phaser.Input.Keyboard.Key} [down] - A Key object mapping to the DOWN arrow key.
- * @property {Phaser.Input.Keyboard.Key} [left] - A Key object mapping to the LEFT arrow key.
- * @property {Phaser.Input.Keyboard.Key} [right] - A Key object mapping to the RIGHT arrow key.
- * @property {Phaser.Input.Keyboard.Key} [space] - A Key object mapping to the SPACE BAR key.
- * @property {Phaser.Input.Keyboard.Key} [shift] - A Key object mapping to the SHIFT key.
+ *
+ * @property {Phaser.Input.Keyboard.Key} up - A Key object mapping to the UP arrow key.
+ * @property {Phaser.Input.Keyboard.Key} down - A Key object mapping to the DOWN arrow key.
+ * @property {Phaser.Input.Keyboard.Key} left - A Key object mapping to the LEFT arrow key.
+ * @property {Phaser.Input.Keyboard.Key} right - A Key object mapping to the RIGHT arrow key.
+ * @property {Phaser.Input.Keyboard.Key} space - A Key object mapping to the SPACE BAR key.
+ * @property {Phaser.Input.Keyboard.Key} shift - A Key object mapping to the SHIFT key.
  */


### PR DESCRIPTION
This PR

* Updates the Documentation

Its properties (`left`, `right`, etc.) are never undefined.

