### PR TITLE
fix: Correct Group.angle description

### DIFF
--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -1390,12 +1390,12 @@ var Group = new Class({
     },
 
     /**
-     * Sets the angle of each group member.
+     * Adds the given value to the angle of each group member.
      *
      * @method Phaser.GameObjects.Group#angle
      * @since 3.21.0
      *
-     * @param {number} value - The amount to set the angle to, in degrees.
+     * @param {number} value - The amount to add to the angle, in degrees.
      * @param {number} [step=0] - This is added to the `value` amount, multiplied by the iteration counter.
      *
      * @return {this} This Group object.


### PR DESCRIPTION
This PR 

* Updates the Documentation

Describe the changes below:

Fixes #7084 The description incorrectly stated that the method 'Sets' the angle when it 
actually adds to it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates JSDoc for `Phaser.GameObjects.Group#angle` to state it adds to each member’s angle and adjusts the parameter description accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8285a78231648fbfe80b172afb0ad2a32b6f9204. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->