### PR TITLE
Fix drawing Group to RenderTexture

### DIFF
--- a/src/gameobjects/rendertexture/RenderTexture.js
+++ b/src/gameobjects/rendertexture/RenderTexture.js
@@ -983,7 +983,7 @@ var RenderTexture = new Class({
         {
             var entry = children[i];
 
-            if (entry.willRender())
+            if (entry.willRender(this.camera))
             {
                 var tx = entry.x + x;
                 var ty = entry.y + y;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Group children (generic GameObjects) expect a 'camera' argument
in their 'willRender' function; that was missing in RenderTexture.batchGroup().