### PR TITLE
fix(physics): update local body variable after creating MatterTileBody

### DIFF
--- a/src/physics/matter-js/MatterTileBody.js
+++ b/src/physics/matter-js/MatterTileBody.js
@@ -113,6 +113,8 @@ var MatterTileBody = new Class({
             {
                 this.setFromTileRectangle(options);
             }
+
+            body = this.body;
         }
         else
         {


### PR DESCRIPTION
## Description

Fixes a scope bug in MatterTileBody where the local 'body' variable remained null after creating the body via setFromTileCollision() or setFromTileRectangle(). This caused a crash when processing flipped tiles because Body.scale() was called with null.

## Bug

When Matter.World.convertTilemapLayer() processes a tile that has flipX or flipY set, it crashes with:


## Root Cause

The constructor declares a local body variable initialised to null, then creates the actual body via setFromTileCollision() or setFromTileRectangle() — both of which set this.body but never update the local body variable. Immediately after, the flip check reads from the stale local.

## Fix

Add one line to update the local body variable after the body is created:


Fixes #7267

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line fix in `MatterTileBody` constructor to prevent `null` body usage when scaling flipped tiles.
> 
> **Overview**
> Fixes a constructor scoping bug in `MatterTileBody` where the local `body` variable could remain `null` after creating a body from tile collision shapes or a tile rectangle.
> 
> After generating the body via `setFromTileCollision()` / `setFromTileRectangle()`, it now reassigns `body = this.body` so the subsequent flip handling (`Body.scale` for `flipX`/`flipY`) operates on the created body instead of crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415a5fc38feff75c168fe61dfb3b45d0ef9754d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->