### PR TITLE
Add min and max zoom to camera controls

### DIFF
--- a/src/cameras/controls/FixedKeyControl.js
+++ b/src/cameras/controls/FixedKeyControl.js
@@ -120,6 +120,26 @@ var FixedKeyControl = new Class({
         this.zoomSpeed = GetValue(config, 'zoomSpeed', 0.01);
 
         /**
+         * The smallest zoom value the camera will reach when zoomed out.
+         *
+         * @name Phaser.Cameras.Controls.FixedKeyControl#minZoom
+         * @type {number}
+         * @default 0.001
+         * @since 3.53.0
+         */
+        this.minZoom = GetValue(config, 'minZoom', 0.001);
+
+        /**
+         * The largest zoom value the camera will reach when zoomed in.
+         *
+         * @name Phaser.Cameras.Controls.FixedKeyControl#maxZoom
+         * @type {number}
+         * @default 1000
+         * @since 3.53.0
+         */
+        this.maxZoom = GetValue(config, 'maxZoom', 1000);
+
+        /**
          * The horizontal speed the camera will move.
          *
          * @name Phaser.Cameras.Controls.FixedKeyControl#speedX
@@ -265,14 +285,19 @@ var FixedKeyControl = new Class({
         {
             cam.zoom -= this.zoomSpeed;
 
-            if (cam.zoom < 0.1)
+            if (cam.zoom < this.minZoom)
             {
-                cam.zoom = 0.1;
+                cam.zoom = this.minZoom;
             }
         }
         else if (this.zoomOut && this.zoomOut.isDown)
         {
             cam.zoom += this.zoomSpeed;
+
+            if (cam.zoom > this.maxZoom)
+            {
+                cam.zoom = this.maxZoom;
+            }
         }
     },
 

--- a/src/cameras/controls/SmoothedKeyControl.js
+++ b/src/cameras/controls/SmoothedKeyControl.js
@@ -29,7 +29,7 @@ var GetValue = require('../../utils/object/GetValue');
  *     maxSpeed: 1.0
  * };
  * ```
- * 
+ *
  * You must call the `update` method of this controller every frame.
  *
  * @class SmoothedKeyControl
@@ -124,6 +124,26 @@ var SmoothedKeyControl = new Class({
          * @since 3.0.0
          */
         this.zoomSpeed = GetValue(config, 'zoomSpeed', 0.01);
+
+        /**
+         * The smallest zoom value the camera will reach when zoomed out.
+         *
+         * @name Phaser.Cameras.Controls.SmoothedKeyControl#minZoom
+         * @type {number}
+         * @default 0.001
+         * @since 3.53.0
+         */
+        this.minZoom = GetValue(config, 'minZoom', 0.001);
+
+        /**
+         * The largest zoom value the camera will reach when zoomed in.
+         *
+         * @name Phaser.Cameras.Controls.SmoothedKeyControl#maxZoom
+         * @type {number}
+         * @default 1000
+         * @since 3.53.0
+         */
+        this.maxZoom = GetValue(config, 'maxZoom', 1000);
 
         /**
          * The horizontal acceleration the camera will move.
@@ -446,9 +466,13 @@ var SmoothedKeyControl = new Class({
         {
             cam.zoom += this._zoom;
 
-            if (cam.zoom < 0.001)
+            if (cam.zoom < this.minZoom)
             {
-                cam.zoom = 0.001;
+                cam.zoom = this.minZoom;
+            }
+            else if (cam.zoom > this.maxZoom)
+            {
+                cam.zoom = this.maxZoom;
             }
         }
     },

--- a/src/cameras/controls/typedefs/FixedKeyControlConfig.js
+++ b/src/cameras/controls/typedefs/FixedKeyControlConfig.js
@@ -11,4 +11,6 @@
  * @property {Phaser.Input.Keyboard.Key} [zoomOut] - The Key to be pressed that will zoom the Camera out.
  * @property {number} [zoomSpeed=0.01] - The speed at which the camera will zoom if the `zoomIn` or `zoomOut` keys are pressed.
  * @property {(number|{x:number,y:number})} [speed=0] - The horizontal and vertical speed the camera will move.
+ * @property {number} [minZoom=0.001] - The smallest zoom value the camera will reach when zoomed out.
+ * @property {number} [maxZoom=1000] - The largest zoom value the camera will reach when zoomed in.
  */

--- a/src/cameras/controls/typedefs/SmoothedKeyControlConfig.js
+++ b/src/cameras/controls/typedefs/SmoothedKeyControlConfig.js
@@ -13,4 +13,6 @@
  * @property {(number|{x:number,y:number})} [acceleration=0] - The horizontal and vertical acceleration the camera will move.
  * @property {(number|{x:number,y:number})} [drag=0] - The horizontal and vertical drag applied to the camera when it is moving.
  * @property {(number|{x:number,y:number})} [maxSpeed=0] - The maximum horizontal and vertical speed the camera will move.
+ * @property {number} [minZoom=0.001] - The smallest zoom value the camera will reach when zoomed out.
+ * @property {number} [maxZoom=1000] - The largest zoom value the camera will reach when zoomed in.
  */


### PR DESCRIPTION
This PR

* Adds a new feature

As people often ask for this, I added `minZoom` and `maxZoom` properties to the camera controllers and their configuration objects. Default values are 0.001 and 1000.

This is a minor API change for `FixedKeyControl`. Previously it had a nonconfigurable minimum zoom of 0.1.



