### PR TITLE
Stop RGBToString from returning CSS strings with decimal places

### DIFF
--- a/src/display/color/RGBToString.js
+++ b/src/display/color/RGBToString.js
@@ -27,7 +27,7 @@ var RGBToString = function (r, g, b, a, prefix)
 
     if (prefix === '#')
     {
-        return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+        return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1, 7);
     }
     else
     {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR
* Fixes a bug

Describe the changes below:
Currently if the r g b arguments to RGBToString contain decimal places, then outputting a string with the # prefix may result in decimals places in the CSS string, e.g. '#898989.4cccccd'.
This change slices off anything after the 6 proper digits.

