### PR TITLE
Correct use of Tween#setCallback() and Timeline#setCallback()

### DIFF
--- a/src/tweens/Timeline.js
+++ b/src/tweens/Timeline.js
@@ -595,7 +595,7 @@ var Timeline = new Class({
     {
         if (Timeline.TYPES.indexOf(type) !== -1)
         {
-            this.callbacks[type] = { func: callback, scope: scope, params: params };
+            this.callbacks[type] = { func: callback, scope: scope, params: [ this ].concat(params) };
         }
 
         return this;

--- a/src/tweens/builders/NumberTweenBuilder.js
+++ b/src/tweens/builders/NumberTweenBuilder.js
@@ -97,9 +97,6 @@ var NumberTweenBuilder = function (parent, config, defaults)
     //  Set the Callbacks
     var scope = GetValue(config, 'callbackScope', tween);
 
-    //  Callback parameters: 0 = a reference to the Tween itself, 1 = the target/s of the Tween, ... your own params
-    var tweenArray = [ tween, null ];
-
     var callbacks = Tween.TYPES;
 
     for (var i = 0; i < callbacks.length; i++)
@@ -114,7 +111,7 @@ var NumberTweenBuilder = function (parent, config, defaults)
             var callbackParams = GetValue(config, type + 'Params', []);
 
             //  The null is reset to be the Tween target
-            tween.setCallback(type, callback, tweenArray.concat(callbackParams), callbackScope);
+            tween.setCallback(type, callback, callbackParams, callbackScope);
         }
     }
 

--- a/src/tweens/builders/NumberTweenBuilder.js
+++ b/src/tweens/builders/NumberTweenBuilder.js
@@ -110,7 +110,6 @@ var NumberTweenBuilder = function (parent, config, defaults)
             var callbackScope = GetValue(config, type + 'Scope', scope);
             var callbackParams = GetValue(config, type + 'Params', []);
 
-            //  The null is reset to be the Tween target
             tween.setCallback(type, callback, callbackParams, callbackScope);
         }
     }

--- a/src/tweens/builders/TimelineBuilder.js
+++ b/src/tweens/builders/TimelineBuilder.js
@@ -40,9 +40,6 @@ var TimelineBuilder = function (manager, config)
     //  Callbacks
 
     var scope = GetValue(config, 'callbackScope', timeline);
-
-    var timelineArray = [ timeline ];
-
     var onStart = GetValue(config, 'onStart', false);
 
     //  The Start of the Timeline
@@ -51,7 +48,7 @@ var TimelineBuilder = function (manager, config)
         var onStartScope = GetValue(config, 'onStartScope', scope);
         var onStartParams = GetValue(config, 'onStartParams', []);
 
-        timeline.setCallback('onStart', onStart, timelineArray.concat(onStartParams), onStartScope);
+        timeline.setCallback('onStart', onStart, onStartParams, onStartScope);
     }
 
     var onUpdate = GetValue(config, 'onUpdate', false);
@@ -62,7 +59,7 @@ var TimelineBuilder = function (manager, config)
         var onUpdateScope = GetValue(config, 'onUpdateScope', scope);
         var onUpdateParams = GetValue(config, 'onUpdateParams', []);
 
-        timeline.setCallback('onUpdate', onUpdate, timelineArray.concat(onUpdateParams), onUpdateScope);
+        timeline.setCallback('onUpdate', onUpdate, onUpdateParams, onUpdateScope);
     }
 
     var onLoop = GetValue(config, 'onLoop', false);
@@ -73,7 +70,7 @@ var TimelineBuilder = function (manager, config)
         var onLoopScope = GetValue(config, 'onLoopScope', scope);
         var onLoopParams = GetValue(config, 'onLoopParams', []);
 
-        timeline.setCallback('onLoop', onLoop, timelineArray.concat(onLoopParams), onLoopScope);
+        timeline.setCallback('onLoop', onLoop, onLoopParams, onLoopScope);
     }
 
     var onYoyo = GetValue(config, 'onYoyo', false);
@@ -84,7 +81,7 @@ var TimelineBuilder = function (manager, config)
         var onYoyoScope = GetValue(config, 'onYoyoScope', scope);
         var onYoyoParams = GetValue(config, 'onYoyoParams', []);
 
-        timeline.setCallback('onYoyo', onYoyo, timelineArray.concat(null, onYoyoParams), onYoyoScope);
+        timeline.setCallback('onYoyo', onYoyo, onYoyoParams, onYoyoScope);
     }
 
     var onComplete = GetValue(config, 'onComplete', false);
@@ -95,7 +92,7 @@ var TimelineBuilder = function (manager, config)
         var onCompleteScope = GetValue(config, 'onCompleteScope', scope);
         var onCompleteParams = GetValue(config, 'onCompleteParams', []);
 
-        timeline.setCallback('onComplete', onComplete, timelineArray.concat(onCompleteParams), onCompleteScope);
+        timeline.setCallback('onComplete', onComplete, onCompleteParams, onCompleteScope);
     }
 
     // Tweens

--- a/src/tweens/builders/TweenBuilder.js
+++ b/src/tweens/builders/TweenBuilder.js
@@ -99,10 +99,6 @@ var TweenBuilder = function (parent, config, defaults)
 
     //  Set the Callbacks
     var scope = GetValue(config, 'callbackScope', tween);
-
-    //  Callback parameters: 0 = a reference to the Tween itself, 1 = the target/s of the Tween, ... your own params
-    var tweenArray = [ tween, null ];
-
     var callbacks = Tween.TYPES;
 
     for (var i = 0; i < callbacks.length; i++)
@@ -116,8 +112,7 @@ var TweenBuilder = function (parent, config, defaults)
             var callbackScope = GetValue(config, type + 'Scope', scope);
             var callbackParams = GetValue(config, type + 'Params', []);
 
-            //  The null is reset to be the Tween target
-            tween.setCallback(type, callback, tweenArray.concat(callbackParams), callbackScope);
+            tween.setCallback(type, callback, callbackParams, callbackScope);
         }
     }
 

--- a/src/tweens/tween/Tween.js
+++ b/src/tweens/tween/Tween.js
@@ -1006,7 +1006,7 @@ var Tween = new Class({
      */
     setCallback: function (type, callback, params, scope)
     {
-        this.callbacks[type] = { func: callback, scope: scope, params: params };
+        this.callbacks[type] = { func: callback, scope: scope, params: [ this, null ].concat(params) };
 
         return this;
     },


### PR DESCRIPTION
This PR

* Fixes a bug

Fixes #5753

Phaser's use of the `setCallback()` methods was inconsistent with the API, and if you used `setCallback()` as documented you would lose callback arguments (#5753).
