### PR TITLE
Docs: Text#setResolution() description

### DIFF
--- a/src/gameobjects/text/Text.js
+++ b/src/gameobjects/text/Text.js
@@ -1055,17 +1055,17 @@ var Text = new Class({
     },
 
     /**
-     * Set the resolution used by this Text object.
+     * Set the resolution of the Texture used by this Text object.
      *
-     * It allows for much clearer text on High DPI devices, at the cost of memory because it uses larger
-     * internal Canvas textures for the Text.
+     * Setting resolution above 1 is useful only if you're scaling up this Text object (or an ancestor) or zooming a Camera on it.
+     * Otherwise, any extra detail in the Texture would just be lost during rendering.
      *
-     * Therefore, please use with caution, as the more high res Text you have, the more memory it uses.
+     * Please use with caution, as the more high-resolution Text you have, the more memory it uses.
      *
      * @method Phaser.GameObjects.Text#setResolution
      * @since 3.12.0
      *
-     * @param {number} value - The resolution for this Text object to use.
+     * @param {number} value - The resolution for this Text object to use, relative to 1.
      *
      * @return {this} This Text object.
      */


### PR DESCRIPTION
This PR

* Updates the Documentation

I think the original description is now obsolete and has caused some user confusion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `Text#setResolution` JSDoc; no runtime behavior is modified, so risk is minimal aside from potential wording/expectation shifts.
> 
> **Overview**
> Updates the `Text#setResolution` JSDoc to clarify that it controls the *texture* resolution, is only beneficial when the Text (or an ancestor/camera) is scaled up, and that the value is relative to `1`.
> 
> Rewords the memory-use warning to emphasize the cost of higher-resolution text textures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c83a0e8ac674cc08a7bc3bb8f99634e991e43a97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->