### PR TITLE
Warn, throw for particle texture frame mistakes

### DIFF
--- a/src/gameobjects/particles/Particle.js
+++ b/src/gameobjects/particles/Particle.js
@@ -293,6 +293,11 @@ var Particle = new Class({
 
         this.frame = emitter.getFrame();
 
+        if (!this.frame)
+        {
+            throw new Error('Particle has no texture frame');
+        }
+
         if (emitter.emitZone)
         {
             //  Updates particle.x and particle.y during this call

--- a/src/gameobjects/particles/ParticleEmitterManager.js
+++ b/src/gameobjects/particles/ParticleEmitterManager.js
@@ -245,6 +245,10 @@ var ParticleEmitterManager = new Class({
             {
                 out.push(this.texture.get(frame));
             }
+            else
+            {
+                console.warn('Texture "%s" has no frame "%s"', this.texture.key, frame);
+            }
         }
 
         if (out.length > 0)
@@ -253,6 +257,8 @@ var ParticleEmitterManager = new Class({
         }
         else
         {
+            console.warn('No texture frames were set');
+
             emitter.defaultFrame = this.defaultFrame;
         }
 


### PR DESCRIPTION
This PR

* Adds a new feature

Closes #5838 

- In `Particle#fire()`, an error is thrown if the particle has no texture frame. This prevents an uncaught error later when the particle fails to render.
- In `ParticleEmitterManager#setEmitterFrames()`, console warnings are printed if an invalid texture frame is given or if no texture frames were set.

