### PR TITLE
Scale damping by the physics step delta

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -335,10 +335,11 @@ var Body = new Class({
         /**
          * When `useDamping` is false (the default), this is absolute loss of velocity due to movement, in pixels per second squared.
          *
-         * When `useDamping` is true, this is 1 minus the damping factor.
+         * When `useDamping` is true, this is a damping multiplier between 0 and 1.
+         * A value of 0 means the Body stops instantly.
+         * A value of 0.01 mean the Body loses 99% of its velocity per second.
+         * A value of 0.1 means the Body loses 90% of its velocity per second.
          * A value of 1 means the Body loses no velocity.
-         * A value of 0.95 means the Body loses 5% of its velocity per step.
-         * A value of 0.5 means the Body loses 50% of its velocity per step.
          *
          * The x and y components are applied separately.
          *
@@ -486,8 +487,8 @@ var Body = new Class({
          * by using damping, avoiding the axis-drift that is prone with linear deceleration.
          *
          * If you enable this property then you should use far smaller `drag` values than with linear, as
-         * they are used as a multiplier on the velocity. Values such as 0.95 will give a nice slow
-         * deceleration, where-as smaller values, such as 0.5 will stop an object almost immediately.
+         * they are used as a multiplier on the velocity. Values such as 0.05 will give a nice slow
+         * deceleration.
          *
          * @name Phaser.Physics.Arcade.Body#useDamping
          * @type {boolean}

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1248,6 +1248,7 @@ var World = new Class({
             if (useDamping)
             {
                 //  Damping based deceleration
+                dragX = Math.pow(dragX, delta);
 
                 velocityX *= dragX;
 
@@ -1287,6 +1288,8 @@ var World = new Class({
             if (useDamping)
             {
                 //  Damping based deceleration
+                dragY = Math.pow(dragY, delta);
+
                 velocityY *= dragY;
 
                 speed = Math.sqrt(velocityX * velocityX + velocityY * velocityY);


### PR DESCRIPTION
This PR

* Adds a new feature

This redefines [Arcade.Body#drag](https://photonstorm.github.io/phaser3-docs/Phaser.Physics.Arcade.Body.html#drag) when [damping](https://photonstorm.github.io/phaser3-docs/Phaser.Physics.Arcade.Body.html#damping) is used and scales the damping multiplier by the physics step delta. Drag is now velocity retained after 1 second instead of after 1 step, when damping is used.

Purpose is to make damping consistent for different physics step rates and more accurate when `fixedStep` is off (#5356).

Authors will need to change any existing drag values to get the same effects as before. Convert `drag` to `drag ^ 60` or `drag ^ fps` if you use a different step rate.

Closes #5356.
