### PR TITLE
Don't add white space when measure last word of a line

### DIFF
--- a/src/gameobjects/text/Text.js
+++ b/src/gameobjects/text/Text.js
@@ -520,7 +520,12 @@ var Text = new Class({
             {
                 var word = words[j];
                 var wordWidth = context.measureText(word).width;
-                var wordWidthWithSpace = wordWidth + whiteSpaceWidth;
+                var wordWidthWithSpace = wordWidth;
+
+                if (j < lastWordIndex)
+                {
+                    wordWidthWithSpace += whiteSpaceWidth;
+                }
 
                 if (wordWidthWithSpace > spaceLeft)
                 {


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

[Here](https://codepen.io/rexrainbow/pen/RwRGPRj) is a sample code of current basicWordWrap result.
I try to put wrapped content back to text game object and expect the render result is the same as previous one.

The issue is from adding an extra white space width when counting the width of last word of a line. Also, white space character won't be added to line string for last word, see [this logic](https://github.com/photonstorm/phaser/blob/master/src/gameobjects/text/Text.js#L538-L546)