### PR TITLE
Add x, y options to Group createMultiple()

### DIFF
--- a/src/gameobjects/group/Group.js
+++ b/src/gameobjects/group/Group.js
@@ -8,6 +8,7 @@ var Actions = require('../../actions/');
 var Class = require('../../utils/Class');
 var Events = require('../events');
 var EventEmitter = require('eventemitter3');
+var GetAdvancedValue = require('../../utils/object/GetAdvancedValue');
 var GetAll = require('../../utils/array/GetAll');
 var GetFastValue = require('../../utils/object/GetFastValue');
 var GetValue = require('../../utils/object/GetValue');
@@ -442,9 +443,15 @@ var Group = new Class({
             this.internalRemoveCallback = options.internalRemoveCallback;
         }
 
+        var x;
+        var y;
+
         for (var c = 0; c < range.length; c++)
         {
-            var created = this.create(0, 0, range[c].a, range[c].b, visible, active);
+            x = GetAdvancedValue(options, 'x', 0);
+            y = GetAdvancedValue(options, 'y', 0);
+
+            var created = this.create(x, y, range[c].a, range[c].b, visible, active);
 
             if (!created)
             {
@@ -458,8 +465,8 @@ var Group = new Class({
 
         if (HasValue(options, 'setXY'))
         {
-            var x = GetValue(options, 'setXY.x', 0);
-            var y = GetValue(options, 'setXY.y', 0);
+            x = GetValue(options, 'setXY.x', 0);
+            y = GetValue(options, 'setXY.y', 0);
             var stepX = GetValue(options, 'setXY.stepX', 0);
             var stepY = GetValue(options, 'setXY.stepY', 0);
 

--- a/src/gameobjects/group/typedefs/GroupCreateConfig.js
+++ b/src/gameobjects/group/typedefs/GroupCreateConfig.js
@@ -22,6 +22,8 @@
  * @property {?boolean} [yoyo=false] - Select keys and frames by moving forward then backward through `key` and `frame`.
  * @property {?number} [frameQuantity=1] - The number of times each `frame` should be combined with one `key`.
  * @property {?number} [max=0] - The maximum number of new Game Objects to create. 0 is no maximum.
+ * @property {?(number|number[]|object)} [x=0] - The horizontal position of each new Game Object. See value types in {@link Phaser.Utils.Objects.GetAdvancedValue}.
+ * @property {?(number|number[]|object)} [y=0] - The vertical position of each new Game Object. See value types in {@link Phaser.Utils.Objects.GetAdvancedValue}.
  * @property {?object} [setXY]
  * @property {?number} [setXY.x=0] - The horizontal position of each new Game Object.
  * @property {?number} [setXY.y=0] - The vertical position of each new Game Object.


### PR DESCRIPTION
This PR

* Adds a new feature

Adds `x` and `y` options to [Group#createMultiple()](https://docs.phaser.io/api-documentation/class/gameobjects-group#createmultiple). Values per [GetAdvancedValue()](https://docs.phaser.io/api-documentation/namespace/utils-objects#getadvancedvalue).

For Arcade Bodies this is a lot cleaner, as it initializes them with the desired position and you don't have to refresh/reset later.

### Examples

```js
this.group.createMultiple({
    // …
    x: 100,
    y: 100
});

this.group.createMultiple({
    // …
    x: { randInt: [0, 800] },
    y: { randInt: [0, 600] },
});

this.group.createMultiple({
    // …
    x: [100, 200, 300, 400],
    y: [500, 600]
});

this.group.createMultiple({
    // …
    x: () => Phaser.Math.RND.weightedPick(X),
    y: () => Phaser.Math.RND.weightedPick(Y)
});
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small additive change to `Group#createFromConfig` that only affects initial positions of newly created objects when `x`/`y` are provided; existing `setXY` behavior remains unchanged.
> 
> **Overview**
> **Adds support for per-object initial positioning in `Group#createMultiple()`.** `createFromConfig` now reads `x` and `y` from the creation config via `GetAdvancedValue` and passes them into `Group#create`, enabling fixed, array-driven, or dynamic/randomized coordinates at creation time.
> 
> Updates the `GroupCreateConfig` typedef to document the new `x`/`y` options and their supported value types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f41624869ad97653c1fb44901d76e71162bb60d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->