### PR TITLE
Set Arcade.Body#overlapR in separateCircle()

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1518,6 +1518,9 @@ var World = new Class({
             overlap = (body1.halfWidth + body2.halfWidth) - DistanceBetween(body1.center.x, body1.center.y, body2.center.x, body2.center.y);
         }
 
+        body1.overlapR = overlap;
+        body2.overlapR = overlap;
+
         //  Can't separate two immovable bodies, or a body with its own custom separation logic
         if (overlapOnly || overlap === 0 || (body1.immovable && body2.immovable) || body1.customSeparateX || body2.customSeparateX)
         {


### PR DESCRIPTION
This PR

* Fixes a bug

[Arcade.Body#overlapR](https://photonstorm.github.io/phaser3-docs/Phaser.Physics.Arcade.Body.html#overlapR) wasn't set during collisions.

