### PR TITLE
Add Phaser.GameObjects.Shape#setDisplaySize()

### DIFF
--- a/src/gameobjects/shape/Shape.js
+++ b/src/gameobjects/shape/Shape.js
@@ -328,6 +328,27 @@ var Shape = new Class({
     },
 
     /**
+     * Sets the display size of this Shape.
+     *
+     * Calling this will adjust the scale.
+     *
+     * @method Phaser.GameObjects.Shape#setDisplaySize
+     * @since 3.53.0
+     *
+     * @param {number} width - The display width of this Shape.
+     * @param {number} height - The display height of this Shape.
+     *
+     * @return {this} This Shape instance.
+     */
+    setDisplaySize: function (width, height)
+    {
+        this.displayWidth = width;
+        this.displayHeight = height;
+
+        return this;
+    },
+
+    /**
      * Internal destroy handler, called as part of the destroy process.
      *
      * @method Phaser.GameObjects.Shape#preDestroy


### PR DESCRIPTION
This PR

* Adds a new feature

This is a new helper method for setting [Shape#displayHeight](https://photonstorm.github.io/phaser3-docs/Phaser.GameObjects.Shape.html#displayHeight) and [Shape#displayWidth](https://photonstorm.github.io/phaser3-docs/Phaser.GameObjects.Shape.html#displayWidth).

Closes #5526 

