### PR TITLE
Turn off registered context-restored event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 3.56.0 - Miku - in development
+
+### Bug Fixes
+
+* `Animation.createFromAseprite` would calculate an incorrect frame duration if the frames didn't all have the same speed.
+
 ## Version 3.55.2 - Ichika - 27th May 2021
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 * `Animation.createFromAseprite` would calculate an incorrect frame duration if the frames didn't all have the same speed.
+* The URL scheme `capacitor://` has been added to the protocol check to prevent malformed double-urls in some environments (thanks @consolenaut)
 
 ## Version 3.55.2 - Ichika - 27th May 2021
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "phaser",
-  "version": "3.53.0",
+  "version": "3.56.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phaser",
-  "version": "3.55.2",
-  "release": "Ichika",
+  "version": "3.56.0",
+  "release": "Miku",
   "description": "A fast, free and fun HTML5 Game Framework for Desktop and Mobile web browsers.",
   "author": "Richard Davey <rich@photonstorm.com> (http://www.photonstorm.com)",
   "homepage": "http://phaser.io",

--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -459,7 +459,7 @@ var AnimationManager = new Class({
                         animFrames.push({
                             key: key,
                             frame: entry.frame,
-                            duration: (minDuration - entry.duration)
+                            duration: (entry.duration - minDuration)
                         });
                     });
 

--- a/src/const.js
+++ b/src/const.js
@@ -20,7 +20,7 @@ var CONST = {
      * @type {string}
      * @since 3.0.0
      */
-    VERSION: '3.55.2',
+    VERSION: '3.56.0-dev',
 
     BlendModes: require('./renderer/BlendModes'),
 

--- a/src/gameobjects/text/Text.js
+++ b/src/gameobjects/text/Text.js
@@ -287,10 +287,7 @@ var Text = new Class({
             this.setLineSpacing(style.lineSpacing);
         }
 
-        scene.sys.game.events.on(GameEvents.CONTEXT_RESTORED, function ()
-        {
-            this.dirty = true;
-        }, this);
+        scene.sys.game.events.on(GameEvents.CONTEXT_RESTORED, this.onContextRestored, this);
     },
 
     /**
@@ -1364,6 +1361,18 @@ var Text = new Class({
     },
 
     /**
+     * Internal context-restored handler.
+     *
+     * @method Phaser.GameObjects.Text#onContextRestored
+     * @protected
+     * @since 3.56.0
+     */
+    onContextRestored: function ()
+    {
+        this.dirty = true;
+    },
+
+    /**
      * Internal destroy handler, called as part of the destroy process.
      *
      * @method Phaser.GameObjects.Text#preDestroy
@@ -1380,6 +1389,8 @@ var Text = new Class({
         CanvasPool.remove(this.canvas);
 
         this.texture.destroy();
+
+        this.scene.sys.game.events.off(GameEvents.CONTEXT_RESTORED, this.onContextRestored, this);
     }
 
     /**

--- a/src/gameobjects/tilesprite/TileSprite.js
+++ b/src/gameobjects/tilesprite/TileSprite.js
@@ -275,20 +275,7 @@ var TileSprite = new Class({
         this.setOriginFromFrame();
         this.initPipeline();
 
-        scene.sys.game.events.on(GameEvents.CONTEXT_RESTORED, function (renderer)
-        {
-            if (!renderer)
-            {
-                return;
-            }
-            
-            var gl = renderer.gl;
-
-            this.dirty = true;
-            this.fillPattern = null;
-            this.fillPattern = renderer.createTexture2D(0, gl.LINEAR, gl.LINEAR, gl.REPEAT, gl.REPEAT, gl.RGBA, this.fillCanvas, this.potWidth, this.potHeight);
-
-        }, this);
+        scene.sys.game.events.on(GameEvents.CONTEXT_RESTORED, this.onContextRestored, this);
     },
 
     /**
@@ -526,6 +513,28 @@ var TileSprite = new Class({
     },
 
     /**
+     * Internal context-restored handler.
+     *
+     * @method Phaser.GameObjects.TileSprite#onContextRestored
+     * @protected
+     * @since 3.56.0
+     */
+    onContextRestored: function (renderer)
+    {
+        if (!renderer)
+        {
+            return;
+        }
+         
+        var gl = renderer.gl;
+ 
+        this.dirty = true;
+        this.fillPattern = null;
+        this.fillPattern = renderer.createTexture2D(0, gl.LINEAR, gl.LINEAR, gl.REPEAT, gl.REPEAT, gl.RGBA, this.fillCanvas, this.potWidth, this.potHeight);
+ 
+    },    
+ 
+    /**
      * Internal destroy handler, called as part of the destroy process.
      *
      * @method Phaser.GameObjects.TileSprite#preDestroy
@@ -552,6 +561,8 @@ var TileSprite = new Class({
         this.texture.destroy();
 
         this.renderer = null;
+
+        this.scene.sys.game.events.on(GameEvents.CONTEXT_RESTORED, this.onContextRestored, this);
     },
 
     /**

--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -86,7 +86,7 @@ var File = new Class({
         {
             url = loader.path + loadKey + '.' + GetFastValue(fileConfig, 'extension', '');
         }
-        else if (typeof url === 'string' && !url.match(/^(?:blob:|data:|http:\/\/|https:\/\/|\/\/)/))
+        else if (typeof url === 'string' && !url.match(/^(?:blob:|data:|capacitor:\/\/|http:\/\/|https:\/\/|\/\/)/))
         {
             url = loader.path + url;
         }

--- a/src/loader/GetURL.js
+++ b/src/loader/GetURL.js
@@ -22,7 +22,7 @@ var GetURL = function (file, baseURL)
         return false;
     }
 
-    if (file.url.match(/^(?:blob:|data:|http:\/\/|https:\/\/|\/\/)/))
+    if (file.url.match(/^(?:blob:|data:|capacitor:\/\/|http:\/\/|https:\/\/|\/\/)/))
     {
         return file.url;
     }


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

CONTEXT_RESTORED event has been registered but won't be turn off when respond game object has been destroyed, thus the game object won't be released fully.

[Bitmask](https://github.com/photonstorm/phaser/blob/master/src/display/mask/BitmapMask.js#L147) also registers CONTEXT_RESTORED event without turn off it. But I did not fix it in this PR.
