### PR TITLE
Added loadMediaStream() method

### DIFF
--- a/src/gameobjects/video/Video.js
+++ b/src/gameobjects/video/Video.js
@@ -857,7 +857,67 @@ var Video = new Class({
 
         return this;
     },
+    
+    /**
+     * Loads a Video from the given MediaStream Object, ready for playback with the `Video.play` method.
+     *
+     * You can control at what point the browser determines the video as being ready for playback via
+     * the `loadEvent` parameter. See https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement
+     * for more details.
+     *
+     * @method Phaser.GameObjects.Video#loadMediaStream
+     * @since 3.20.0
+     *
+     * @param {string} stream - The MediaStream Object.
+     * @param {string} [loadEvent='loadeddata'] - The load event to listen for. Either `loadeddata`, `canplay` or `canplaythrough`.
+     * @param {boolean} [noAudio=false] - Does the video have an audio track? If not you can enable auto-playing on it.
+     *
+     * @return {this} This Video Game Object for method chaining.
+     */
+    loadMediaStream: function(stream, loadEvent, noAudio) {
+        if (loadEvent === undefined) { loadEvent = 'loadeddata'; }
+        if (noAudio === undefined) { noAudio = false; }
 
+        if (this.video)
+        {
+            this.stop();
+        }
+
+        if (this.videoTexture)
+        {
+            this.scene.sys.textures.remove(this._key);
+        }
+
+        var video = document.createElement('video');
+
+        video.controls = false;
+
+        if (noAudio)
+        {
+            video.muted = true;
+            video.defaultMuted = true;
+
+            video.setAttribute('autoplay', 'autoplay');
+        }
+
+        video.setAttribute('playsinline', 'playsinline');
+        video.setAttribute('preload', 'auto');
+
+        video.addEventListener('error', this._callbacks.error, true);
+        
+        try {
+            this.srcObject = stream;
+        } catch (error) {
+            this.src = window.URL.createObjectURL(stream);
+        }
+
+        video.load();
+
+        this.video = video;
+
+        return this;
+    },
+    
     /**
      * This internal method is called automatically if the playback Promise resolves successfully.
      *


### PR DESCRIPTION
This PR
* Adds a new feature

Describe the changes below:
* Added a new method **loadMediaStream** which takes parameter stream, loadEvent, and noAudio. Here, the stream is the _**MediaStream**_ Object.
* This will allow us to load the video directly from the **_MediaStream_** object **instead of using a URL (like loadURL method)** thus will be helpful to load a video being streamed from a webcam.
* As, _**window.URL.createObjectURL()**_ has been **deprecated**, so, instead of using **video.src = window.URL.createObjectURL(stream)**, this method uses **video.srcObject = stream**.
