### PR TITLE
Add optional sortByY param to tilemap createFromObjects method

### DIFF
--- a/src/tilemaps/Tilemap.js
+++ b/src/tilemaps/Tilemap.js
@@ -818,6 +818,11 @@ var Tilemap = new Class({
 
         var objects = objectLayer.objects;
 
+        if (config.sortByY))
+        {
+            objects.sort((a,b) => a.y > b.y ? 1 : -1)
+        }
+
         for (var c = 0; c < config.length; c++)
         {
             var singleConfig = config[ c ];

--- a/src/tilemaps/typedefs/CreateFromObjectLayerConfig.js
+++ b/src/tilemaps/typedefs/CreateFromObjectLayerConfig.js
@@ -12,4 +12,5 @@
  * @property {Phaser.GameObjects.Container} [container] - Optional Container to which the Game Objects are added.
  * @property {(string|Phaser.Textures.Texture)} [key] - Optional key of a Texture to be used, as stored in the Texture Manager, or a Texture instance. If omitted, the object's gid's tileset key is used if available.
  * @property {(string|number)} [frame] - Optional name or index of the frame within the Texture. If omitted, the tileset index is used, assuming that spritesheet frames exactly match tileset indices & geometries -- if available.
+ * @property {boolean} [sortByY=false] - Sort objects in layer by their y position. Objects with a higher y are displayed above objects with a lower y.
  */


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:
Setting the optional sortByY attribute in the config sorts tilemap layer objects before creation by y position which leads to objects that are lower on screen being displayed on top of higher objects. Tiled uses this sort order by default.