### PR TITLE
Fixed video not resuming on regaining focus

### DIFF
--- a/src/gameobjects/video/Video.js
+++ b/src/gameobjects/video/Video.js
@@ -929,6 +929,7 @@ var Video = new Class({
      */
     playPromiseSuccessHandler: function ()
     {
+        this._codePaused = false;
         this.touchLocked = false;
 
         this.emit(Events.VIDEO_PLAY, this);
@@ -970,6 +971,7 @@ var Video = new Class({
      */
     playHandler: function ()
     {
+        this._codePaused = false;
         this.touchLocked = false;
 
         this.emit(Events.VIDEO_PLAY, this);


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

As described in issue #5377 the video would not resume on regaining focus unless setting `setPaused(false)` on the object.
Fixed by setting the `_codePaused` attribute back to `false` in the play handler methods.

