### PR TITLE
Fix typing of MapData objects

### DIFF
--- a/src/tilemaps/mapdata/MapData.js
+++ b/src/tilemaps/mapdata/MapData.js
@@ -173,10 +173,10 @@ var MapData = new Class({
          * An object of Tiled Object Layers.
          *
          * @name Phaser.Tilemaps.MapData#objects
-         * @type {object}
+         * @type {Phaser.Types.Tilemaps.ObjectLayerConfig[]}
          * @since 3.0.0
          */
-        this.objects = GetFastValue(config, 'objects', {});
+        this.objects = GetFastValue(config, 'objects', []);
 
         /**
           * An object of collision data. Must be created as physics object or will return undefined.


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation

Describe the changes below:

I believe that objects is going to be an array as the result of calling this function: https://github.com/photonstorm/phaser/blob/7834095789fd3ac24ee0146e65eefa096b22b1d6/src/tilemaps/parsers/tiled/ParseObjectLayers.js#L20

I'm not 100% sure on the type of the array elements (Phaser.Types.Tilemaps.ObjectLayerConfig), but that appears to be what ParseObjectLayers returns.
