### PR TITLE
Remove a type of Post Pipeline instances, not only a single instance

### DIFF
--- a/src/gameobjects/components/Pipeline.js
+++ b/src/gameobjects/components/Pipeline.js
@@ -341,7 +341,7 @@ var Pipeline = {
     },
 
     /**
-     * Removes a single Post Pipeline instance from this Game Object, based on the given name, and destroys it.
+     * Removes a type of Post Pipeline instances from this Game Object, based on the given name, and destroys them.
      *
      * If you wish to remove all Post Pipelines use the `resetPostPipeline` method instead.
      *
@@ -357,7 +357,7 @@ var Pipeline = {
     {
         var pipelines = this.postPipelines;
 
-        for (var i = 0; i < pipelines.length; i++)
+        for (var i = pipelines.length - 1; i >= 0; i--)
         {
             var instance = pipelines[i];
 
@@ -368,10 +368,10 @@ var Pipeline = {
                 instance.destroy();
 
                 SpliceOne(pipelines, i);
-
-                return this;
             }
         }
+
+        this.hasPostPipeline = (this.postPipelines.length > 0);
 
         return this;
     },


### PR DESCRIPTION
This PR (delete as applicable)

* Adds a new feature/bug fix

Describe the changes below:

A post-fix pipeline class can be added to game object many times, via different instances.

Previously, `removePostPipeline(pipelineClass)` method only removes a single pipeline instance. It won't clear all instances of pipelineClass. This PR will remove all instances of pipelineClass.

