### PR TITLE
Do not set pointer-events property on DOM elements container

### DIFF
--- a/src/dom/CreateDOMContainer.js
+++ b/src/dom/CreateDOMContainer.js
@@ -25,7 +25,6 @@ var CreateDOMContainer = function (game)
         'padding: 0; margin: 0;',
         'position: absolute;',
         'overflow: hidden;',
-        'pointer-events: none;',
         'transform: scale(1);',
         'transform-origin: left top;'
     ].join(' ');


### PR DESCRIPTION
Fixes #5594.

If I understand correctly, #5504 tried to achieve that the property is left
at its default value. The fact that the DOM container also defines it
was probably overlooked. :-)
