### PR TITLE
Updates geom, width and height of the Ellipse GO

### DIFF
--- a/src/gameobjects/shape/ellipse/Ellipse.js
+++ b/src/gameobjects/shape/ellipse/Ellipse.js
@@ -125,6 +125,9 @@ var Ellipse = new Class({
      */
     setSize: function (width, height)
     {
+        this.width = width;
+        this.height = height;
+        this.geom.setPosition(width / 2, height / 2);
         this.geom.setSize(width, height);
 
         return this.updateData();


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Updates the `width`, `height`, and geometric position of the Ellipse in the `setSize()` method.

This code shows the wrong positioning of the Ellipse: https://codepen.io/phasereditor2d/pen/jOrvexM

To fix it, uncomment lines `21`, `24`, and `25`.


