### PR TITLE
Remove Arcade.Body#updateCenter() in Arcade.Body#setOffset()

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1252,7 +1252,6 @@ var Body = new Class({
         if (y === undefined) { y = x; }
 
         this.offset.set(x, y);
-        this.updateCenter();
 
         return this;
     },


### PR DESCRIPTION
Not really a bug, but `updateCenter()` there was unnecessary because `position` is still unchanged.