### PR TITLE
Docs: correct types in Arcade.Body#setBounce

### DIFF
--- a/src/physics/arcade/Body.js
+++ b/src/physics/arcade/Body.js
@@ -1899,7 +1899,7 @@ var Body = new Class({
      * @since 3.0.0
      *
      * @param {number} x - The horizontal bounce, relative to 1.
-     * @param {number} y - The vertical bounce, relative to 1.
+     * @param {?number} y - The vertical bounce, relative to 1.
      *
      * @return {Phaser.Physics.Arcade.Body} This Body object.
      */


### PR DESCRIPTION
This PR

* Updates the Documentation

Describe the changes below:

y argument is optional, will be equal to x if not given