### PR TITLE
Fix SinCosTable types

### DIFF
--- a/src/math/typedefs/SinCosTable.js
+++ b/src/math/typedefs/SinCosTable.js
@@ -2,7 +2,7 @@
  * @typedef {object} Phaser.Types.Math.SinCosTable
  * @since 3.0.0
  *
- * @property {number} sin - The sine value.
- * @property {number} cos - The cosine value.
- * @property {number} length - The length.
+ * @property {number[]} sin - The sine values.
+ * @property {number[]} cos - The cosine values.
+ * @property {number} length - The length of the table.
  */


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation
* Fixes a bug

Describe the changes below:

The types for `SinCosTable` are incorrect. I fixed them since I think this might be helpful in my game, so I wanted to share a quick fix!

Cheers!

Edit:

Now that I look at the actual source code and values generated, I am not entirely sure what this function is actually doing. Ended up just using my own table which gives values that make a lot more sense to me.

```ts
export function generateCosTable(size: number): number[] {
  const cosTable = [];
  for (let i = 0; i < size; i++) {
    cosTable.push(Math.cos((i / size) * Math.PI * 2));
  }
  return cosTable;
}
```

The PR is still relevant to fixing types though!