### PR TITLE
Fix ScaleManager not resizing to parent container (#7213)

### DIFF
--- a/src/scale/ScaleManager.js
+++ b/src/scale/ScaleManager.js
@@ -1542,8 +1542,15 @@ var ScaleManager = new Class({
         {
             _this.updateBounds();
 
+            // --- FIX START ---
+            // Recalculate parent container size and force Phaser to resize.
+            _this.getParentBounds();
+            _this.refresh();
+            // --- FIX END ---
+
             _this.dirty = true;
         };
+
 
         //  Only dispatched on mobile devices
         if (screen.orientation && screen.orientation.addEventListener)


### PR DESCRIPTION
This PR fixes issue #7213 where the ScaleManager fails to resize the game canvas
to match the size of its parent container.

Root Cause:
The window resize handler only updated canvas bounds, but did not re-measure the
parent container size. As a result, the Scale Manager used outdated parent size
values, causing the canvas to display incorrectly after window resize or mobile
orientation changes.

Fix:
- Added getParentBounds() and refresh() inside listeners.windowResize.
- Ensures the parent container size is always recalculated.
- Forces Phaser to re-run scale calculations using correct parent bounds.

Tested:
- Browser window resize (Chrome, Edge)
- CSS-driven container resizing
- Mobile device orientation change
- RESIZE and FIT scale modes

Result:
The canvas now consistently fills the parent container without clipping,
shifting, or leaving empty space.

This resolves #7213.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On window resize, recalculate parent bounds and refresh scaling so the canvas correctly resizes to its parent.
> 
> - **ScaleManager (`src/scale/ScaleManager.js`)**:
>   - Window resize listener now recalculates parent bounds and forces a scale refresh:
>     - Calls `getParentBounds()` and `refresh()` inside `listeners.windowResize` after `updateBounds()` to ensure canvas resizes to current parent size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 108e196e6ed24c3066e08686d8900b91c7a8158c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->