### PR TITLE
Improve performance of MeasureText

### DIFF
--- a/src/gameobjects/text/MeasureText.js
+++ b/src/gameobjects/text/MeasureText.js
@@ -25,7 +25,7 @@ var MeasureText = function (textStyle)
 
     var metrics = context.measureText(textStyle.testString);
 
-    if (metrics.hasOwnProperty('actualBoundingBoxAscent'))
+    if ('actualBoundingBoxAscent' in metrics)
     {
         var ascent = metrics.actualBoundingBoxAscent;
         var descent = metrics.actualBoundingBoxDescent;

--- a/src/gameobjects/text/MeasureText.js
+++ b/src/gameobjects/text/MeasureText.js
@@ -63,7 +63,8 @@ var MeasureText = function (textStyle)
         fontSize: 0
     };
 
-    if (!context.getImageData(0, 0, width, height))
+    var imagedata = context.getImageData(0, 0, width, height);
+    if (!imagedata)
     {
         output.ascent = baseline;
         output.descent = baseline + 6;
@@ -74,8 +75,8 @@ var MeasureText = function (textStyle)
         return output;
     }
 
-    var imagedata = context.getImageData(0, 0, width, height).data;
-    var pixels = imagedata.length;
+    var pixels = imagedata.data;
+    var numPixels = pixels.length;
     var line = width * 4;
     var i;
     var j;
@@ -87,7 +88,7 @@ var MeasureText = function (textStyle)
     {
         for (j = 0; j < line; j += 4)
         {
-            if (imagedata[idx + j] !== 255)
+            if (pixels[idx + j] !== 255)
             {
                 stop = true;
                 break;
@@ -106,7 +107,7 @@ var MeasureText = function (textStyle)
 
     output.ascent = baseline - i;
 
-    idx = pixels - line;
+    idx = numPixels - line;
     stop = false;
 
     // descent. scan from bottom to top until we find a non red pixel
@@ -114,7 +115,7 @@ var MeasureText = function (textStyle)
     {
         for (j = 0; j < line; j += 4)
         {
-            if (imagedata[idx + j] !== 255)
+            if (pixels[idx + j] !== 255)
             {
                 stop = true;
                 break;


### PR DESCRIPTION
This PR

* Improves performance

Describe the changes below:

1. The `MeasureText` function previously called `getImageData` twice, once to see if it worked(?) and once to actually use the result.

    `getImageData` is quite slow on Chrome:
![image](https://user-images.githubusercontent.com/79560998/114806260-733ad480-9d72-11eb-9933-f4c72bb7e255.png)

    By only calling it once, this PR should improve text measurement performance.

2. `metrics.hasOwnProperty('actualBoundingBoxAscent')` would return false even on browsers which supported these new text metrics properties, because `actualBoundingBoxAscent` is defined on its *prototype*. Changing the check to `'actualBoundingBoxAscent' in metrics` allows the fast path to actually be used.