### PR TITLE
Update Rectangle shape game object's display origin and default hitArea

### DIFF
--- a/src/gameobjects/shape/rectangle/Rectangle.js
+++ b/src/gameobjects/shape/rectangle/Rectangle.js
@@ -93,6 +93,16 @@ var Rectangle = new Class({
 
         this.updateData();
 
+        this.updateDisplayOrigin();
+
+        var input = this.input;
+
+        if (input && !input.customHitArea)
+        {
+            input.hitArea.width = width;
+            input.hitArea.height = height;
+        }
+
         return this;
     },
 


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Update display origin and default hitArea in `rectangle.setSize` method.