### PR TITLE
fix(spine-plugin): errors throw while game destroy

### DIFF
--- a/plugins/spine/src/SpinePlugin.js
+++ b/plugins/spine/src/SpinePlugin.js
@@ -1128,18 +1128,16 @@ var SpinePlugin = new Class({
      */
     gameDestroy: function ()
     {
-        this.destroy();
+        this.pluginManager.removeGameObject('spine', true, true);
+        this.pluginManager.removeGameObject('spineContainer', true, true);
+        this.pluginManager = null;
 
         if (sceneRenderer)
         {
             sceneRenderer.dispose();
+            sceneRenderer = null;
         }
-
         this.sceneRenderer = null;
-        this.pluginManager = null;
-
-        this.pluginManager.removeGameObject('spine', true, true);
-        this.pluginManager.removeGameObject('spineContainer', true, true);
     }
 
 });


### PR DESCRIPTION
This PR fixes SpinePlugin throws error while unloading and restart game #5477 

below scripts for someone who need a quick fix
```ts
declare global {
  interface SpinePlugin {
    bootWebGL(): void;
    gameDestroy(): void;
    spineFileCallback(this: Phaser.Loader.LoaderPlugin): void;
  }
}

const { bootWebGL } = SpinePlugin.prototype;

let sceneRenderer: spine.webgl.SceneRenderer | null | undefined = undefined;
let setBlendMode: any;

SpinePlugin.prototype.bootWebGL = function (this: SpinePlugin) {
  bootWebGL.call(this);

  if (typeof sceneRenderer === 'undefined') {
    sceneRenderer = this.sceneRenderer;
    setBlendMode = this.sceneRenderer.batcher.setBlendMode;
  } else if (sceneRenderer === null) {
    // eslint-disable-next-line
    // @ts-ignore
    sceneRenderer = new this.sceneRenderer.constructor(
      (this.renderer as any).canvas,
      this.gl,
      true
    );
    (sceneRenderer as any).batcher.setBlendMode = setBlendMode;
    (sceneRenderer as any).shapes.setBlendMode = setBlendMode;

    if (sceneRenderer) {
      this.sceneRenderer = sceneRenderer;
    }
  }
};

SpinePlugin.prototype.gameDestroy = function (this: any) {
  this.pluginManager.removeGameObject('spine', true, true);
  this.pluginManager.removeGameObject('spineContainer', true, true);
  this.pluginManager = null;

  if (sceneRenderer) {
    sceneRenderer.dispose();
    sceneRenderer = null;
  }
  this.sceneRenderer = null;
};
```
