### PR TITLE
Loading retry improvements

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -53,8 +53,6 @@ module.exports = [
                     });
                 }
             }
-        ],
-
-        devtool: 'source-map'
+        ]
     }
 ];

--- a/src/core/Config.js
+++ b/src/core/Config.js
@@ -533,7 +533,7 @@ var Config = new Class({
         /**
          * @const {number} Phaser.Core.Config#loaderMaxRetries - The number of times to retry a file load if it fails.
          */
-        this.loaderMaxRetries = GetValue(config, 'loader.maxRetries', 2);
+        this.loaderMaxRetries = GetValue(config, 'loader.maxRetries', 5);
 
         /**
          * @const {boolean} Phaser.Core.Config#loaderWithCredentials - Optional XHR withCredentials value.

--- a/src/core/typedefs/LoaderConfig.js
+++ b/src/core/typedefs/LoaderConfig.js
@@ -14,5 +14,5 @@
  * @property {string[]} [localScheme] - An optional array of schemes that the Loader considers as being 'local' files. Defaults to: `[ 'file://', 'capacitor://' ]` if not specified.
  * @property {boolean} [withCredentials=false] - Optional XHR withCredentials value.
  * @property {string} [imageLoadType='XHR'] - Optional load type for image, `XHR` is default, or `HTMLImageElement` for a lightweight way.
- * @property {number} [maxRetries=2] - The number of times to retry the file load if it fails.
+ * @property {number} [maxRetries=5] - The number of times to retry the file load if it fails.
  */

--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -256,7 +256,7 @@ var File = new Class({
          *
          * @name Phaser.Loader.File#maxRetries
          * @type {number}
-         * @default 2
+         * @default 5
          * @since 3.88.0
          */
         this.maxRetries = GetFastValue(this.xhrSettings, 'maxRetries', loader.maxRetries);

--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -259,7 +259,7 @@ var File = new Class({
          * @default 2
          * @since 3.88.0
          */
-        this.maxRetries = GetFastValue(fileConfig, 'maxRetries', loader.maxRetries);
+        this.maxRetries = GetFastValue(this.xhrSettings, 'maxRetries', loader.maxRetries);
 
         /**
          * The counter for the number of times loading has failed and was retried.

--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -368,7 +368,7 @@ var File = new Class({
 
         this.resetXHR();
 
-        this.loader.nextFile(this, success);
+        this.loader.nextFile(this, success, event);
     },
 
     /**
@@ -418,7 +418,7 @@ var File = new Class({
         }
         else
         {
-            this.loader.nextFile(this, false);
+            this.loader.nextFile(this, false, event);
         }
     },
 

--- a/src/loader/File.js
+++ b/src/loader/File.js
@@ -396,12 +396,13 @@ var File = new Class({
      * Called if the file errors while loading, is sent a DOM ProgressEvent.
      *
      * @method Phaser.Loader.File#onError
+     * @fires Phaser.Loader.Events#FILE_LOAD_RETRY
      * @since 3.0.0
      *
      * @param {XMLHttpRequest} xhr - The XMLHttpRequest that caused this onload event.
      * @param {ProgressEvent} event - The DOM ProgressEvent that resulted from this error.
      */
-    onError: function ()
+    onError: function (xhr, event)
     {
         this.resetXHR();
 
@@ -410,6 +411,8 @@ var File = new Class({
             var retryDelay = Math.min(Math.pow(2, this.retries) * 100, 5000); // ms
 
             this.retries++;
+
+            this.loader.emit(Events.FILE_LOAD_RETRY, this, event, this.retries);
 
             setTimeout(this.load.bind(this), retryDelay);
         }

--- a/src/loader/LoaderPlugin.js
+++ b/src/loader/LoaderPlugin.js
@@ -1029,8 +1029,9 @@ var LoaderPlugin = new Class({
      *
      * @param {Phaser.Loader.File} file - The File that just finished loading, or errored during load.
      * @param {boolean} success - `true` if the file loaded successfully, otherwise `false`.
+     * @param {Event | string} [event] - The Event that resulted from an error, if loading was not successful.
      */
-    nextFile: function (file, success)
+    nextFile: function (file, success, event)
     {
         //  Has the game been destroyed during load? If so, bail out now.
         if (!this.inflight)
@@ -1058,7 +1059,7 @@ var LoaderPlugin = new Class({
 
             this._deleteQueue.set(file);
 
-            this.emit(Events.FILE_LOAD_ERROR, file);
+            this.emit(Events.FILE_LOAD_ERROR, file, event);
 
             this.fileProcessComplete(file);
         }

--- a/src/loader/LoaderPlugin.js
+++ b/src/loader/LoaderPlugin.js
@@ -349,10 +349,10 @@ var LoaderPlugin = new Class({
 
         /**
          * The number of times to retry loading a single file before it fails.
-         * 
+         *
          * This property is read by the `File` object when it is created and set to
          * the internal property of the same name. It's not used by the Loader itself.
-         * 
+         *
          * You can set this value via the Game Config, or you can adjust this property
          * at any point after the Loader has started. However, it will not apply to files
          * that have already been added to the Loader, only those added after this value
@@ -360,7 +360,7 @@ var LoaderPlugin = new Class({
          *
          * @name Phaser.Loader.LoaderPlugin#maxRetries
          * @type {number}
-         * @default 2
+         * @default 5
          * @since 3.85.0
          */
         this.maxRetries = GetFastValue(sceneConfig, 'maxRetries', gameConfig.loaderMaxRetries);

--- a/src/loader/events/FILE_LOAD_ERROR_EVENT.js
+++ b/src/loader/events/FILE_LOAD_ERROR_EVENT.js
@@ -7,7 +7,7 @@
 /**
  * The File Load Error Event.
  *
- * This event is dispatched by the Loader Plugin when a file fails to load.
+ * This event is dispatched by the Loader Plugin when a file fails to load without retry.
  *
  * Listen to it from a Scene using: `this.load.on('loaderror', listener)`.
  *
@@ -16,5 +16,6 @@
  * @since 3.0.0
  *
  * @param {Phaser.Loader.File} file - A reference to the File which errored during load.
+ * @param {Event | string} event - The Event that resulted from this error.
  */
 module.exports = 'loaderror';

--- a/src/loader/events/FILE_LOAD_RETRY_EVENT.js
+++ b/src/loader/events/FILE_LOAD_RETRY_EVENT.js
@@ -1,0 +1,23 @@
+/**
+ * @author       Richard Davey <rich@phaser.io>
+ * @author       Pavle Goloskokovic <pgoloskokovic@gmail.com> (http://prunegames.com)
+ * @copyright    2013-2024 Phaser Studio Inc.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+/**
+ * The File Load Retry Event.
+ *
+ * This event is dispatched by the Loader Plugin when a file fails to load but will retry loading.
+ *
+ * Listen to it from a Scene using: `this.load.on('loadretry', listener)`.
+ *
+ * @event Phaser.Loader.Events#FILE_LOAD_RETRY
+ * @type {string}
+ * @since 3.88.0
+ *
+ * @param {Phaser.Loader.File} file - A reference to the File which errored during load, and is retrying.
+ * @param {ProgressEvent} event - The DOM ProgressEvent that resulted from this error.
+ * @param {number} retries - The number of times loading has failed and was retried.
+ */
+module.exports = 'loadretry';

--- a/src/loader/events/FILE_PROGRESS_EVENT.js
+++ b/src/loader/events/FILE_PROGRESS_EVENT.js
@@ -16,7 +16,7 @@
  * @type {string}
  * @since 3.0.0
  *
- * @param {Phaser.Loader.File} file - A reference to the File which errored during load.
+ * @param {Phaser.Loader.File} file - A reference to the File which is loading.
  * @param {number} percentComplete - A value between 0 and 1 indicating how 'complete' this file is.
  */
 module.exports = 'fileprogress';

--- a/src/loader/events/index.js
+++ b/src/loader/events/index.js
@@ -14,6 +14,7 @@ module.exports = {
     COMPLETE: require('./COMPLETE_EVENT'),
     FILE_COMPLETE: require('./FILE_COMPLETE_EVENT'),
     FILE_KEY_COMPLETE: require('./FILE_KEY_COMPLETE_EVENT'),
+    FILE_LOAD_RETRY: require('./FILE_LOAD_RETRY_EVENT'),
     FILE_LOAD_ERROR: require('./FILE_LOAD_ERROR_EVENT'),
     FILE_LOAD: require('./FILE_LOAD_EVENT'),
     FILE_PROGRESS: require('./FILE_PROGRESS_EVENT'),

--- a/src/loader/filetypes/HTML5AudioFile.js
+++ b/src/loader/filetypes/HTML5AudioFile.js
@@ -87,8 +87,10 @@ var HTML5AudioFile = new Class({
      *
      * @method Phaser.Loader.FileTypes.HTML5AudioFile#onError
      * @since 3.0.0
+     *
+     * @param {Event | string} event - The Event that resulted from this error.
      */
-    onError: function ()
+    onError: function (event)
     {
         for (var i = 0; i < this.data.length; i++)
         {
@@ -98,7 +100,7 @@ var HTML5AudioFile = new Class({
             audio.onerror = null;
         }
 
-        this.loader.nextFile(this, false);
+        this.loader.nextFile(this, false, event);
     },
 
     /**

--- a/src/loader/filetypes/ImageFile.js
+++ b/src/loader/filetypes/ImageFile.js
@@ -178,9 +178,9 @@ var ImageFile = new Class({
             _this.loader.nextFile(_this, true);
         };
 
-        this.data.onerror = function ()
+        this.data.onerror = function (event)
         {
-            _this.loader.nextFile(_this, false);
+            _this.loader.nextFile(_this, false, event);
         };
 
         this.data.src = this.src;

--- a/src/loader/typedefs/FileConfig.js
+++ b/src/loader/typedefs/FileConfig.js
@@ -51,5 +51,4 @@
  * @property {string} [systemKey] - If this plugin is to be added to Scene.Systems, this is the property key for it.
  * @property {string} [sceneKey] - If this plugin is to be added to the Scene, this is the property key for it.
  * @property {Phaser.Types.Loader.FileTypes.SVGSizeConfig} [svgConfig] - The svg size configuration object.
- * @property {number} [maxRetries=2] - The number of times to retry the file load if it fails.
  */

--- a/src/loader/typedefs/XHRSettingsObject.js
+++ b/src/loader/typedefs/XHRSettingsObject.js
@@ -12,5 +12,6 @@
  * @property {(string|undefined)} [headerValue] - This value is used to populate the XHR `setRequestHeader` and is undefined by default.
  * @property {(string|undefined)} [requestedWith] - This value is used to populate the XHR `setRequestHeader` and is undefined by default.
  * @property {(string|undefined)} [overrideMimeType] - Provide a custom mime-type to use instead of the default.
- * @property {boolean} [withCredentials=false] - The withCredentials property indicates whether or not cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting withCredentials has no effect on same-site requests.
+ * @property {boolean} [withCredentials=false] - The withCredentials property indicates whether cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting withCredentials has no effect on same-site requests.
+ * @property {number} [maxRetries=2] - The number of times to retry the file load if it fails.
  */

--- a/src/loader/typedefs/XHRSettingsObject.js
+++ b/src/loader/typedefs/XHRSettingsObject.js
@@ -13,5 +13,5 @@
  * @property {(string|undefined)} [requestedWith] - This value is used to populate the XHR `setRequestHeader` and is undefined by default.
  * @property {(string|undefined)} [overrideMimeType] - Provide a custom mime-type to use instead of the default.
  * @property {boolean} [withCredentials=false] - The withCredentials property indicates whether cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting withCredentials has no effect on same-site requests.
- * @property {number} [maxRetries=2] - The number of times to retry the file load if it fails.
+ * @property {number} [maxRetries=5] - The number of times to retry the file load if it fails.
  */


### PR DESCRIPTION
This PR improves an existing feature:

- Implemented retries with exponential backoff which is a technique that retries loading with an exponentially increasing delay time, up to a maximum retry count
- Increased default `maxRetries` value to `5`, which together with exponential backoff increases possible loading error recovery time to ~3 seconds compared to previous less then 100ms
- Added `FILE_LOAD_RETRY` event to Loader Plugin to enable listening to retry occurrences
- `FILE_LOAD_ERROR` now also emits Event that resulted form an error as an argument to provide more details to user regarding error cause
- Moved `maxRetries` setting from `FileConfig` to `XHRSettingsObject` provided to any Loader Plugin method call, to make it possible to override value per file, since there is no way to define properties on `fileConfig` directly
- Few other fixes along the way
