### PR TITLE
Docs: fix scene events example code

### DIFF
--- a/src/scene/events/ADDED_TO_SCENE_EVENT.js
+++ b/src/scene/events/ADDED_TO_SCENE_EVENT.js
@@ -9,7 +9,7 @@
  *
  * This event is dispatched when a Game Object is added to a Scene.
  *
- * Listen for it from a Scene using `this.scene.events.on('addedtoscene', listener)`.
+ * Listen for it from a Scene using `this.events.on('addedtoscene', listener)`.
  *
  * @event Phaser.Scenes.Events#ADDED_TO_SCENE
  * @since 3.50.0

--- a/src/scene/events/BOOT_EVENT.js
+++ b/src/scene/events/BOOT_EVENT.js
@@ -9,8 +9,8 @@
  * 
  * This event is dispatched by a Scene during the Scene Systems boot process. Primarily used by Scene Plugins.
  * 
- * Listen to it from a Scene using `this.scene.events.on('boot', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('boot', listener)`.
  * @event Phaser.Scenes.Events#BOOT
  * @since 3.0.0
  * 

--- a/src/scene/events/CREATE_EVENT.js
+++ b/src/scene/events/CREATE_EVENT.js
@@ -13,8 +13,8 @@
  * 
  * If there is a transition, this event will be fired after the `TRANSITION_START` event.
  * 
- * Listen to it from a Scene using `this.scene.events.on('create', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('create', listener)`.
  * @event Phaser.Scenes.Events#CREATE
  * @since 3.17.0
  * 

--- a/src/scene/events/DESTROY_EVENT.js
+++ b/src/scene/events/DESTROY_EVENT.js
@@ -9,8 +9,8 @@
  * 
  * This event is dispatched by a Scene during the Scene Systems destroy process.
  * 
- * Listen to it from a Scene using `this.scene.events.on('destroy', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('destroy', listener)`.
  * You should destroy any resources that may be in use by your Scene in this event handler.
  * 
  * @event Phaser.Scenes.Events#DESTROY

--- a/src/scene/events/PAUSE_EVENT.js
+++ b/src/scene/events/PAUSE_EVENT.js
@@ -10,8 +10,8 @@
  * This event is dispatched by a Scene when it is paused, either directly via the `pause` method, or as an
  * action from another Scene.
  * 
- * Listen to it from a Scene using `this.scene.events.on('pause', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('pause', listener)`.
  * @event Phaser.Scenes.Events#PAUSE
  * @since 3.0.0
  * 

