### PR TITLE
Fix Capacitor iOS audio issue

### DIFF
--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -310,7 +310,12 @@ var File = new Class({
      */
     onLoad: function (xhr, event)
     {
-        var localFileOk = ((xhr.responseURL && xhr.responseURL.indexOf('file://') === 0 && event.target.status === 0));
+
+        // On iOS, Capacitor often runs on a capacitor:// protocol, meaning local files are served from capacitor:// rather than file://
+        // See: https://github.com/photonstorm/phaser/issues/5685 
+        var isLocalFile = xhr.responseURL && (xhr.responseURL.indexOf('file://') === 0 || xhr.responseURL.indexOf('capacitor://') === 0);
+
+        var localFileOk = ( isLocalFile && event.target.status === 0);
 
         var success = !(event.target && event.target.status !== 200) || localFileOk;
 


### PR DESCRIPTION
This PR (delete as applicable)
* Fixes a bug

Describe the changes below:

This fix addresses [#5685](https://github.com/photonstorm/phaser/issues/5685), an issue with loading audio files when a Phaser project is wrapped in a Capacitor native app shell on iOS. 
Capacitor on iOS often serves local files with a capacitor:// custom scheme, so just checking `file://` leads to strange behaviour, extending the check to add `capacitor://` resolves this issue.