### PR TITLE
Add modern exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,15 @@
   "types": "./types/phaser.d.ts",
   "browser": "./dist/phaser.js",
   "module": "./dist/phaser.esm.js",
+  "exports": {
+    ".": {
+      "types": "./types/phaser.d.ts",
+      "import": "./dist/phaser.esm.js",
+      "require": "./dist/phaser.js",
+      "default": "./dist/phaser.esm.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://phaserjs@github.com/phaserjs/phaser.git"


### PR DESCRIPTION
This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

In order to use headless version of Phaser with vitest, an explicit alias is needed in the configuration:

```
    resolve: {
        alias: {
            // Phaser's "main" points to source that requires the devDependency
            // phaser3spectorjs. Redirect to the pre-built ESM bundle instead.
            phaser: "phaser/dist/phaser.esm.js",
        },
    },
```

This is unnecessary and ideally should be handled by explicitly defined export, which are added in this PR. I have validated that after this change alias is no longer necessary, vitest just works.