### PR TITLE
Transparent background for banner gameURL

### DIFF
--- a/src/core/DebugHeader.js
+++ b/src/core/DebugHeader.js
@@ -83,8 +83,8 @@ var DebugHeader = function (game)
             args.push('color: ' + config.bannerTextColor + '; background: ' + config.bannerBackgroundColor);
         }
 
-        //  URL link background color (always white)
-        args.push('background: #fff');
+        //  URL link background color (always transparent to support different browser themes)
+        args.push('background: transparent');
 
         if (config.gameTitle)
         {


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

Use transparent background for banner gameURL to support different browser color themes.
Currently, when using a dark theme for the dev console, both the background and the text are white.