### PR TITLE
Fix IsometricWorldToTileXY result

### DIFF
--- a/src/tilemaps/components/IsometricWorldToTileXY.js
+++ b/src/tilemaps/components/IsometricWorldToTileXY.js
@@ -50,8 +50,6 @@ var IsometricWorldToTileXY = function (worldX, worldY, snapToFloor, point, camer
         tileWidth *= tilemapLayer.scaleX;
     }
 
-    worldX -= tileWidth / 2;
-
     var x = (snapToFloor) ? Math.floor((worldX / (tileWidth / 2) + worldY / (tileHeight / 2)) / 2) : ((worldX / (tileWidth / 2) + worldY / (tileHeight / 2)) / 2);
     var y = (snapToFloor) ? Math.floor((worldY / (tileHeight / 2) - worldX / (tileWidth / 2)) / 2) : ((worldY / (tileHeight / 2) - worldX / (tileWidth / 2)) / 2);
 


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

IsometricWorldToTileXY returns a tile that is offset by (-0.5, 0.5)
tiles from the expected location.  This fixes the function so that
Tile => World => Tile conversion returns the same value.