### PR TITLE
Allow non-zero `min` in `FromPercent`

### DIFF
--- a/src/math/FromPercent.js
+++ b/src/math/FromPercent.js
@@ -22,7 +22,7 @@ var FromPercent = function (percent, min, max)
 {
     percent = Clamp(percent, 0, 1);
 
-    return (max - min) * percent;
+    return (max - min) * percent + min;
 };
 
 module.exports = FromPercent;


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

`FromPercent` silently assumed `min` to be 0.
E.g.: `FromPercent(1, 0, 200)` correctly gives 200, but `FromPercent(1, 100, 200)` wrongly gives 100 instead of the correct 200.

Shifting the result by
`min` makes it work as documented and gives a value between `min` and
`max`.

Phaser's uses of `FromPercent` only have `min` at 0, so there is no
regression in our code. This is merely a fix for 3rd party users.

