### PR TITLE
Fix Group#getMatching()

### DIFF
--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -762,7 +762,7 @@ var Group = new Class({
      */
     getMatching: function (property, value, startIndex, endIndex)
     {
-        return GetAll(this.children, property, value, startIndex, endIndex);
+        return GetAll(this.children.entries, property, value, startIndex, endIndex);
     },
 
     /**


### PR DESCRIPTION
This PR

* Fixes a bug

It would always return `[]` (no matches).

