### PR TITLE
Warn and call onProcessError() for invalid JSON

### DIFF
--- a/src/loader/filetypes/JSONFile.js
+++ b/src/loader/filetypes/JSONFile.js
@@ -98,7 +98,18 @@ var JSONFile = new Class({
         {
             this.state = CONST.FILE_PROCESSING;
 
-            var json = JSON.parse(this.xhrLoader.responseText);
+            try
+            {
+                var json = JSON.parse(this.xhrLoader.responseText);
+            }
+            catch (e)
+            {
+                console.warn('Invalid JSON: ' + this.key);
+
+                this.onProcessError();
+
+                throw e;
+            }
 
             var key = this.config;
 


### PR DESCRIPTION
This PR

* Adds a new feature
* Fixes a bug

New: when a loaded JSON file fails to parse, there's a console warning with the file key. Without this it was difficult to find which file failed.

Fixed: when a loaded JSON file fails to parse, it's marked [FILE_ERRORED](https://photonstorm.github.io/phaser3-docs/Phaser.Loader.html#.FILE_ERRORED) and the loader continues. Before this change the loader would stall.

