### PR TITLE
Remove CONTEXT_RESTORED listeners when destroyed

### DIFF
--- a/src/display/mask/BitmapMask.js
+++ b/src/display/mask/BitmapMask.js
@@ -55,6 +55,15 @@ var BitmapMask = new Class({
         var renderer = scene.sys.renderer;
 
         /**
+         * The Scene which this Bitmap Mask will be used in.
+         *
+         * @name Phaser.Display.Masks.BitmapMask#scene
+         * @type {Phaser.Scene}
+         * @since 3.56.0
+         */
+        this.scene = scene;
+
+        /**
          * A reference to either the Canvas or WebGL Renderer that this Mask is using.
          *
          * @name Phaser.Display.Masks.BitmapMask#renderer
@@ -302,14 +311,17 @@ var BitmapMask = new Class({
     {
         this.clearMask();
 
+        this.scene.sys.game.events.off(GameEvents.CONTEXT_RESTORED, this.createMask, this);
+
         if (this.renderer)
         {
             this.renderer.off(RenderEvents.RESIZE, this.createMask, this);
         }
-        
+
         this.bitmapMask = null;
         this.prevFramebuffer = null;
         this.renderer = null;
+        this.scene = null;
     }
 
 });

--- a/src/gameobjects/text/Text.js
+++ b/src/gameobjects/text/Text.js
@@ -287,10 +287,7 @@ var Text = new Class({
             this.setLineSpacing(style.lineSpacing);
         }
 
-        scene.sys.game.events.on(GameEvents.CONTEXT_RESTORED, function ()
-        {
-            this.dirty = true;
-        }, this);
+        scene.sys.game.events.on(GameEvents.CONTEXT_RESTORED, this.onContextRestored, this);
     },
 
     /**
@@ -1380,6 +1377,22 @@ var Text = new Class({
         CanvasPool.remove(this.canvas);
 
         this.texture.destroy();
+
+        this.scene.sys.game.events.off(GameEvents.CONTEXT_RESTORED, this.onContextRestored, this);
+    },
+
+    /**
+     * Internal handler for {@link Phaser.Core.Events#CONTEXT_RESTORED}.
+     *
+     * Marks the Text object dirty.
+     *
+     * @method Phaser.GameObjects.Text#onContextRestored
+     * @protected
+     * @since 3.56.0
+     */
+    onContextRestored: function ()
+    {
+        this.dirty = true;
     }
 
     /**

--- a/src/gameobjects/tilesprite/TileSprite.js
+++ b/src/gameobjects/tilesprite/TileSprite.js
@@ -275,20 +275,7 @@ var TileSprite = new Class({
         this.setOriginFromFrame();
         this.initPipeline();
 
-        scene.sys.game.events.on(GameEvents.CONTEXT_RESTORED, function (renderer)
-        {
-            if (!renderer)
-            {
-                return;
-            }
-            
-            var gl = renderer.gl;
-
-            this.dirty = true;
-            this.fillPattern = null;
-            this.fillPattern = renderer.createTexture2D(0, gl.LINEAR, gl.LINEAR, gl.REPEAT, gl.REPEAT, gl.RGBA, this.fillCanvas, this.potWidth, this.potHeight);
-
-        }, this);
+        scene.sys.game.events.on(GameEvents.CONTEXT_RESTORED, this.onContextRestored, this);
     },
 
     /**
@@ -552,6 +539,33 @@ var TileSprite = new Class({
         this.texture.destroy();
 
         this.renderer = null;
+
+        this.scene.sys.game.events.off(GameEvents.CONTEXT_RESTORED, this.onContextRestored, this);
+    },
+
+    /**
+     * Internal handler for {@link Phaser.Core.Events#CONTEXT_RESTORED}.
+     *
+     * Recreates the fill pattern texture.
+     *
+     * @method Phaser.GameObjects.TileSprite#onContextRestored
+     * @protected
+     * @since 3.56.0
+     *
+     * @param {Phaser.Renderer.WebGL.WebGLRenderer} renderer - The WebGL renderer.
+     */
+    onContextRestored: function (renderer)
+    {
+        if (!renderer)
+        {
+            return;
+        }
+
+        var gl = renderer.gl;
+
+        this.dirty = true;
+        this.fillPattern = null;
+        this.fillPattern = renderer.createTexture2D(0, gl.LINEAR, gl.LINEAR, gl.REPEAT, gl.REPEAT, gl.RGBA, this.fillCanvas, this.potWidth, this.potHeight);
     },
 
     /**


### PR DESCRIPTION
This PR

* Fixes a bug

Three classes did not unregister [CONTEXT_RESTORED](https://newdocs.phaser.io/docs/3.55.2/Phaser.Core.Events.CONTEXT_RESTORED) when destroyed.

- BitmapMask
- Text
- TileSprite

Also adds Phaser.Display.Masks.BitmapMask#scene

Thanks @rollinsafary-inomma, reporter

