### PR TITLE
fix  `setPollAlways()` hit-testing inactive pointers

### DIFF
--- a/src/input/InputPlugin.js
+++ b/src/input/InputPlugin.js
@@ -652,6 +652,11 @@ var InputPlugin = new Class({
 
             var pointer = pointers[i];
 
+            if (!pointer.active)
+            {
+                continue;
+            }
+
             //  Always reset this array
             this._tempZones = [];
 


### PR DESCRIPTION
When `scene.input.setPollAlways()` is enabled, `InputPlugin.updatePoll` would hit-tests **every** pointer in `input.manager.pointers` on every frame,  including the spare touch pointer (`id === 1`) that Phaser allocates but keeps **parked at world (0,0)** with `active === false` until the first real touch.

As a result, an interactive Game Object whose hit area covers world **(0,0)** receives `pointerover` / `pointerout` events from that idle phantom pointer **with no user input at all** (the mouse is never moved, the screen is never touched).

Modified Phaser example that reproduces this:
```js
class Example extends Phaser.Scene {
    preload() {
        this.load.image('eye', 'assets/pics/lance-overdose-loader-eye.png');
    }

    create() {
        this.input.setPollAlways();

        const sprite = this.add.sprite(0, 0, 'eye').setInteractive();
        this.input.on('gameobjectover', (pointer, gameObject) => {
            gameObject.setTint(0xff0000);
        });
        this.input.on('gameobjectout', (pointer, gameObject) => {
            gameObject.clearTint();
        });

        this.tweens.add({
            targets: sprite,
            x: 100,
            yoyo: true,
            repeat: -1,
            duration: 500
        });
    }
}

const config = {
    type: Phaser.WEBGL,
    parent: 'phaser-example',
    scene: Example
};

const game = new Phaser.Game(config);
```