### PR TITLE
feat: Add support for load image by HTMLImageElement

### DIFF
--- a/src/core/Config.js
+++ b/src/core/Config.js
@@ -518,6 +518,11 @@ var Config = new Class({
          */
         this.loaderWithCredentials = GetValue(config, 'loader.withCredentials', false);
 
+        /**
+         * @const {string} Phaser.Core.Config#loaderImageLoadType - Optional load type for image, `XHR` is default, or `HTMLImageElement` for a lightweight way.
+         */
+        this.loaderImageLoadType = GetValue(config, 'loader.imageLoadType', 'XHR');
+
         /*
          * Allows `plugins` property to either be an array, in which case it just replaces
          * the default plugins like previously, or a config object.

--- a/src/loader/LoaderPlugin.js
+++ b/src/loader/LoaderPlugin.js
@@ -206,7 +206,15 @@ var LoaderPlugin = new Class({
          * @since 3.0.0
          */
         this.crossOrigin = GetFastValue(sceneConfig, 'crossOrigin', gameConfig.loaderCrossOrigin);
-
+        
+        /**
+         * Optional load type for image, `XHR` is default, or `HTMLImageElement` for a lightweight way.
+         *
+         * @name Phaser.Loader.LoaderPlugin#imageLoadType
+         * @type {string}
+         */
+        this.imageLoadType = GetFastValue(sceneConfig, 'imageLoadType', gameConfig.loaderImageLoadType);
+        
         /**
          * The total number of files to load. It may not always be accurate because you may add to the Loader during the process
          * of loading, especially if you load a Pack File. Therefore this value can change, but in most cases remains static.


### PR DESCRIPTION
This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Add support for load image by HTMLImageElement.
We use phaser in our project, it is great!  And we find that load image by HTMLImageElement (without a blob process) is a lightweight way, which improve the performance. So I think we can support this feature within the phaser, and add a new config to use it.
