### PR TITLE
Use first item of an array of tilesets when making a TilemapGPULayer

### DIFF
--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -590,7 +590,7 @@ var Tilemap = new Class({
      * @param {(string|string[]|Phaser.Tilemaps.Tileset|Phaser.Tilemaps.Tileset[])} tileset - The tileset, or an array of tilesets, used to render this layer. Can be a string or a Tileset object.
      * @param {number} [x=0] - The x position to place the layer in the world. If not specified, it will default to the layer offset from Tiled or 0.
      * @param {number} [y=0] - The y position to place the layer in the world. If not specified, it will default to the layer offset from Tiled or 0.
-     * @param {boolean} [gpu=false] - Create a TilemapGPULayer instead of a TilemapLayer. This option is WebGL-only. A TilemapGPULayer is less flexible, but can be much faster.
+     * @param {boolean} [gpu=false] - Create a TilemapGPULayer instead of a TilemapLayer. This option is WebGL-only. A TilemapGPULayer is less flexible, but can be much faster. When `true`, if `tileset` is an array, only the first element of the array is used as the tileset.
      *
      * @return {?Phaser.Tilemaps.TilemapLayer|?Phaser.Tilemaps.TilemapGPULayer} Returns the new layer was created, or null if it failed.
      */
@@ -637,6 +637,15 @@ var Tilemap = new Class({
 
         if (gpu)
         {
+            if (Array.isArray(tileset))
+            {
+                if (tileset.length > 1)
+                {
+                    console.warn('TilemapGPULayer can only use one tileset. Using the first item given.');
+                }
+                tileset = tileset[0];
+            }
+
             layer = new TilemapGPULayer(this.scene, this, index, tileset, x, y);
         }
         else

--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -587,10 +587,10 @@ var Tilemap = new Class({
      * @since 3.0.0
      *
      * @param {(number|string)} layerID - The layer array index value, or if a string is given, the layer name from Tiled.
-     * @param {(string|string[]|Phaser.Tilemaps.Tileset|Phaser.Tilemaps.Tileset[])} tileset - The tileset, or an array of tilesets, used to render this layer. Can be a string or a Tileset object.
+     * @param {(string|string[]|Phaser.Tilemaps.Tileset|Phaser.Tilemaps.Tileset[])} tileset - The tileset, or an array of tilesets, used to render this layer. Can be a string or a Tileset object. When this is an array, if `gpu` is `true`, only the first element in the array is used as the tileset.
      * @param {number} [x=0] - The x position to place the layer in the world. If not specified, it will default to the layer offset from Tiled or 0.
      * @param {number} [y=0] - The y position to place the layer in the world. If not specified, it will default to the layer offset from Tiled or 0.
-     * @param {boolean} [gpu=false] - Create a TilemapGPULayer instead of a TilemapLayer. This option is WebGL-only. A TilemapGPULayer is less flexible, but can be much faster. When `true`, if `tileset` is an array, only the first element of the array is used as the tileset.
+     * @param {boolean} [gpu=false] - Create a TilemapGPULayer instead of a TilemapLayer. This option is WebGL-only. A TilemapGPULayer is less flexible, but can be much faster.
      *
      * @return {?Phaser.Tilemaps.TilemapLayer|?Phaser.Tilemaps.TilemapGPULayer} Returns the new layer was created, or null if it failed.
      */


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

In the `createLayer` method on a tilemap, it says that a string or tileset (or an array of those) can be passed in for `tileset`. However, the TilemapGPULayer (according to its documentation) can only support one tileset. And so, when the `gpu` parameter was true, the GPU layer didn't expect to see an array, and so when passing in an array, it breaks.

Now, when `gpu` is set to true, it checks if `tileset` is an array. If it is, then it will only pass in the first item of that array when creating the layer. If the array has more than one item, it gives a warning.

Fix #7158