### PR TITLE
Fix: prevent gamepad buttons from sending bogus down events on init

### DIFF
--- a/src/input/gamepad/Button.js
+++ b/src/input/gamepad/Button.js
@@ -19,12 +19,13 @@ var Events = require('./events');
  *
  * @param {Phaser.Input.Gamepad.Gamepad} pad - A reference to the Gamepad that this Button belongs to.
  * @param {number} index - The index of this Button.
+ * @param {boolean} isPressed - Whether or not the button is already being pressed at creation time.  This prevents the Button from emitting spurious 'down' events at first update.
  */
 var Button = new Class({
 
     initialize:
 
-    function Button (pad, index)
+    function Button (pad, index, isPressed)
     {
         /**
          * A reference to the Gamepad that this Button belongs to.
@@ -82,7 +83,7 @@ var Button = new Class({
          * @default false
          * @since 3.0.0
          */
-        this.pressed = false;
+        this.pressed = isPressed;
     },
 
     /**

--- a/src/input/gamepad/Gamepad.js
+++ b/src/input/gamepad/Gamepad.js
@@ -83,7 +83,7 @@ var Gamepad = new Class({
 
         for (var i = 0; i < pad.buttons.length; i++)
         {
-            buttons.push(new Button(this, i));
+            buttons.push(new Button(this, i, (pad.buttons[i].value >= 0.5)));
         }
 
         /**


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Fixes a bug

Describe the changes below:

Phaser is always initializing Gamepad buttons as not being pressed. This creates a problem when reading gamepad inputs in one scene, which starts another, and then reading gamepad inputs in the second scene.  If the player holds the button down for a tiny, tiny bit in the first scene, the second scene sees a bogus `down` event.

The fix introduces a new, boolean parameter to gamepad Button's constructor, `isPressed`.  When gamepad is initializing its buttons, it checks the current value for the button.  If it's greater or equal to 0.5, Gamepad considers the Button pressed and passes true for this parameter.  Otherwise, it passes false.  Button then uses the isPressed parameter to initialize its official `pressed` property.  By initializing with the current pressed state of the gamepad Button, the fix eliminates the bogus event at scene start.

[This Phaselet](https://phaser.io/sandbox/HgqW9szf) tests for the bug.  Grab a gamepad and follow the directions.
