### PR TITLE
Fix scene PRE_UPDATE handlers removed at scene shutdown

### DIFF
--- a/src/gameobjects/UpdateList.js
+++ b/src/gameobjects/UpdateList.js
@@ -199,7 +199,7 @@ var UpdateList = new Class({
 
         var eventEmitter = this.systems.events;
 
-        eventEmitter.off(SceneEvents.PRE_UPDATE, this.preUpdate, this);
+        eventEmitter.off(SceneEvents.PRE_UPDATE, this.update, this);
         eventEmitter.off(SceneEvents.UPDATE, this.sceneUpdate, this);
         eventEmitter.off(SceneEvents.SHUTDOWN, this.shutdown, this);
     },


### PR DESCRIPTION
This PR

* Fixes a bug

If you added a listener to scene [PRE_UPDATE](https://photonstorm.github.io/phaser3-docs/Phaser.Scenes.Events.html#event:PRE_UPDATE) it would get removed when the scene was shut down (e.g., restarted).

It happened because UpdateList#shutdown was unregistering `undefined` so inadvertently clearing the event.

