### PR TITLE
Fix - Math#ToXY, in a specific case, does not set the existing vector passed as 'out' parameter

### DIFF
--- a/src/math/ToXY.js
+++ b/src/math/ToXY.js
@@ -42,11 +42,9 @@ var ToXY = function (index, width, height, out)
         {
             x = index;
         }
-
-        out.set(x, y);
     }
 
-    return out;
+    return out.set(x, y);
 };
 
 module.exports = ToXY;


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:
If the `index` param is 0 and the `out` param is an existing Vector2, the unmodified Vector2 is returned.
This happens because the statement `out.set(x, y);` is inside the `if (index > 0...` block.

Being even more verbose:
```
const vector = new Phaser.Math.Vector2(33, 444)

console.log(Phaser.Math.ToXY(0, 6, 4, vector))
// logs: Object {x: 33, y: 444}
// ...but it need to be: Object {x: 0, y: 0}
```