### PR TITLE
Correct Arcade Body center after separations

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1231,6 +1231,7 @@ var Body = new Class({
         if (wasSet)
         {
             this.blocked.none = false;
+            this.updateCenter();
         }
 
         return wasSet;

--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -2331,6 +2331,8 @@ var Body = new Class({
     {
         this.x += x;
 
+        this.updateCenter();
+
         if (vx !== null)
         {
             this.velocity.x = vx;
@@ -2364,6 +2366,8 @@ var Body = new Class({
     processY: function (y, vy, up, down)
     {
         this.y += y;
+
+        this.updateCenter();
 
         if (vy !== null)
         {

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1466,9 +1466,6 @@ var World = new Class({
      */
     separateCircle: function (body1, body2, overlapOnly, bias)
     {
-        body1.updateCenter();
-        body2.updateCenter();
-
         //  Set the bounding box overlap values into the bodies themselves (hence we don't use the return values here)
         GetOverlapX(body1, body2, false, bias);
         GetOverlapY(body1, body2, false, bias);


### PR DESCRIPTION
This PR

* Fixes a bug

[Arcade.Body#center](https://photonstorm.github.io/phaser3-docs/Phaser.Physics.Arcade.Body.html#center) values were incorrect after collisions with the world bounds or (for rectangular bodies) after collisions with another body. I fixed that by updating the body center after those separations.

I also removed updating the body center **before** separating circles (#5202) because it should be unnecessary now.