### PR TITLE
Add Phaser.Scenes.Events.PRE_RENDER event

### DIFF
--- a/src/scene/Systems.js
+++ b/src/scene/Systems.js
@@ -391,6 +391,7 @@ var Systems = new Class({
      * Instructs the Scene to render itself via its Camera Manager to the renderer given.
      *
      * @method Phaser.Scenes.Systems#render
+     * @fires Phaser.Scenes.Events#PRE_RENDER
      * @fires Phaser.Scenes.Events#RENDER
      * @since 3.0.0
      *
@@ -401,6 +402,8 @@ var Systems = new Class({
         var displayList = this.displayList;
 
         displayList.depthSort();
+
+        this.events.emit(Events.PRE_RENDER, renderer);
 
         this.cameras.render(renderer, displayList);
 

--- a/src/scene/events/POST_UPDATE_EVENT.js
+++ b/src/scene/events/POST_UPDATE_EVENT.js
@@ -15,8 +15,9 @@
  * 2. [UPDATE]{@linkcode Phaser.Scenes.Events#event:UPDATE}
  * 3. The `Scene.update` method is called, if it exists
  * 4. [POST_UPDATE]{@linkcode Phaser.Scenes.Events#event:POST_UPDATE}
- * 5. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
- * 
+ * 5. [PRE_RENDER]{@linkcode Phaser.Scenes.Events#event:PRE_RENDER}
+ * 6. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
+ *
  * Listen to it from a Scene using `this.scene.events.on('postupdate', listener)`.
  * 
  * A Scene will only run its step if it is active.

--- a/src/scene/events/PRE_RENDER_EVENT.js
+++ b/src/scene/events/PRE_RENDER_EVENT.js
@@ -1,0 +1,31 @@
+/**
+ * @author       samme
+ * @copyright    2021 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+/**
+ * The Scene Systems Pre-Render Event.
+ *
+ * This event is dispatched by a Scene during the main game loop step.
+ *
+ * The event flow for a single step of a Scene is as follows:
+ *
+ * 1. [PRE_UPDATE]{@linkcode Phaser.Scenes.Events#event:PRE_UPDATE}
+ * 2. [UPDATE]{@linkcode Phaser.Scenes.Events#event:UPDATE}
+ * 3. The `Scene.update` method is called, if it exists
+ * 4. [POST_UPDATE]{@linkcode Phaser.Scenes.Events#event:POST_UPDATE}
+ * 5. [PRE_RENDER]{@linkcode Phaser.Scenes.Events#event:PRE_RENDER}
+ * 6. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
+ *
+ * Listen to this event from a Scene using `this.scene.events.on('prerender', listener)`.
+ *
+ * A Scene will only render if it is visible.
+ * This event is dispatched after the Scene Display List is sorted and before the Scene is rendered.
+ *
+ * @event Phaser.Scenes.Events#PRE_RENDER
+ * @since 3.53.0
+ *
+ * @param {(Phaser.Renderer.Canvas.CanvasRenderer|Phaser.Renderer.WebGL.WebGLRenderer)} renderer - The renderer that rendered the Scene.
+ */
+module.exports = 'prerender';

--- a/src/scene/events/PRE_UPDATE_EVENT.js
+++ b/src/scene/events/PRE_UPDATE_EVENT.js
@@ -15,8 +15,9 @@
  * 2. [UPDATE]{@linkcode Phaser.Scenes.Events#event:UPDATE}
  * 3. The `Scene.update` method is called, if it exists
  * 4. [POST_UPDATE]{@linkcode Phaser.Scenes.Events#event:POST_UPDATE}
- * 5. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
- * 
+ * 5. [PRE_RENDER]{@linkcode Phaser.Scenes.Events#event:PRE_RENDER}
+ * 6. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
+ *
  * Listen to it from a Scene using `this.scene.events.on('preupdate', listener)`.
  * 
  * A Scene will only run its step if it is active.

--- a/src/scene/events/RENDER_EVENT.js
+++ b/src/scene/events/RENDER_EVENT.js
@@ -15,11 +15,12 @@
  * 2. [UPDATE]{@linkcode Phaser.Scenes.Events#event:UPDATE}
  * 3. The `Scene.update` method is called, if it exists
  * 4. [POST_UPDATE]{@linkcode Phaser.Scenes.Events#event:POST_UPDATE}
- * 5. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
- * 
+ * 5. [PRE_RENDER]{@linkcode Phaser.Scenes.Events#event:PRE_RENDER}
+ * 6. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
+ *
  * Listen to it from a Scene using `this.scene.events.on('render', listener)`.
- * 
- * A Scene will only render if it is visible and active.
+ *
+ * A Scene will only render if it is visible.
  * By the time this event is dispatched, the Scene will have already been rendered.
  * 
  * @event Phaser.Scenes.Events#RENDER

--- a/src/scene/events/UPDATE_EVENT.js
+++ b/src/scene/events/UPDATE_EVENT.js
@@ -15,8 +15,9 @@
  * 2. [UPDATE]{@linkcode Phaser.Scenes.Events#event:UPDATE}
  * 3. The `Scene.update` method is called, if it exists
  * 4. [POST_UPDATE]{@linkcode Phaser.Scenes.Events#event:POST_UPDATE}
- * 5. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
- * 
+ * 5. [PRE_RENDER]{@linkcode Phaser.Scenes.Events#event:PRE_RENDER}
+ * 6. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
+ *
  * Listen to it from a Scene using `this.scene.events.on('update', listener)`.
  * 
  * A Scene will only run its step if it is active.

--- a/src/scene/events/index.js
+++ b/src/scene/events/index.js
@@ -16,6 +16,7 @@ module.exports = {
     DESTROY: require('./DESTROY_EVENT'),
     PAUSE: require('./PAUSE_EVENT'),
     POST_UPDATE: require('./POST_UPDATE_EVENT'),
+    PRE_RENDER: require('./PRE_RENDER_EVENT'),
     PRE_UPDATE: require('./PRE_UPDATE_EVENT'),
     READY: require('./READY_EVENT'),
     REMOVED_FROM_SCENE: require('./REMOVED_FROM_SCENE_EVENT'),


### PR DESCRIPTION
This PR

* Updates the Documentation
* Adds a new feature

PRE_RENDER is a new event fired after the display list is sorted and before the scene is rendered, only for visible scenes.

Closes #5536 

