### PR TITLE
Fix WEBGL-only selection and throw for unknown renderer type

### DIFF
--- a/src/core/CreateRenderer.js
+++ b/src/core/CreateRenderer.js
@@ -31,22 +31,22 @@ var CreateRenderer = function (game)
     //  Not a custom environment, didn't provide their own canvas and not headless, so determine the renderer:
     if (!config.customEnvironment && !config.canvas && config.renderType !== CONST.HEADLESS)
     {
-        if (config.renderType === CONST.CANVAS || (config.renderType !== CONST.CANVAS && !Features.webGL))
+        if (config.renderType === CONST.AUTO)
         {
-            if (Features.canvas)
-            {
-                //  They requested Canvas and their browser supports it
-                config.renderType = CONST.CANVAS;
-            }
-            else
-            {
-                throw new Error('Cannot create Canvas or WebGL context, aborting.');
-            }
+            config.renderType = Features.webGL ? CONST.WEBGL : CONST.CANVAS;
+        }
+
+        if (config.renderType === CONST.WEBGL)
+        {
+            if (!Features.webGL) { throw new Error('Cannot create WebGL context, aborting.'); }
+        }
+        else if (config.renderType === CONST.CANVAS)
+        {
+            if (!Features.canvas) { throw new Error('Cannot create Canvas context, aborting.'); }
         }
         else
         {
-            //  Game requested WebGL and browser says it supports it
-            config.renderType = CONST.WEBGL;
+            throw new Error('Unknown value for renderer type: ' + config.renderType);
         }
     }
 


### PR DESCRIPTION
This PR

* Adds a new feature
* Fixes a bug

Fixes #5583

Fixed: When the device does not support WebGL, creating a game with `{ type: Phaser.WEBGL }` will fail with an error. It will not fall back to `CANVAS` as `AUTO` does.

New: Creating a game with an invalid renderer `type` will throw an error. Before it would be treated like `AUTO`.