### PR TITLE
Fix incorrect key when loading a Video with a config object

### DIFF
--- a/src/loader/filetypes/VideoFile.js
+++ b/src/loader/filetypes/VideoFile.js
@@ -238,10 +238,11 @@ VideoFile.create = function (loader, key, urls, loadEvent, asBlob, noAudio, xhrS
         asBlob = GetFastValue(key, 'asBlob', false);
         noAudio = GetFastValue(key, 'noAudio', false);
         xhrSettings = GetFastValue(key, 'xhrSettings');
+        key = GetFastValue(key, 'key');
     }
 
     var urlConfig = VideoFile.getVideoURL(game, urls);
-
+    
     if (urlConfig)
     {
         return new VideoFile(loader, key, urlConfig, loadEvent, asBlob, noAudio, xhrSettings);


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Fixes an issue where videos would not get the correct key when loaded with a config object.

i.e

```js
this.load.video({ key: 'my-video', url: '/video.mp4' })
```

the key would end up being `{ key: 'my-video', url: '/video.mp4' }`. This PR would correctly use `my-video` as the key.