### PR TITLE
added null check for WebAudio pannerNode

### DIFF
--- a/src/sound/webaudio/WebAudioSound.js
+++ b/src/sound/webaudio/WebAudioSound.js
@@ -512,8 +512,10 @@ var WebAudioSound = new Class({
         this.muteNode = null;
         this.volumeNode.disconnect();
         this.volumeNode = null;
-        this.pannerNode.disconnect();
-        this.pannerNode = null;
+        if (this.pannerNode) {
+            this.pannerNode.disconnect();
+            this.pannerNode = null;
+        }
         this.rateUpdates.length = 0;
         this.rateUpdates = null;
     },


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:
Added a null check for pannerNode in WebAudio on destroy. This was throwing an error in Safari, since pannerNode is null.
