### PR TITLE
fixed spine texture bug when using prefixes

### DIFF
--- a/plugins/spine/src/SpineFile.js
+++ b/plugins/spine/src/SpineFile.js
@@ -176,7 +176,7 @@ var SpineFile = new Class({
                 {
                     var textureURL = textures[i];
 
-                    var key = this.prefix + textureURL;
+                    var key = textureURL;
 
                     var image = new ImageFile(loader, key, textureURL, textureXhrSettings);
 


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

When using an asset pack with a prefix, and loading a spine file, the prefix gets appended twice since it was added manually here (the loader already appends the prefix).

example asset pack, with testasset.png referenced by the .atlas:
```
{
    "scenePack": {
        "prefix": "testpack-",
        "files": [
            {
                "type": "spine",
                "key": "testasset",
                "jsonURL": "assets/testasset.json",
                "atlasURL": "assets/testasset.atlas"
            }
        ]
    },
}

```

This results in the spine missing textures at runtime, because the spine plugin searches the texture cache for "testpack-testpack-testasset.png" instead of "testpack-testasset.png".
