### PR TITLE
add build dir to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -19,3 +19,4 @@ webpack-nospector.config.js
 webpack.dist.config.js
 webpack.fb.config.js
 webpack.fb.dist.config.js
+build/


### PR DESCRIPTION
so that viewing built phaser.js in editor is not full or errors


