### PR TITLE
Cross Origin support on video loadURL

### DIFF
--- a/src/gameobjects/video/Video.js
+++ b/src/gameobjects/video/Video.js
@@ -811,10 +811,11 @@ var Video = new Class({
      * @param {string} url - The URL of the video to load or be streamed.
      * @param {string} [loadEvent='loadeddata'] - The load event to listen for. Either `loadeddata`, `canplay` or `canplaythrough`.
      * @param {boolean} [noAudio=false] - Does the video have an audio track? If not you can enable auto-playing on it.
+     * @param {string} [crossOrigin] - The value to use for the `crossOrigin` property in the video load request.  Either undefined, `anonymous` or `use-credentials`
      *
      * @return {this} This Video Game Object for method chaining.
      */
-    loadURL: function (url, loadEvent, noAudio)
+    loadURL: function (url, loadEvent, noAudio, crossOrigin)
     {
         if (loadEvent === undefined) { loadEvent = 'loadeddata'; }
         if (noAudio === undefined) { noAudio = false; }
@@ -843,6 +844,10 @@ var Video = new Class({
 
         video.setAttribute('playsinline', 'playsinline');
         video.setAttribute('preload', 'auto');
+
+        if(crossOrigin !== undefined) {
+            video.setAttribute('crossorigin', crossOrigin);
+        }
 
         video.addEventListener('error', this._callbacks.error, true);
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:
When using the loadURL method on video, it was not possible to specify a crossorigin request, so it was impossible to load videos from non-same domain locations.  Note that this is only when streaming - if you use the loader, crossorigin support was builtin.

I considered using the same methodology as the loader, where it pulls from the sceneconfig on init and allows override, but that I think that would muddle the water in terms of "who has precedence" (loader or video?).  Since this is only an issue on loadURL, IMHO made the most sense to add it as a 4th parameter.
