### PR TITLE
fixed type of ParticleEmitterConfig deathCallback to function

### DIFF
--- a/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
+++ b/src/gameobjects/particles/typedefs/ParticleEmitterConfig.js
@@ -9,7 +9,7 @@
  * @property {boolean} [collideLeft] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#collideLeft}.
  * @property {boolean} [collideRight] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#collideRight}.
  * @property {boolean} [collideTop] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#collideTop}.
- * @property {boolean} [deathCallback] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#deathCallback}.
+ * @property {function} [deathCallback] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#deathCallback}.
  * @property {*} [deathCallbackScope] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#deathCallbackScope}.
  * @property {function} [emitCallback] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#emitCallback}.
  * @property {*} [emitCallbackScope] - Sets {@link Phaser.GameObjects.Particles.ParticleEmitter#emitCallbackScope}.


### PR DESCRIPTION
* Updates the Documentation

Describe the changes below:
ParticleEmitterConfig "deathCallback" is change from a boolean to a function as it is a callback