--- a/src/scene/events/POST_UPDATE_EVENT.js
+++ b/src/scene/events/POST_UPDATE_EVENT.js
@@ -18,8 +18,8 @@
  * 5. [PRE_RENDER]{@linkcode Phaser.Scenes.Events#event:PRE_RENDER}
  * 6. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
  *
- * Listen to it from a Scene using `this.scene.events.on('postupdate', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('postupdate', listener)`.
  * A Scene will only run its step if it is active.
  * 
  * @event Phaser.Scenes.Events#POST_UPDATE

--- a/src/scene/events/PRE_RENDER_EVENT.js
+++ b/src/scene/events/PRE_RENDER_EVENT.js
@@ -18,7 +18,7 @@
  * 5. [PRE_RENDER]{@linkcode Phaser.Scenes.Events#event:PRE_RENDER}
  * 6. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
  *
- * Listen to this event from a Scene using `this.scene.events.on('prerender', listener)`.
+ * Listen to this event from a Scene using `this.events.on('prerender', listener)`.
  *
  * A Scene will only render if it is visible.
  * This event is dispatched after the Scene Display List is sorted and before the Scene is rendered.

--- a/src/scene/events/PRE_UPDATE_EVENT.js
+++ b/src/scene/events/PRE_UPDATE_EVENT.js
@@ -18,8 +18,8 @@
  * 5. [PRE_RENDER]{@linkcode Phaser.Scenes.Events#event:PRE_RENDER}
  * 6. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
  *
- * Listen to it from a Scene using `this.scene.events.on('preupdate', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('preupdate', listener)`.
  * A Scene will only run its step if it is active.
  * 
  * @event Phaser.Scenes.Events#PRE_UPDATE

--- a/src/scene/events/READY_EVENT.js
+++ b/src/scene/events/READY_EVENT.js
@@ -11,8 +11,8 @@
  * By this point in the process the Scene is now fully active and rendering.
  * This event is meant for your game code to use, as all plugins have responded to the earlier 'start' event.
  * 
- * Listen to it from a Scene using `this.scene.events.on('ready', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('ready', listener)`.
  * @event Phaser.Scenes.Events#READY
  * @since 3.0.0
  * 

--- a/src/scene/events/REMOVED_FROM_SCENE_EVENT.js
+++ b/src/scene/events/REMOVED_FROM_SCENE_EVENT.js
@@ -9,7 +9,7 @@
  *
  * This event is dispatched when a Game Object is removed from a Scene.
  *
- * Listen for it from a Scene using `this.scene.events.on('removedfromscene', listener)`.
+ * Listen for it from a Scene using `this.events.on('removedfromscene', listener)`.
  *
  * @event Phaser.Scenes.Events#REMOVED_FROM_SCENE
  * @since 3.50.0

--- a/src/scene/events/RENDER_EVENT.js
+++ b/src/scene/events/RENDER_EVENT.js
@@ -18,7 +18,7 @@
  * 5. [PRE_RENDER]{@linkcode Phaser.Scenes.Events#event:PRE_RENDER}
  * 6. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
  *
- * Listen to it from a Scene using `this.scene.events.on('render', listener)`.
+ * Listen to it from a Scene using `this.events.on('render', listener)`.
  *
  * A Scene will only render if it is visible.
  * By the time this event is dispatched, the Scene will have already been rendered.

--- a/src/scene/events/RESUME_EVENT.js
+++ b/src/scene/events/RESUME_EVENT.js
@@ -10,8 +10,8 @@
  * This event is dispatched by a Scene when it is resumed from a paused state, either directly via the `resume` method,
  * or as an action from another Scene.
  * 
- * Listen to it from a Scene using `this.scene.events.on('resume', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('resume', listener)`.
  * @event Phaser.Scenes.Events#RESUME
  * @since 3.0.0
  * 

--- a/src/scene/events/SHUTDOWN_EVENT.js
+++ b/src/scene/events/SHUTDOWN_EVENT.js
@@ -9,8 +9,8 @@
  * 
  * This event is dispatched by a Scene during the Scene Systems shutdown process.
  * 
- * Listen to it from a Scene using `this.scene.events.on('shutdown', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('shutdown', listener)`.
  * You should free-up any resources that may be in use by your Scene in this event handler, on the understanding
  * that the Scene may, at any time, become active again. A shutdown Scene is not 'destroyed', it's simply not
  * currently active. Use the [DESTROY]{@linkcode Phaser.Scenes.Events#event:DESTROY} event to completely clear resources.

--- a/src/scene/events/SLEEP_EVENT.js
+++ b/src/scene/events/SLEEP_EVENT.js
@@ -10,8 +10,8 @@
  * This event is dispatched by a Scene when it is sent to sleep, either directly via the `sleep` method,
  * or as an action from another Scene.
  * 
- * Listen to it from a Scene using `this.scene.events.on('sleep', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('sleep', listener)`.
  * @event Phaser.Scenes.Events#SLEEP
  * @since 3.0.0
  * 

--- a/src/scene/events/START_EVENT.js
+++ b/src/scene/events/START_EVENT.js
@@ -9,8 +9,8 @@
  * 
  * This event is dispatched by a Scene during the Scene Systems start process. Primarily used by Scene Plugins.
  * 
- * Listen to it from a Scene using `this.scene.events.on('start', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('start', listener)`.
  * @event Phaser.Scenes.Events#START
  * @since 3.0.0
  * 

--- a/src/scene/events/TRANSITION_COMPLETE_EVENT.js
+++ b/src/scene/events/TRANSITION_COMPLETE_EVENT.js
@@ -12,8 +12,8 @@
  * It happens when the transition process has completed. This occurs when the duration timer equals or exceeds the duration
  * of the transition.
  * 
- * Listen to it from a Scene using `this.scene.events.on('transitioncomplete', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('transitioncomplete', listener)`.
  * The Scene Transition event flow is as follows:
  * 
  * 1. [TRANSITION_OUT]{@linkcode Phaser.Scenes.Events#event:TRANSITION_OUT} - the Scene that started the transition will emit this event.

--- a/src/scene/events/TRANSITION_INIT_EVENT.js
+++ b/src/scene/events/TRANSITION_INIT_EVENT.js
@@ -12,8 +12,8 @@
  * It happens immediately after the `Scene.init` method is called. If the Scene does not have an `init` method,
  * this event is not dispatched.
  * 
- * Listen to it from a Scene using `this.scene.events.on('transitioninit', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('transitioninit', listener)`.
  * The Scene Transition event flow is as follows:
  * 
  * 1. [TRANSITION_OUT]{@linkcode Phaser.Scenes.Events#event:TRANSITION_OUT} - the Scene that started the transition will emit this event.

--- a/src/scene/events/TRANSITION_OUT_EVENT.js
+++ b/src/scene/events/TRANSITION_OUT_EVENT.js
@@ -9,8 +9,8 @@
  * 
  * This event is dispatched by a Scene when it initiates a transition to another Scene.
  * 
- * Listen to it from a Scene using `this.scene.events.on('transitionout', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('transitionout', listener)`.
  * The Scene Transition event flow is as follows:
  * 
  * 1. [TRANSITION_OUT]{@linkcode Phaser.Scenes.Events#event:TRANSITION_OUT} - the Scene that started the transition will emit this event.

--- a/src/scene/events/TRANSITION_START_EVENT.js
+++ b/src/scene/events/TRANSITION_START_EVENT.js
@@ -15,8 +15,8 @@
  * If the Target Scene was sleeping then the [TRANSITION_WAKE]{@linkcode Phaser.Scenes.Events#event:TRANSITION_WAKE} event is
  * dispatched instead of this event.
  * 
- * Listen to it from a Scene using `this.scene.events.on('transitionstart', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('transitionstart', listener)`.
  * The Scene Transition event flow is as follows:
  * 
  * 1. [TRANSITION_OUT]{@linkcode Phaser.Scenes.Events#event:TRANSITION_OUT} - the Scene that started the transition will emit this event.

--- a/src/scene/events/TRANSITION_WAKE_EVENT.js
+++ b/src/scene/events/TRANSITION_WAKE_EVENT.js
@@ -10,8 +10,8 @@
  * This event is dispatched by the Target Scene of a transition, only if that Scene was asleep before
  * the transition began. If the Scene was not asleep the [TRANSITION_START]{@linkcode Phaser.Scenes.Events#event:TRANSITION_START} event is dispatched instead.
  * 
- * Listen to it from a Scene using `this.scene.events.on('transitionwake', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('transitionwake', listener)`.
  * The Scene Transition event flow is as follows:
  * 
  * 1. [TRANSITION_OUT]{@linkcode Phaser.Scenes.Events#event:TRANSITION_OUT} - the Scene that started the transition will emit this event.

--- a/src/scene/events/UPDATE_EVENT.js
+++ b/src/scene/events/UPDATE_EVENT.js
@@ -18,8 +18,8 @@
  * 5. [PRE_RENDER]{@linkcode Phaser.Scenes.Events#event:PRE_RENDER}
  * 6. [RENDER]{@linkcode Phaser.Scenes.Events#event:RENDER}
  *
- * Listen to it from a Scene using `this.scene.events.on('update', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('update', listener)`.
  * A Scene will only run its step if it is active.
  * 
  * @event Phaser.Scenes.Events#UPDATE

--- a/src/scene/events/WAKE_EVENT.js
+++ b/src/scene/events/WAKE_EVENT.js
@@ -10,8 +10,8 @@
  * This event is dispatched by a Scene when it is woken from sleep, either directly via the `wake` method,
  * or as an action from another Scene.
  * 
- * Listen to it from a Scene using `this.scene.events.on('wake', listener)`.
  * 
+ * Listen to it from a Scene using `this.events.on('wake', listener)`.
  * @event Phaser.Scenes.Events#WAKE
  * @since 3.0.0
  * 


### PR DESCRIPTION
This PR

* Updates the Documentation

Scene events descriptions incorrectly referred to `this.scene.events`.

