### PR TITLE
Load Tiled object properties using names.

### DIFF
--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -831,15 +831,34 @@ var Tilemap = new Class({
                 }
 
                 //  Set properties the class may have, or setData those it doesn't
-                for (var key in obj.properties)
+                if (Array.isArray(obj.properties))
                 {
-                    if (sprite[key] !== undefined)
+                    // Tiled objects custom properties format
+                    obj.properties.forEach(function (propData)
                     {
-                        sprite[key] = obj.properties[key];
-                    }
-                    else
+                        var key = propData['name'];
+                        if (sprite[key] !== undefined)
+                        {
+                            sprite[key] = propData['value'];
+                        }
+                        else
+                        {
+                            sprite.setData(key, propData['value']);
+                        }
+                    });
+                }
+                else
+                {
+                    for (var key in obj.properties)
                     {
-                        sprite.setData(key, obj.properties[key]);
+                        if (sprite[key] !== undefined)
+                        {
+                            sprite[key] = obj.properties[key];
+                        }
+                        else
+                        {
+                            sprite.setData(key, obj.properties[key]);
+                        }
                     }
                 }
 


### PR DESCRIPTION
This PR 

* Fixes a bug

Describe the changes below:

Tiled objects have properties as an array of objects like:

```
[
  { name: ..., type: ..., value: ...},
  { name: ..., type: ..., value: ...},
  ...
]
```

Update the parser to load these using the name/value properties instead
of just treating it as an array and loading properties named '0', '1',
etc.  This is the same as how properties are handled in ParseTilesets.js