### PR TITLE
Docs: fix the suboptions in GroupCreateConfig

### DIFF
--- a/src/gameobjects/group/typedefs/GroupCreateConfig.js
+++ b/src/gameobjects/group/typedefs/GroupCreateConfig.js
@@ -22,47 +22,17 @@
  * @property {?boolean} [yoyo=false] - Select keys and frames by moving forward then backward through `key` and `frame`.
  * @property {?number} [frameQuantity=1] - The number of times each `frame` should be combined with one `key`.
  * @property {?number} [max=0] - The maximum number of new Game Objects to create. 0 is no maximum.
- * @property {?object} [setXY]
- * @property {?number} [setXY.x=0] - The horizontal position of each new Game Object.
- * @property {?number} [setXY.y=0] - The vertical position of each new Game Object.
- * @property {?number} [setXY.stepX=0] - Increment each Game Object's horizontal position from the previous by this amount, starting from `setXY.x`.
- * @property {?number} [setXY.stepY=0] - Increment each Game Object's vertical position from the previous by this amount, starting from `setXY.y`.
- * @property {?object} [setRotation]
- * @property {?number} [setRotation.value=0] - Rotation of each new Game Object.
- * @property {?number} [setRotation.step=0] - Increment each Game Object's rotation from the previous by this amount, starting at `setRotation.value`.
- * @property {?object} [setScale]
- * @property {?number} [setScale.x=0] - The horizontal scale of each new Game Object.
- * @property {?number} [setScale.y=0] - The vertical scale of each new Game Object.
- * @property {?number} [setScale.stepX=0] - Increment each Game Object's horizontal scale from the previous by this amount, starting from `setScale.x`.
- * @property {?number} [setScale.stepY=0] - Increment each Game object's vertical scale from the previous by this amount, starting from `setScale.y`.
- * @property {?object} [setOrigin]
- * @property {?number} [setOrigin.x=0] - The horizontal origin of each new Game Object.
- * @property {?number} [setOrigin.y=0] - The vertical origin of each new Game Object.
- * @property {?number} [setOrigin.stepX=0] - Increment each Game Object's horizontal origin from the previous by this amount, starting from `setOrigin.x`.
- * @property {?number} [setOrigin.stepY=0] - Increment each Game object's vertical origin from the previous by this amount, starting from `setOrigin.y`.
- * @property {?object} [setAlpha]
- * @property {?number} [setAlpha.value=0] - The alpha value of each new Game Object.
- * @property {?number} [setAlpha.step=0] - Increment each Game Object's alpha from the previous by this amount, starting from `setAlpha.value`.
- * @property {?object} [setDepth]
- * @property {?number} [setDepth.value=0] - The depth value of each new Game Object.
- * @property {?number} [setDepth.step=0] - Increment each Game Object's depth from the previous by this amount, starting from `setDepth.value`.
- * @property {?object} [setScrollFactor]
- * @property {?number} [setScrollFactor.x=0] - The horizontal scroll factor of each new Game Object.
- * @property {?number} [setScrollFactor.y=0] - The vertical scroll factor of each new Game Object.
- * @property {?number} [setScrollFactor.stepX=0] - Increment each Game Object's horizontal scroll factor from the previous by this amount, starting from `setScrollFactor.x`.
- * @property {?number} [setScrollFactor.stepY=0] - Increment each Game object's vertical scroll factor from the previous by this amount, starting from `setScrollFactor.y`.
+ * @property {?object} [setXY] - Options as named in {@link Phaser.Actions.SetXY}.
+ * @property {?object} [setRotation] - Options as named in {@link Phaser.Actions.SetRotation}.
+ * @property {?object} [setScale] - Options as named in {@link Phaser.Actions.SetScale}.
+ * @property {?object} [setOrigin] - Options as named in {@link Phaser.Actions.SetOrigin}.
+ * @property {?object} [setAlpha] - Options as named in {@link Phaser.Actions.SetAlpha}.
+ * @property {?object} [setDepth] - Options as named in {@link Phaser.Actions.SetDepth}.
+ * @property {?object} [setScrollFactor] - Options as named in {@link Phaser.Actions.SetScrollFactor}.
  * @property {?*} [hitArea] - A geometric shape that defines the hit area for the Game Object.
  * @property {?Phaser.Types.Input.HitAreaCallback} [hitAreaCallback] - A callback to be invoked when the Game Object is interacted with.
  * @property {?(false|Phaser.Types.Actions.GridAlignConfig)} [gridAlign=false] - Align the new Game Objects in a grid using these settings.
  *
- * @see Phaser.Actions.GridAlign
- * @see Phaser.Actions.SetAlpha
- * @see Phaser.Actions.SetHitArea
- * @see Phaser.Actions.SetRotation
- * @see Phaser.Actions.SetScale
- * @see Phaser.Actions.SetXY
- * @see Phaser.Actions.SetDepth
- * @see Phaser.Actions.SetScrollFactor
  * @see Phaser.GameObjects.Group#createFromConfig
  * @see Phaser.Utils.Array.Range
  */


### PR DESCRIPTION
This PR

* Updates the Documentation
* Fixes a bug (TypeScript declarations)

In `GroupCreateConfig` JSDOC properties like `setXY.x` were being interpreted as verbatim property names for TypeScript, which was wrong, so I removed all of them.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates `GroupCreateConfig` JSDoc to avoid incorrect TypeScript property inference; no runtime behavior changes.
> 
> **Overview**
> Simplifies the `Phaser.Types.GameObjects.Group.GroupCreateConfig` JSDoc by removing nested sub-properties like `setXY.x` / `setScale.stepX` that were being misread as literal TypeScript fields.
> 
> The `setXY`, `setRotation`, `setScale`, `setOrigin`, `setAlpha`, `setDepth`, and `setScrollFactor` entries are now documented as option objects that follow the corresponding `Phaser.Actions.*` config shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ed61aaa667295c1ac3d8b0ea4310cb6d385cb46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->