### PR TITLE
Add reserve property to particle emitter config

### DIFF
--- a/src/gameobjects/particles/ParticleEmitter.js
+++ b/src/gameobjects/particles/ParticleEmitter.js
@@ -863,6 +863,11 @@ var ParticleEmitter = new Class({
             this.setFrame(config.frame);
         }
 
+        if (HasValue(config, "reserve"))
+        {
+            this.reserve(config.reserve);
+        }
+
         return this;
     },
 

--- a/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
+++ b/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
@@ -48,7 +48,8 @@
  * @property {(Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType|Phaser.Types.GameObjects.Particles.EmitterOpOnUpdateType)} [tint] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#tint}.
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [x] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#x} (emit only).
  * @property {Phaser.Types.GameObjects.Particles.EmitterOpOnEmitType} [y] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#y} (emit only).
- * @property {object} [emitZone] - As {@link Phaser.GameObjects.Particles.ParticleEmitter#setEmitZone}.
+ * @property {Phaser.Types.GameObjects.Particles.ParticleEmitterEdgeZoneConfig | Phaser.Types.GameObjects.Particles.ParticleEmitterRandomZoneConfig} [emitZone] - As {@link Phaser.GameObjects.Particles.ParticleEmitter#setEmitZone}.
+ * @property {Phaser.Types.GameObjects.Particles.ParticleEmitterDeathZoneConfig} [deathZone] - As {@link Phaser.GameObjects.Particles.ParticleEmitter#setDeathZone}.
  * @property {Phaser.Types.GameObjects.Particles.ParticleEmitterBounds|Phaser.Types.GameObjects.Particles.ParticleEmitterBoundsAlt} [bounds] - As {@link Phaser.GameObjects.Particles.ParticleEmitter#setBounds}.
  * @property {object} [followOffset] - Assigns to {@link Phaser.GameObjects.Particles.ParticleEmitter#followOffset}.
  * @property {number} [followOffset.x] - x-coordinate of the offset.

--- a/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
+++ b/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
@@ -54,4 +54,5 @@
  * @property {number} [followOffset.x] - x-coordinate of the offset.
  * @property {number} [followOffset.y] - y-coordinate of the offset.
  * @property {number|number[]|string|string[]|Phaser.Textures.Frame|Phaser.Textures.Frame[]|Phaser.Types.GameObjects.Particles.ParticleEmitterFrameConfig} [frame] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#frames}.
+ * @property {integer} [reserve] - Creates specified number of inactive particles and adds them to this emitter's pool. {@link Phaser.GameObjects.Particles.ParticleEmitter#reserve}
  */

--- a/src/gameobjects/particles/typedefs/RandomZoneSourceCallback.js
+++ b/src/gameobjects/particles/typedefs/RandomZoneSourceCallback.js
@@ -2,5 +2,5 @@
  * @callback Phaser.Types.GameObjects.Particles.RandomZoneSourceCallback
  * @since 3.0.0
  *
- * @param {Phaser.Math.Vector2} point - A point to modify.
+ * @param {Phaser.Math.Vector2Like} point - A point to modify.
  */


### PR DESCRIPTION
This PR
* Updates the Documentation
* Adds a new feature


Describe the changes below:

Add reserve property to particle emitter config
We can configure emitter almost entirely via config so it makes sense to include `reserve` property. And code looks just a little bit better
```
particles.createEmitter({
	lifespan: 1000,
	speed: 100,
	reserve: 100,
})
		
// vs 
		
particles.createEmitter({
	lifespan: 1000,
	speed: 100,
}).reserve(100)
```
