### PR TITLE
Set maxVelocity in PhysicsGroupConfig

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1820,6 +1820,40 @@ var Body = new Class({
     },
 
     /**
+     * Sets the Body's maximum horizontal velocity.
+     *
+     * @method Phaser.Physics.Arcade.Body#setMaxVelocityX
+     * @since 3.50.0
+     *
+     * @param {number} value - The maximum horizontal velocity, in pixels per second.
+     *
+     * @return {Phaser.Physics.Arcade.Body} This Body object.
+     */
+    setMaxVelocityX: function (value)
+    {
+        this.maxVelocity.x = value;
+
+        return this;
+    },
+
+    /**
+     * Sets the Body's maximum vertical velocity.
+     *
+     * @method Phaser.Physics.Arcade.Body#setMaxVelocityY
+     * @since 3.50.0
+     *
+     * @param {number} value - The maximum vertical velocity, in pixels per second.
+     *
+     * @return {Phaser.Physics.Arcade.Body} This Body object.
+     */
+    setMaxVelocityY: function (value)
+    {
+        this.maxVelocity.y = value;
+
+        return this;
+    },
+
+    /**
      * Sets the maximum speed the Body can move.
      *
      * @method Phaser.Physics.Arcade.Body#setMaxSpeed

--- a/src/physics/arcade/PhysicsGroup.js
+++ b/src/physics/arcade/PhysicsGroup.js
@@ -145,6 +145,8 @@ var PhysicsGroup = new Class({
             setGravityY: GetFastValue(config, 'gravityY', 0),
             setFrictionX: GetFastValue(config, 'frictionX', 0),
             setFrictionY: GetFastValue(config, 'frictionY', 0),
+            setMaxVelocityX: GetFastValue(config, 'maxVelocityX', 10000),
+            setMaxVelocityY: GetFastValue(config, 'maxVelocityY', 10000),
             setVelocityX: GetFastValue(config, 'velocityX', 0),
             setVelocityY: GetFastValue(config, 'velocityY', 0),
             setAngularVelocity: GetFastValue(config, 'angularVelocity', 0),

--- a/src/physics/arcade/typedefs/PhysicsGroupConfig.js
+++ b/src/physics/arcade/typedefs/PhysicsGroupConfig.js
@@ -19,6 +19,8 @@
  * @property {number} [gravityY=0] - Sets {@link Phaser.Physics.Arcade.Body#gravity gravity.y}.
  * @property {number} [frictionX=0] - Sets {@link Phaser.Physics.Arcade.Body#friction friction.x}.
  * @property {number} [frictionY=0] - Sets {@link Phaser.Physics.Arcade.Body#friction friction.y}.
+ * @property {number} [maxVelocityX=10000] - Sets {@link Phaser.Physics.Arcade.Body#maxVelocity maxVelocity.x}.
+ * @property {number} [maxVelocityY=10000] - Sets {@link Phaser.Physics.Arcade.Body#maxVelocity maxVelocity.y}.
  * @property {number} [velocityX=0] - Sets {@link Phaser.Physics.Arcade.Body#velocity velocity.x}.
  * @property {number} [velocityY=0] - Sets {@link Phaser.Physics.Arcade.Body#velocity velocity.y}.
  * @property {number} [angularVelocity=0] - Sets {@link Phaser.Physics.Arcade.Body#angularVelocity}.


### PR DESCRIPTION
This PR

* Adds a new feature

- `maxVelocityX` and `maxVelocityY` to PhysicsGroupConfig
- Phaser.Physics.Arcade.Body#setMaxVelocityX()
- Phaser.Physics.Arcade.Body#setMaxVelocityY()
