### PR TITLE
add Tileset#animating

### DIFF
--- a/src/tilemaps/TilemapLayerWebGLRenderer.js
+++ b/src/tilemaps/TilemapLayerWebGLRenderer.js
@@ -78,7 +78,7 @@ var TilemapLayerWebGLRenderer = function (renderer, src, drawingContext, parentM
             continue;
         }
 
-        var tileIndex = tileset.getAnimatedTileId(tile.index, timeElapsed);
+        var tileIndex = tileset.getAnimatedTileId(tile.index, tileset.animating ? timeElapsed : 0);
 
         if (tileIndex === null)
         {

--- a/src/tilemaps/Tileset.js
+++ b/src/tilemaps/Tileset.js
@@ -197,6 +197,17 @@ var Tileset = new Class({
         */
         this.texCoordinates = [];
 
+        
+		/**
+		 * Whether the tileset animations should play or not. If false, animated tiles will stay on their first frame.
+		 *
+		 * @name Phaser.Tilemaps.Tileset#animating
+		 * @type {boolean}
+		 * @since 4.2.0
+		 * @default true
+		 */
+		this.animating = true;
+
         /**
          * The number of frames above which a tile is considered to have
          * many animation frames. This is used to optimize rendering.

--- a/tests/tilemaps/Tileset.test.js
+++ b/tests/tilemaps/Tileset.test.js
@@ -22,6 +22,7 @@ describe('Tileset', function ()
             expect(ts.columns).toBe(0);
             expect(ts.total).toBe(0);
             expect(ts.texCoordinates).toEqual([]);
+            expect(ts.animating).toBe(true);
             expect(ts.animationSearchThreshold).toBe(64);
             expect(ts.maxAnimationLength).toBe(0);
         });


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Adds a new field to Tileset class, Tileset.animating ; boolean ; whether the tileset animations should play or not. If false, animated tiles will stay on their first frame.

Phaser 4 supporting animated tilesets natively is very nice, but being able to propose an option to players to disable those background animations is important for accessibility reasons. I did not find a way to easily do that with current API so I added a field for that.