### PR TITLE
Check event.type in duplicate event bailout

### DIFF
--- a/src/input/keyboard/KeyboardPlugin.js
+++ b/src/input/keyboard/KeyboardPlugin.js
@@ -167,6 +167,16 @@ var KeyboardPlugin = new Class({
          */
         this.prevTime = 0;
 
+        /**
+         * Internal repeat key flag.
+         *
+         * @name Phaser.Input.Keyboard.KeyboardPlugin#prevType
+         * @type {string}
+         * @private
+         * @since 3.50.1
+         */
+        this.prevType = null;
+
         sceneInputPlugin.pluginEvents.once(InputEvents.BOOT, this.boot, this);
         sceneInputPlugin.pluginEvents.on(InputEvents.START, this.start, this);
     },

--- a/src/input/keyboard/KeyboardPlugin.js
+++ b/src/input/keyboard/KeyboardPlugin.js
@@ -747,7 +747,7 @@ var KeyboardPlugin = new Class({
             }
 
             //  Duplicate event bailout
-            if (code === this.prevCode && event.timeStamp === this.prevTime)
+            if (code === this.prevCode && event.timeStamp === this.prevTime && event.type === this.prevType)
             {
                 //  On some systems, the exact same event will fire multiple times. This prevents it.
                 continue;
@@ -755,6 +755,7 @@ var KeyboardPlugin = new Class({
 
             this.prevCode = code;
             this.prevTime = event.timeStamp;
+            this.prevType = event.type;
 
             if (event.type === 'keydown')
             {


### PR DESCRIPTION
Fixes #5471.

Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
Check that the current key event type is the same type as the previous event event, before bailing out of event processing.