### PR TITLE
Update JSDoc for `Phaser.Math.Wrap`

### DIFF
--- a/src/math/Wrap.js
+++ b/src/math/Wrap.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * Wrap the given `value` between `min` and `max`.
+ * Wrap the given `value` between `min` and `max - 1`.
  *
  * @function Phaser.Math.Wrap
  * @since 3.0.0


### PR DESCRIPTION
This PR:

* Updates the Documentation

Describe the changes below:

The doc now mentions that it wraps between `min` and `max - 1` instead of between `min` and `max`,
to match the behavior of the function.