### PR TITLE
Fix Capacitor iOS file load issue

### DIFF
--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -86,7 +86,7 @@ var File = new Class({
         {
             url = loader.path + loadKey + '.' + GetFastValue(fileConfig, 'extension', '');
         }
-        else if (typeof url === 'string' && !url.match(/^(?:blob:|data:|http:\/\/|https:\/\/|\/\/)/))
+        else if (typeof url === 'string' && !url.match(/^(?:blob:|data:|capacitor:\/\/|http:\/\/|https:\/\/|\/\/)/))
         {
             url = loader.path + url;
         }

--- a/src/loader/GetURL.js
+++ b/src/loader/GetURL.js
@@ -22,7 +22,7 @@ var GetURL = function (file, baseURL)
         return false;
     }
 
-    if (file.url.match(/^(?:blob:|data:|http:\/\/|https:\/\/|\/\/)/))
+    if (file.url.match(/^(?:blob:|data:|capacitor:\/\/|http:\/\/|https:\/\/|\/\/)/))
     {
         return file.url;
     }


### PR DESCRIPTION
This PR (delete as applicable)

Fixes a bug
Describe the changes below:

This fix addresses a similar issue to #5685, an issue with loading files when a Phaser project is wrapped in a Capacitor native app shell on iOS.
Capacitor on iOS often serves local files with a capacitor:// custom scheme, so just checking file:// leads to strange behaviour, extending the check to add capacitor:// resolves this issue.

We ran into this when using spine animations, whereby when Phaser tried to get a file URL, rather than getting something similar to `capacitor://myapp/images/file.png` it would get `capacitor://myapp/capacitor://myapp/images/file.png`. This is because Phaser checks to see if the URL is either blob/file/http/https, in which case it uses the raw URL, but if not prepends a baseURL before the URL assuming its a relative path.  This PR adds capacitor:// to the protocol check to prevent malformed double-url issue.


