### PR TITLE
Fix rounded Rectangle fill not rendering in WebGL

### DIFF
--- a/src/gameobjects/shape/rectangle/RectangleWebGLRenderer.js
+++ b/src/gameobjects/shape/rectangle/RectangleWebGLRenderer.js
@@ -38,11 +38,7 @@ var RectangleWebGLRenderer = function (renderer, src, drawingContext, parentMatr
     var defaultRenderNodes = src.defaultRenderNodes;
     var submitter = customRenderNodes.Submitter || defaultRenderNodes.Submitter;
 
-    if (src.isRounded && src.isFilled)
-    {
-        FillPathWebGL(pipeline, result.calc, src, alpha, dx, dy);
-    }
-    else if (src.isFilled)
+    if (src.isFilled)
     {
         if (src.isRounded)
         {


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR

* Fixes a bug

Fixes #7276

## Description

In `RectangleWebGLRenderer.js`, there was a stale code block that used undefined variables (`pipeline` and `result.calc`) from an older API. This block was a leftover from a previous refactor and caused a short-circuit before the correct rendering path was reached, resulting in the fill not being rendered for rounded rectangles when using the ESM build with the WebGL renderer.

### Changes

- Removed the dead `if (src.isRounded && src.isFilled)` block that referenced non-existent variables `pipeline` and `result.calc`.
- The existing `if (src.isFilled)` → `if (src.isRounded)` branch already handles rounded filled rectangles correctly via `FillPathWebGL`, so no additional logic was needed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unreachable/stale WebGL fill branch and routes filled rounded rectangles through the existing `FillPathWebGL` codepath, with minimal behavioral change outside the bug fix.
> 
> **Overview**
> Fixes filled rounded rectangles not rendering in WebGL by removing a stale early `if (src.isRounded && src.isFilled)` branch in `RectangleWebGLRenderer` that referenced undefined variables.
> 
> All filled rectangles now consistently go through the existing `if (src.isFilled)` path, using `FillPathWebGL` for rounded shapes and `FillRect` for non-rounded ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498b49ebde532455aa74e7b894b0cffba9d01314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->