### PR TITLE
Implemented reading WebGL texture dimensions automatically when adding them to the TextureManager

### DIFF
--- a/src/textures/TextureManager.js
+++ b/src/textures/TextureManager.js
@@ -390,6 +390,9 @@ var TextureManager = new Class({
      *
      * This allows you to then use the Texture as a normal texture for texture based Game Objects like Sprites.
      *
+     * If the `width` and `height` arguments are omitted, but the WebGL Texture was created by Phaser's WebGL Renderer
+     * and has `glTexture.width` and `glTexture.height` properties, these values will be used instead.
+     *
      * This is a WebGL only feature.
      *
      * @method Phaser.Textures.TextureManager#addGLTexture
@@ -398,8 +401,8 @@ var TextureManager = new Class({
      *
      * @param {string} key - The unique string-based key of the Texture.
      * @param {WebGLTexture} glTexture - The source Render Texture.
-     * @param {number} width - The new width of the Texture.
-     * @param {number} height - The new height of the Texture.
+     * @param {number} [width] - The new width of the Texture. Read from `glTexture.width` if omitted.
+     * @param {number} [height] - The new height of the Texture. Read from `glTexture.height` if omitted.
      *
      * @return {?Phaser.Textures.Texture} The Texture that was created, or `null` if the key is already in use.
      */
@@ -409,6 +412,9 @@ var TextureManager = new Class({
 
         if (this.checkKey(key))
         {
+            if (width === undefined) { width = glTexture.width };
+            if (height === undefined) { height = glTexture.height };
+
             texture = this.create(key, glTexture, width, height);
 
             texture.add('__BASE', 0, 0, 0, width, height);


### PR DESCRIPTION
This PR adds a new feature. 

While taking 3.50.0-beta10 for a spin, I ran into a "gotcha" when attempting to reuse custom-generated WebGL textures from a custom pipeline of mine. When calling `this.textures.addGLTexture('texture', glTexture);` from my scene, and attempting to use this texture for a sprite, it wouldn't display, yet I saw no errors.

I finally noticed, after scratching my head and reading the docs more clearly, that `width` and `height` were required parameters for this method. This makes sense, because it's not possible to query GLES 2 for the width or height of a texture in any way. However, having worked closely with custom pipelines in Phaser 3 this year, I recalled that Phaser's WebGL Renderer attaches its own properties to the native `WebGLTexture` objects when it creates them.

While augmenting browser-native objects like this is discouraged by some, in this case I think it's very useful for the `TextureManager#addGLTexture()` method and Phaser itself. 

This PR changes `TextureManager#addGLTexture()` to read `glTexture.width` and `glTexture.height` if the `width` and `height` parameters have no arguments, respectively. This means that adding a Phaser-created WebGL texture to the `TextureManager` can look like this:

```js
this.textures.addGLTexture('texture', glTexture);
```

Instead of either of these:

```js
this.textures.addGLTexture('texture', glTexture, width, height);
this.textures.addGLTexture('texture', glTexture, glTexture.width, glTexture.height);
```

The behaviour should be the same if `glTexture.width` and `glTexture.height` properties are `undefined`.