### PR TITLE
fix(loader): recognize file:// as absolute URL in GetURL() to support offline environments

### DIFF
--- a/src/loader/GetURL.js
+++ b/src/loader/GetURL.js
@@ -22,7 +22,7 @@ var GetURL = function (file, baseURL)
         return false;
     }
 
-    if (file.url.match(/^(?:blob:|data:|capacitor:\/\/|http:\/\/|https:\/\/|\/\/)/))
+    if (file.url.match(/^(?:blob:|data:|capacitor:\/\/|file:\/\/|http:\/\/|https:\/\/|\/\/)/))
     {
         return file.url;
     }


### PR DESCRIPTION
### fix(loader): recognize `file://` as absolute in `GetURL()`

#### Summary
Under the **`file://` protocol**, `Phaser.Loader.GetURL()` does not treat `file://` URLs as absolute. When a `baseURL` is set, it
gets **prepended** to an already-absolute `file://` path, producing double-prefixed URLs like:

```
file:///Users/.../spine--demo.../file:///Users/.../assets/spine/spineboy-pma.png
```

**Important scope clarification:** In my environment, **_all other assets load correctly_** under `file://` + `setBaseURL(...)`.  
The problem manifests specifically when **Spine atlas-derived page images (the `.png` listed inside the `.atlas`)** are queued.  
Those page images sometimes end up with an **absolute `file://` in `file.url`**, and `GetURL()` then prepends `baseURL` again.

This PR adds `file://` to the absolute-URL check so `GetURL()` returns the original URL and does not concatenate `baseURL`.
This keeps atlas page images consistent with all other file types that already behave correctly in the same environment.

---

#### Why this matters
In our setup we **must** run under **`file://`** (no local HTTP server available) **and** we **must** use `this.load.setBaseURL(...)`
to keep asset resolution consistent across browsers. Without this patch, using both `file://` + `baseURL` breaks **Spine atlas page PNGs**,
while other assets remain fine. With this patch, Phaser treats `file://` just like `http(s)`, `blob:`, and `data:`.

---

#### Changes
```diff
// src/loader/GetURL.js

var GetURL = function (file, baseURL)
{
    if (!file.url)
    {
        return false;
    }

-   if (file.url.match(/^(?:blob:|data:|capacitor:\/\/|http:\/\/|https:\/\/|\/\/)/))
+   if (file.url.match(/^(?:blob:|data:|capacitor:\/\/|file:\/\/|http:\/\/|https:\/\/|\/\/)/))
    {
        return file.url;
    }
    else
    {
        return baseURL + file.url;
    }
};
```

---

#### Results

| Environment           | Case                                      | `file.url`                                 | `file.src`                                              | Outcome |
|-----------------------|-------------------------------------------|---------------------------------------------|---------------------------------------------------------|---------|
| HTTP / HTTPS          | any asset                                 | `assets/bg.png`                             | `http://localhost/.../assets/bg.png`                    | ✅ OK   |
| `file://` (before)    | **Spine atlas _page PNG_** (derived file) | `file:///Users/.../spineboy-pma.png`        | `file:///base/.../file:///Users/.../spineboy-pma.png`   | ❌ BAD  |
| `file://` (after)     | **Spine atlas _page PNG_** (derived file) | `file:///Users/.../spineboy-pma.png`        | `file:///Users/.../spineboy-pma.png`                    | ✅ OK   |
| `file://` (baseline)  | regular images / audio / json             | `assets/...`                                | `file:///base/.../assets/...`                           | ✅ OK   |

---

#### Notes
- No impact on `http(s)`, `blob:`, `data:`, or `capacitor://` environments.
- Patch is isolated to `GetURL()`; no other loader behavior is changed.
- Verified on Phaser 3.90.0 (macOS + Chrome) under `file://` with `setBaseURL(...)` required for consistent resolution.