### PR TITLE
Add new `getNormal()` and `getNormalAt()` methods to `Curve` and `Path` classes

### DIFF
--- a/src/curves/Curve.js
+++ b/src/curves/Curve.js
@@ -490,6 +490,46 @@ var Curve = new Class({
     },
 
     /**
+     * Get a unit vector normal at a relative position on the curve.
+     *
+     * @method Phaser.Curves.Curve#getNormal
+     * @since 3.60.0
+     *
+     * @generic {Phaser.Math.Vector2} O - [out,$return]
+     *
+     * @param {number} t - The relative position on the curve, [0..1].
+     * @param {Phaser.Math.Vector2} [out] - A vector to store the result in.
+     *
+     * @return {Phaser.Math.Vector2} The normal vector.
+     */
+    getNormal: function (t, out)
+    {
+        if (out === undefined) { out = new Vector2(); }
+
+        return this.getTangent(t, out).rotate(Math.PI / 2);
+    },
+
+    /**
+     * Get a unit vector normal at a relative position on the curve, by arc length.
+     *
+     * @method Phaser.Curves.Curve#getNormalAt
+     * @since 3.60.0
+     *
+     * @generic {Phaser.Math.Vector2} O - [out,$return]
+     *
+     * @param {number} u - The relative position on the curve, [0..1].
+     * @param {Phaser.Math.Vector2} [out] - A vector to store the result in.
+     *
+     * @return {Phaser.Math.Vector2} The normal vector.
+     */
+    getNormalAt: function (u, out)
+    {
+        var t = this.getUtoTmapping(u);
+
+        return this.getNormal(t, out);
+    },
+
+    /**
      * Given a distance in pixels, get a t to find p.
      *
      * @method Phaser.Curves.Curve#getTFromDistance

--- a/src/curves/Curve.js
+++ b/src/curves/Curve.js
@@ -504,8 +504,6 @@ var Curve = new Class({
      */
     getNormal: function (t, out)
     {
-        if (out === undefined) { out = new Vector2(); }
-
         return this.getTangent(t, out).rotate(Math.PI / 2);
     },
 

--- a/src/curves/path/Path.js
+++ b/src/curves/path/Path.js
@@ -748,8 +748,6 @@ var Path = new Class({
      */
     getNormal: function (t, out)
     {
-        if (out === undefined) { out = new Vector2(); }
-
         return this.getTangent(t, out).rotate(MATH_CONST.TAU);
     },
 

--- a/src/curves/path/Path.js
+++ b/src/curves/path/Path.js
@@ -734,6 +734,26 @@ var Path = new Class({
     },
 
     /**
+     * Gets a unit vector normal at a relative position on the path.
+     *
+     * @method Phaser.Curves.Path#getNormal
+     * @since 3.60.0
+     *
+     * @generic {Phaser.Math.Vector2} O - [out,$return]
+     *
+     * @param {number} t - The relative position on the path, [0..1].
+     * @param {Phaser.Math.Vector2} [out] - A vector to store the result in.
+     *
+     * @return {Phaser.Math.Vector2} Vector approximating the normal line at the point t (delta +/- 0.0001)
+     */
+    getNormal: function (t, out)
+    {
+        if (out === undefined) { out = new Vector2(); }
+
+        return this.getTangent(t, out).rotate(MATH_CONST.TAU);
+    },
+
+    /**
      * Creates a line curve from the previous end point to x/y.
      *
      * @method Phaser.Curves.Path#lineTo


### PR DESCRIPTION
This PR

* Adds a new feature

Describe the changes below:

_As Pomax wrote on the Bezier.js website,_
> In 2d, the normal is simply the normalised tangent vector, rotated by a quarter turn.