### PR TITLE
Invoke `addToRenderList()` before leaving render method

### DIFF
--- a/src/gameobjects/container/ContainerCanvasRenderer.js
+++ b/src/gameobjects/container/ContainerCanvasRenderer.js
@@ -21,14 +21,14 @@
  */
 var ContainerCanvasRenderer = function (renderer, container, camera, parentMatrix)
 {
+    camera.addToRenderList(container);
+
     var children = container.list;
 
     if (children.length === 0)
     {
         return;
     }
-
-    camera.addToRenderList(container);
 
     var transformMatrix = container.localTransform;
 

--- a/src/gameobjects/container/ContainerWebGLRenderer.js
+++ b/src/gameobjects/container/ContainerWebGLRenderer.js
@@ -21,6 +21,8 @@
  */
 var ContainerWebGLRenderer = function (renderer, container, camera, parentMatrix)
 {
+    camera.addToRenderList(container);
+
     var children = container.list;
     var childCount = children.length;
 
@@ -28,8 +30,6 @@ var ContainerWebGLRenderer = function (renderer, container, camera, parentMatrix
     {
         return;
     }
-
-    camera.addToRenderList(container);
 
     var transformMatrix = container.localTransform;
 


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Invoke `addToRenderList()` first before leaving render method. #5506 
