### PR TITLE
Fix audio files not loading from Base64 data URIs

### DIFF
--- a/src/loader/XHRLoader.js
+++ b/src/loader/XHRLoader.js
@@ -27,9 +27,17 @@ var XHRLoader = function (file, globalXHRSettings)
     {
         var base64Data = file.url.split(';base64,').pop() || file.url.split(',').pop();
 
-        var fakeXHR = {
-            responseText: atob(base64Data)
-        };
+        var fakeXHR;
+
+        if (file.xhrSettings.responseType === 'arraybuffer') {
+            fakeXHR = {
+                response: Uint8Array.from(atob(base64Data), c => c.charCodeAt(0)).buffer
+            };
+        } else {
+            fakeXHR = {
+                responseText: atob(base64Data)
+            };
+        }
 
         file.onBase64Load(fakeXHR);
 


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

When sending an XHR with `responseType: 'arraybuffer'`, the `response` field will get populated with an `ArrayBuffer`. The fake XHR code path doesn't do this, so audio files, which expect this field, can't be loaded from base64.
The fix uses [this](https://stackoverflow.com/a/41106346) workaround to do the conversion. Tested with a few jsfxr outputs and found no issues.