### PR TITLE
Move webpack loaders to dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
     "dts-dom": "^3.6.0",
     "eslint": "^7.11.0",
     "eslint-plugin-es5": "^1.5.0",
+    "exports-loader": "^1.1.1",
     "fs-extra": "^9.0.1",
+    "imports-loader": "^1.2.0",
     "jsdoc": "^3.6.6",
     "node-sloc": "^0.1.12",
     "remove-files-webpack-plugin": "^1.4.4",
@@ -83,8 +85,6 @@
   },
   "dependencies": {
     "eventemitter3": "^4.0.7",
-    "exports-loader": "^1.1.1",
-    "imports-loader": "^1.2.0",
     "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:
Moves webpack loaders (exports-loader & imports-loader) to devDependencies. Being in the runtime dependencies meant that Phaser ended up with webpack as a peer dependency, and that was causing problems for me, at least when using PNPM.
This wasn't an issue before 3.50.0, because the versions of the two loaders in use weren't declaring their peer dependency yet.
