### PR TITLE
feature: added human-readable names for input keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phaser",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "phaser",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4"

--- a/src/input/keyboard/keys/GetKeyName.js
+++ b/src/input/keyboard/keys/GetKeyName.js
@@ -1,0 +1,27 @@
+/**
+ * @author       Richard Davey <rich@phaser.io>
+ * @copyright    2013-2026 Phaser Studio Inc.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+var KeyCodeNameMap = require('./KeyCodeNameMap');
+var KeyNames = require('./KeyNames');
+
+/**
+ * Converts a keycode or key name to a human-readable Key Name
+ *
+ * @function Phaser.Input.Keyboard.GetKeyName
+ * @since 4.1.0
+ *
+ * @param {(string|number)} key - The keycode or string to lookup.
+ * @return {string} The human-readable key name.
+ */
+var GetKeyName = function (key)
+{
+    if (typeof key === 'string') {
+        return KeyNames[key]
+    }
+    return KeyCodeNameMap[key]
+};
+
+module.exports = JustUp;

--- a/src/input/keyboard/keys/KeyCodeNameMap.js
+++ b/src/input/keyboard/keys/KeyCodeNameMap.js
@@ -1,0 +1,17 @@
+/**
+ * @author       Richard Davey <rich@phaser.io>
+ * @copyright    2013-2026 Phaser Studio Inc.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+var KeyCodes = require('./KeyCodes');
+var KeyNames = require('./KeyNames');
+
+var KeyCodeNameMap = {};
+
+for (var key in KeyCodes)
+{
+    KeyCodeNameMap[KeyCodes[key]] = KeyNames[key];
+}
+
+module.exports = KeyCodeNameMap;

--- a/src/input/keyboard/keys/KeyNames.js
+++ b/src/input/keyboard/keys/KeyNames.js
@@ -1,0 +1,902 @@
+/**
+ * @author       Richard Davey <rich@phaser.io>
+ * @copyright    2013-2026 Phaser Studio Inc.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+/**
+ * A mapping of keyboard key names to their corresponding human-readable string.
+ *
+ * @namespace Phaser.Input.Keyboard.KeyNames
+ * @memberof Phaser.Input.Keyboard
+ * @since 4.1.0
+ */
+
+var KeyNames = {
+    /**
+     * The BACKSPACE key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.BACKSPACE
+     * @type {string}
+     * @since 4.1.0
+     */
+    BACKSPACE: 'Backspace',
+
+    /**
+     * The TAB key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.TAB
+     * @type {string}
+     * @since 4.1.0
+     */
+    TAB: 'Tab',
+
+    /**
+     * The ENTER key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.ENTER
+     * @type {string}
+     * @since 4.1.0
+     */
+    ENTER: 'Enter',
+
+    /**
+     * The SHIFT key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.SHIFT
+     * @type {string}
+     * @since 4.1.0
+     */
+    SHIFT: 'Shift',
+
+    /**
+     * The CTRL key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.CTRL
+     * @type {string}
+     * @since 4.1.0
+     */
+    CTRL: 'Ctrl',
+
+    /**
+     * The ALT key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.ALT
+     * @type {string}
+     * @since 4.1.0
+     */
+    ALT: 'Alt',
+
+    /**
+     * The PAUSE key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.PAUSE
+     * @type {string}
+     * @since 4.1.0
+     */
+    PAUSE: 'Pause',
+
+    /**
+     * The CAPS_LOCK key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.CAPS_LOCK
+     * @type {string}
+     * @since 4.1.0
+     */
+    CAPS_LOCK: 'Caps Lock',
+
+    /**
+     * The ESC key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.ESC
+     * @type {string}
+     * @since 4.1.0
+     */
+    ESC: 'Escape',
+
+    /**
+     * The SPACE key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.SPACE
+     * @type {string}
+     * @since 4.1.0
+     */
+    SPACE: ' ',
+
+    /**
+     * The PAGE_UP key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.PAGE_UP
+     * @type {string}
+     * @since 4.1.0
+     */
+    PAGE_UP: 'Page Up',
+
+    /**
+     * The PAGE_DOWN key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.PAGE_DOWN
+     * @type {string}
+     * @since 4.1.0
+     */
+    PAGE_DOWN: 'Page Down',
+
+    /**
+     * The END key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.END
+     * @type {string}
+     * @since 4.1.0
+     */
+    END: 'End',
+
+    /**
+     * The HOME key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.HOME
+     * @type {string}
+     * @since 4.1.0
+     */
+    HOME: 'Home',
+
+    /**
+     * The LEFT key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.LEFT
+     * @type {string}
+     * @since 4.1.0
+     */
+    LEFT: '←',
+
+    /**
+     * The UP key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.UP
+     * @type {string}
+     * @since 4.1.0
+     */
+    UP: '↑',
+
+    /**
+     * The RIGHT key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.RIGHT
+     * @type {string}
+     * @since 4.1.0
+     */
+    RIGHT: '→',
+
+    /**
+     * The DOWN key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.DOWN
+     * @type {string}
+     * @since 4.1.0
+     */
+    DOWN: '↓',
+
+    /**
+     * The PRINT_SCREEN key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.PRINT_SCREEN
+     * @type {string}
+     * @since 4.1.0
+     */
+    PRINT_SCREEN: 'Print Screen',
+
+    /**
+     * The INSERT key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.INSERT
+     * @type {string}
+     * @since 4.1.0
+     */
+    INSERT: 'Insert',
+
+    /**
+     * The DELETE key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.DELETE
+     * @type {string}
+     * @since 4.1.0
+     */
+    DELETE: 'Delete',
+
+    /**
+     * The ZERO key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.ZERO
+     * @type {string}
+     * @since 4.1.0
+     */
+    ZERO: '0',
+
+    /**
+     * The ONE key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.ONE
+     * @type {string}
+     * @since 4.1.0
+     */
+    ONE: '1',
+
+    /**
+     * The TWO key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.TWO
+     * @type {string}
+     * @since 4.1.0
+     */
+    TWO: '2',
+
+    /**
+     * The THREE key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.THREE
+     * @type {string}
+     * @since 4.1.0
+     */
+    THREE: '3',
+
+    /**
+     * The FOUR key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.FOUR
+     * @type {string}
+     * @since 4.1.0
+     */
+    FOUR: '4',
+
+    /**
+     * The FIVE key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.FIVE
+     * @type {string}
+     * @since 4.1.0
+     */
+    FIVE: '5',
+
+    /**
+     * The SIX key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.SIX
+     * @type {string}
+     * @since 4.1.0
+     */
+    SIX: '6',
+
+    /**
+     * The SEVEN key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.SEVEN
+     * @type {string}
+     * @since 4.1.0
+     */
+    SEVEN: '7',
+
+    /**
+     * The EIGHT key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.EIGHT
+     * @type {string}
+     * @since 4.1.0
+     */
+    EIGHT: '8',
+
+    /**
+     * The NINE key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NINE
+     * @type {string}
+     * @since 4.1.0
+     */
+    NINE: '9',
+
+    /**
+     * The numeric keypad 0 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_ZERO
+     * @type {string}
+     * @since 4.1.0
+     */
+    NUMPAD_ZERO: 'Num0',
+
+    /**
+     * The numeric keypad 1 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_ONE
+     * @type {string}
+     * @since 4.1.0
+     */
+    NUMPAD_ONE: 'Num1',
+
+    /**
+     * The numeric keypad 2 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_TWO
+     * @type {string}
+     * @since 4.1.0
+     */
+    NUMPAD_TWO: 'Num2',
+
+    /**
+     * The numeric keypad 3 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_THREE
+     * @type {string}
+     * @since 4.1.0
+     */
+    NUMPAD_THREE: 'Num3',
+
+    /**
+     * The numeric keypad 4 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_FOUR
+     * @type {string}
+     * @since 4.1.0
+     */
+    NUMPAD_FOUR: 'Num4',
+
+    /**
+     * The numeric keypad 5 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_FIVE
+     * @type {string}
+     * @since 4.1.0
+     */
+    NUMPAD_FIVE: 'Num5',
+
+    /**
+     * The numeric keypad 6 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_SIX
+     * @type {string}
+     * @since 4.1.0
+     */
+    NUMPAD_SIX: 'Num6',
+
+    /**
+     * The numeric keypad 7 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_SEVEN
+     * @type {string}
+     * @since 4.1.0
+     */
+    NUMPAD_SEVEN: 'Num7',
+
+    /**
+     * The numeric keypad 8 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_EIGHT
+     * @type {string}
+     * @since 4.1.0
+     */
+    NUMPAD_EIGHT: 'Num8',
+
+    /**
+     * The numeric keypad 9 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_NINE
+     * @type {string}
+     * @since 4.1.0
+     */
+    NUMPAD_NINE: 'Num9',
+
+    /**
+     * The Numpad Addition (+) key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_ADD
+     * @type {string}
+     * @since 3.21.0
+     */
+    NUMPAD_ADD: '+',
+
+    /**
+     * The Numpad Subtraction (-) key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.NUMPAD_SUBTRACT
+     * @type {string}
+     * @since 3.21.0
+     */
+    NUMPAD_SUBTRACT: '-',
+
+    /**
+     * The A key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.A
+     * @type {string}
+     * @since 4.1.0
+     */
+    A: 'A',
+
+    /**
+     * The B key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.B
+     * @type {string}
+     * @since 4.1.0
+     */
+    B: 'B',
+
+    /**
+     * The C key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.C
+     * @type {string}
+     * @since 4.1.0
+     */
+    C: 'C',
+
+    /**
+     * The D key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.D
+     * @type {string}
+     * @since 4.1.0
+     */
+    D: 'D',
+
+    /**
+     * The E key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.E
+     * @type {string}
+     * @since 4.1.0
+     */
+    E: 'E',
+
+    /**
+     * The F key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F
+     * @type {string}
+     * @since 4.1.0
+     */
+    F: 'F',
+
+    /**
+     * The G key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.G
+     * @type {string}
+     * @since 4.1.0
+     */
+    G: 'G',
+
+    /**
+     * The H key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.H
+     * @type {string}
+     * @since 4.1.0
+     */
+    H: 'H',
+
+    /**
+     * The I key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.I
+     * @type {string}
+     * @since 4.1.0
+     */
+    I: 'I',
+
+    /**
+     * The J key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.J
+     * @type {string}
+     * @since 4.1.0
+     */
+    J: 'J',
+
+    /**
+     * The K key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.K
+     * @type {string}
+     * @since 4.1.0
+     */
+    K: 'K',
+
+    /**
+     * The L key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.L
+     * @type {string}
+     * @since 4.1.0
+     */
+    L: 'L',
+
+    /**
+     * The M key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.M
+     * @type {string}
+     * @since 4.1.0
+     */
+    M: 'M',
+
+    /**
+     * The N key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.N
+     * @type {string}
+     * @since 4.1.0
+     */
+    N: 'N',
+
+    /**
+     * The O key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.O
+     * @type {string}
+     * @since 4.1.0
+     */
+    O: 'O',
+
+    /**
+     * The P key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.P
+     * @type {string}
+     * @since 4.1.0
+     */
+    P: 'P',
+
+    /**
+     * The Q key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.Q
+     * @type {string}
+     * @since 4.1.0
+     */
+    Q: 'Q',
+
+    /**
+     * The R key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.R
+     * @type {string}
+     * @since 4.1.0
+     */
+    R: 'R',
+
+    /**
+     * The S key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.S
+     * @type {string}
+     * @since 4.1.0
+     */
+    S: 'S',
+
+    /**
+     * The T key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.T
+     * @type {string}
+     * @since 4.1.0
+     */
+    T: 'T',
+
+    /**
+     * The U key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.U
+     * @type {string}
+     * @since 4.1.0
+     */
+    U: 'U',
+
+    /**
+     * The V key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.V
+     * @type {string}
+     * @since 4.1.0
+     */
+    V: 'V',
+
+    /**
+     * The W key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.W
+     * @type {string}
+     * @since 4.1.0
+     */
+    W: 'W',
+
+    /**
+     * The X key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.X
+     * @type {string}
+     * @since 4.1.0
+     */
+    X: 'X',
+
+    /**
+     * The Y key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.Y
+     * @type {string}
+     * @since 4.1.0
+     */
+    Y: 'Y',
+
+    /**
+     * The Z key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.Z
+     * @type {string}
+     * @since 4.1.0
+     */
+    Z: 'Z',
+
+    /**
+     * The F1 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F1
+     * @type {string}
+     * @since 4.1.0
+     */
+    F1: 'F1',
+
+    /**
+     * The F2 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F2
+     * @type {string}
+     * @since 4.1.0
+     */
+    F2: 'F2',
+
+    /**
+     * The F3 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F3
+     * @type {string}
+     * @since 4.1.0
+     */
+    F3: 'F3',
+
+    /**
+     * The F4 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F4
+     * @type {string}
+     * @since 4.1.0
+     */
+    F4: 'F4',
+
+    /**
+     * The F5 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F5
+     * @type {string}
+     * @since 4.1.0
+     */
+    F5: 'F5',
+
+    /**
+     * The F6 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F6
+     * @type {string}
+     * @since 4.1.0
+     */
+    F6: 'F6',
+
+    /**
+     * The F7 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F7
+     * @type {string}
+     * @since 4.1.0
+     */
+    F7: 'F7',
+
+    /**
+     * The F8 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F8
+     * @type {string}
+     * @since 4.1.0
+     */
+    F8: 'F8',
+
+    /**
+     * The F9 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F9
+     * @type {string}
+     * @since 4.1.0
+     */
+    F9: 'F9',
+
+    /**
+     * The F10 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F10
+     * @type {string}
+     * @since 4.1.0
+     */
+    F10: 'F10',
+
+    /**
+     * The F11 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F11
+     * @type {string}
+     * @since 4.1.0
+     */
+    F11: 'F11',
+
+    /**
+     * The F12 key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.F12
+     * @type {string}
+     * @since 4.1.0
+     */
+    F12: 'F12',
+
+    /**
+     * The SEMICOLON key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.SEMICOLON
+     * @type {string}
+     * @since 4.1.0
+     */
+    SEMICOLON: ';',
+
+    /**
+     * The PLUS key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.PLUS
+     * @type {string}
+     * @since 4.1.0
+     */
+    PLUS: '+',
+
+    /**
+     * The COMMA key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.COMMA
+     * @type {string}
+     * @since 4.1.0
+     */
+    COMMA: ',',
+
+    /**
+     * The MINUS key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.MINUS
+     * @type {string}
+     * @since 4.1.0
+     */
+    MINUS: '-',
+
+    /**
+     * The PERIOD key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.PERIOD
+     * @type {string}
+     * @since 4.1.0
+     */
+    PERIOD: '.',
+
+    /**
+     * The FORWARD_SLASH key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.FORWARD_SLASH
+     * @type {string}
+     * @since 4.1.0
+     */
+    FORWARD_SLASH: '/',
+
+    /**
+     * The BACK_SLASH key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.BACK_SLASH
+     * @type {string}
+     * @since 4.1.0
+     */
+    BACK_SLASH: `\\`,
+
+    /**
+     * The QUOTES key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.QUOTES
+     * @type {string}
+     * @since 4.1.0
+     */
+    QUOTES: `'`,
+
+    /**
+     * The BACKTICK key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.BACKTICK
+     * @type {string}
+     * @since 4.1.0
+     */
+    BACKTICK: '`',
+
+    /**
+     * The OPEN_BRACKET key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.OPEN_BRACKET
+     * @type {string}
+     * @since 4.1.0
+     */
+    OPEN_BRACKET: '[',
+
+    /**
+     * The CLOSED_BRACKET key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.CLOSED_BRACKET
+     * @type {string}
+     * @since 4.1.0
+     */
+    CLOSED_BRACKET: ']',
+
+    /**
+     * The Firefox-specific alternate key code for the SEMICOLON (;) key. Firefox historically
+     * reported key code 59 for this key, whereas other browsers use 186 (see `SEMICOLON`).
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.SEMICOLON_FIREFOX
+     * @type {string}
+     * @since 4.1.0
+     */
+    SEMICOLON_FIREFOX: ';',
+
+    /**
+     * The COLON (:) key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.COLON
+     * @type {string}
+     * @since 4.1.0
+     */
+    COLON: ':',
+
+    /**
+     * The Firefox on Windows-specific alternate key code for the less-than sign (<) key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.COMMA_FIREFOX_WINDOWS
+     * @type {string}
+     * @since 4.1.0
+     */
+    COMMA_FIREFOX_WINDOWS: ',',
+
+    /**
+     * The Firefox-specific alternate key code for the greater-than sign (>) key.
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.COMMA_FIREFOX
+     * @type {string}
+     * @since 4.1.0
+     */
+    COMMA_FIREFOX: ',',
+
+    /**
+     * The Firefox-specific alternate key code for the right bracket (]) key. Firefox historically
+     * reported key code 174 for this key, whereas other browsers use 221 (see `CLOSED_BRACKET`).
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.BRACKET_RIGHT_FIREFOX
+     * @type {string}
+     * @since 4.1.0
+     */
+    BRACKET_RIGHT_FIREFOX: ']',
+
+    /**
+     * The Firefox-specific alternate key code for the left bracket ([) key. Firefox historically
+     * reported key code 175 for this key, whereas other browsers use 219 (see `OPEN_BRACKET`).
+     *
+     * @name Phaser.Input.Keyboard.KeyNames.BRACKET_LEFT_FIREFOX
+     * @type {string}
+     * @since 4.1.0
+     */
+    BRACKET_LEFT_FIREFOX: '['
+};
+
+module.exports = KeyNames;


### PR DESCRIPTION
This PR

* Adds a new feature

Describe the changes below:

Adds human readable strings for input keys. 

```js
import GetKeyName from Phaser.Input.Keyboard.GetKeyName
import KeyCodes from Phaser.Input.Keyboard.KeyCodes

GetKeyName(KeyCodes.LEFT) // '←' 
GetKeyName('LEFT') // '←'
GetKeyName(KeyCodes.BACKSPACE) // 'Backspace'
GetKeyName('BACKSPACE') // 'Backspace'
GetKeyName(KeyCodes.OPEN_BRACKET) // '['
GetKeyName('OPEN_BRACKET') // '['
```

This PR still needs tests and documentation updates. I'm happy to do them if this PR is approved.

