### PR TITLE
fix: set light to dirty if culled

### DIFF
--- a/src/gameobjects/lights/LightsManager.js
+++ b/src/gameobjects/lights/LightsManager.js
@@ -170,6 +170,7 @@ var LightsManager = new Class({
 
             if (distance < light.radius + cameraRadius)
             {
+                lights[i].dirty = true;
                 culledLights.push(lights[i]);
             }
         }


### PR DESCRIPTION
This PR

Fixes culled lights that don't re render once they are not culled anymore.
Fixes #5287