### PR TITLE
GameObjectConfig allow type object

### DIFF
--- a/src/gameobjects/typedefs/GameObjectConfig.js
+++ b/src/gameobjects/typedefs/GameObjectConfig.js
@@ -2,16 +2,16 @@
  * @typedef {object} Phaser.Types.GameObjects.GameObjectConfig
  * @since 3.0.0
  *
- * @property {number} [x=0] - The x position of the Game Object.
- * @property {number} [y=0] - The y position of the Game Object.
+ * @property {(number|object}} [x=0] - The x position of the Game Object.
+ * @property {(number|object}} [y=0] - The y position of the Game Object.
  * @property {number} [depth=0] - The depth of the GameObject.
  * @property {boolean} [flipX=false] - The horizontally flipped state of the Game Object.
  * @property {boolean} [flipY=false] - The vertically flipped state of the Game Object.
  * @property {?(number|object)} [scale=null] - The scale of the GameObject.
  * @property {?(number|object)} [scrollFactor=null] - The scroll factor of the GameObject.
- * @property {number} [rotation=0] - The rotation angle of the Game Object, in radians.
- * @property {?number} [angle=null] - The rotation angle of the Game Object, in degrees.
- * @property {number} [alpha=1] - The alpha (opacity) of the Game Object.
+ * @property {(number|object}} [rotation=0] - The rotation angle of the Game Object, in radians.
+ * @property {?(number|object}} [angle=null] - The rotation angle of the Game Object, in degrees.
+ * @property {(number|object}} [alpha=1] - The alpha (opacity) of the Game Object.
  * @property {?(number|object)} [origin=null] - The origin of the Game Object.
  * @property {number} [scaleMode=ScaleModes.DEFAULT] - The scale mode of the GameObject.
  * @property {number} [blendMode=BlendModes.DEFAULT] - The blend mode of the GameObject.


### PR DESCRIPTION
This PR (delete as applicable)

* Updates the Documentation
* Fixes a bug

Describe the changes below:

GameObjectConfig x, y, rotation, angle, and alpha should allow type object

Fixes #5682

Thanks @chousiyan for raising the issue

