### PR TITLE
Print a console error when file processing fails

### DIFF
--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -412,6 +412,7 @@ var File = new Class({
      */
     onProcessError: function ()
     {
+        // eslint-disable-next-line no-console
         console.error('Failed to process file: %s "%s"', this.type, this.key);
 
         this.state = CONST.FILE_ERRORED;

--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -412,6 +412,8 @@ var File = new Class({
      */
     onProcessError: function ()
     {
+        console.error('Failed to process file: %s "%s"', this.type, this.key);
+
         this.state = CONST.FILE_ERRORED;
 
         if (this.multiFile)

--- a/src/loader/MultiFile.js
+++ b/src/loader/MultiFile.js
@@ -232,6 +232,7 @@ var MultiFile = new Class({
         {
             this.failed++;
 
+            // eslint-disable-next-line no-console
             console.error('File failed: %s "%s" (via %s "%s")', this.type, this.key, file.type, file.key);
         }
     }

--- a/src/loader/MultiFile.js
+++ b/src/loader/MultiFile.js
@@ -231,6 +231,8 @@ var MultiFile = new Class({
         if (index !== -1)
         {
             this.failed++;
+
+            console.error('File failed: %s "%s" (via %s "%s")', this.type, this.key, file.type, file.key);
         }
     }
 

--- a/src/loader/filetypes/JSONFile.js
+++ b/src/loader/filetypes/JSONFile.js
@@ -104,8 +104,6 @@ var JSONFile = new Class({
             }
             catch (e)
             {
-                console.warn('Invalid JSON: ' + this.key);
-
                 this.onProcessError();
 
                 throw e;

--- a/src/loader/filetypes/XMLFile.js
+++ b/src/loader/filetypes/XMLFile.js
@@ -83,8 +83,6 @@ var XMLFile = new Class({
         }
         else
         {
-            console.warn('Invalid XMLFile: ' + this.key);
-            
             this.onProcessError();
         }
     }


### PR DESCRIPTION
This PR

* Adds a new feature

Closes #5862 

I used `console.error()` but I could change it to `console.warn()` if that's preferred.

