### PR TITLE
Adding nullish check for gamepad remove all listeners

### DIFF
--- a/src/input/gamepad/GamepadPlugin.js
+++ b/src/input/gamepad/GamepadPlugin.js
@@ -300,7 +300,6 @@ var GamepadPlugin = new Class({
 
         for (var i = 0; i < this.gamepads.length; i++)
         {
-            console.log("you are here in phaser stop listeners22", this.gamepads[i])
             if(this.gamepads[i]){
                 this.gamepads[i].removeAllListeners();
             }

--- a/src/input/gamepad/GamepadPlugin.js
+++ b/src/input/gamepad/GamepadPlugin.js
@@ -300,7 +300,10 @@ var GamepadPlugin = new Class({
 
         for (var i = 0; i < this.gamepads.length; i++)
         {
-            this.gamepads[i].removeAllListeners();
+            console.log("you are here in phaser stop listeners22", this.gamepads[i])
+            if(this.gamepads[i]){
+                this.gamepads[i].removeAllListeners();
+            }
         }
     },
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Updates the Documentation
* Adds a new feature
* Fixes a bug

Describe the changes below:

Fixes a Bug

Solves Issue #7186 

Adds check for nullish gamepads while looping through gamepads. If there was a nullish gamepad, phaser would crash, so I just simply checked to see if there was a gamepad to stop it from crashing

