### PR TITLE
Fix typo in GenerateVerts.js

### DIFF
--- a/src/geom/mesh/GenerateVerts.js
+++ b/src/geom/mesh/GenerateVerts.js
@@ -79,7 +79,7 @@ var GenerateVerts = function (vertices, uvs, indicies, containsZ, normals, color
 
     var result = {
         faces: [],
-        verts: []
+        vertices: []
     };
 
     var i;
@@ -132,7 +132,7 @@ var GenerateVerts = function (vertices, uvs, indicies, containsZ, normals, color
                 normalZ = (containsZ) ? normals[index3 + 2] : 0;
             }
 
-            result.verts.push(new Vertex(x, y, z, u, v, color, alpha, normalX, normalY, normalZ));
+            result.vertices.push(new Vertex(x, y, z, u, v, color, alpha, normalX, normalY, normalZ));
         }
     }
     else
@@ -163,18 +163,18 @@ var GenerateVerts = function (vertices, uvs, indicies, containsZ, normals, color
                 normalZ = (containsZ) ? normals[i + 2] : 0;
             }
 
-            result.verts.push(new Vertex(x, y, z, u, v, color, alpha, normalX, normalY, normalZ));
+            result.vertices.push(new Vertex(x, y, z, u, v, color, alpha, normalX, normalY, normalZ));
 
             uvIndex += 2;
             colorIndex++;
         }
     }
 
-    for (i = 0; i < result.verts.length; i += 3)
+    for (i = 0; i < result.vertices.length; i += 3)
     {
-        var vert1 = result.verts[i];
-        var vert2 = result.verts[i + 1];
-        var vert3 = result.verts[i + 2];
+        var vert1 = result.vertices[i];
+        var vert2 = result.vertices[i + 1];
+        var vert3 = result.vertices[i + 2];
 
         result.faces.push(new Face(vert1, vert2, vert3));
     }

--- a/src/geom/mesh/typedefs/GenerateVertsResult.js
+++ b/src/geom/mesh/typedefs/GenerateVertsResult.js
@@ -3,5 +3,5 @@
  * @since 3.50.0
  *
  * @property {Phaser.Geom.Mesh.Face[]} faces - An array of Face objects generated from the OBJ Data.
- * @property {Phaser.Geom.Mesh.Vertex[]} verts - An array of Vertex objects generated from the OBJ Data.
+ * @property {Phaser.Geom.Mesh.Vertex[]} vertices - An array of Vertex objects generated from the OBJ Data.
  */


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

The result contains `["verts"]`, but the caller expects [`["vertices"]`](https://github.com/photonstorm/phaser/blob/d67c93646cbfe8ba5997954f8af29a8f3f9e8e91/src/gameobjects/mesh/Mesh.js#L705). Better to expand the field name (IMO).
