### PR TITLE
Do physics group vs. self collisions without the RTree

### DIFF
--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1759,7 +1759,7 @@ var World = new Class({
         var i;
         var j;
 
-        if (object1.isParent && object1.physicsType === undefined)
+        if (object1.isParent && (object1.physicsType === undefined || object2 === undefined || object1 === object2))
         {
             object1 = object1.children.entries;
         }


### PR DESCRIPTION
This PR

* Fixes a bug

Fixes #5758

