### PR TITLE
Improve types for WebGL texture compression support

### DIFF
--- a/src/renderer/webgl/WebGLRenderer.js
+++ b/src/renderer/webgl/WebGLRenderer.js
@@ -421,7 +421,7 @@ var WebGLRenderer = new Class({
          * Stores the supported WebGL texture compression formats.
          *
          * @name Phaser.Renderer.WebGL.WebGLRenderer#compression
-         * @type {object}
+         * @type {Phaser.Types.Renderer.WebGL.WebGLTextureCompression}
          * @since 3.8.0
          */
         this.compression = {

--- a/src/renderer/webgl/typedefs/WebGLTextureCompression.js
+++ b/src/renderer/webgl/typedefs/WebGLTextureCompression.js
@@ -1,0 +1,8 @@
+/**
+ * @typedef {object} Phaser.Types.Renderer.WebGL.WebGLTextureCompression
+ * @since 3.55.0
+ *
+ * @property {object|null} ETC1 - Indicates if ETC1 compression is supported on current device (mostly Android).
+ * @property {object|null} PVRTC - Indicates if PVRTC compression is supported on current device (mostly iOS).
+ * @property {object|null} S3TC - Indicates if S3TC compression is supported on current device.
+ */


### PR DESCRIPTION
This PR (delete as applicable)
* Updates the Documentation

Describe the changes below:
Improve types for WebGL texture compression support
