### PR TITLE
fix(input): pierce shadow DOM in onTouchMove over-canvas detection

### DIFF
--- a/src/input/InputManager.js
+++ b/src/input/InputManager.js
@@ -610,7 +610,12 @@ var InputManager = new Class({
 
                 if (pointer.active && pointer.identifier === changedTouch.identifier)
                 {
-                    var element = document.elementFromPoint(changedTouch.clientX, changedTouch.clientY);
+                    //  Use the canvas's root node (a ShadowRoot when Phaser runs inside shadow DOM,
+                    //  otherwise the Document) so over-canvas detection pierces shadow boundaries.
+                    //  document.elementFromPoint does not, returning the shadow host instead, which made
+                    //  isOver latch false and silently dropped every touch move inside a shadow root.
+                    var inputRoot = this.canvas ? this.canvas.getRootNode() : null;
+                    var element = (inputRoot && inputRoot.elementFromPoint ? inputRoot : document).elementFromPoint(changedTouch.clientX, changedTouch.clientY);
                     var overCanvas = element === this.canvas;
 
                     if (!this.isOver && overCanvas)


### PR DESCRIPTION
This PR

* Fixes a bug

Describe the changes below:

InputManager.onTouchMove used document.elementFromPoint() to decide whether a touch is over the canvas. When Phaser runs inside a shadow root, that call resolves to the shadow host rather than the canvas, so `overCanvas` is always false, `isOver` latches false, and every touchmove inside the shadow root is silently dropped — pointer.x/y never update on touch devices.

Use the canvas's root node (canvas.getRootNode(), a ShadowRoot when inside shadow DOM, otherwise the Document) which exposes elementFromPoint and resolves the topmost element across the shadow boundary. Falls back to document when the root node has no elementFromPoint.

### Reproduction

A self-contained, single-file repro that demonstrates the bug:

- Source (gist): https://gist.github.com/pauliojanpera/1a8dab1e2cfaffb103812d0ce7481056
- Live (githack): https://gist.githack.com/pauliojanpera/1a8dab1e2cfaffb103812d0ce7481056/raw/phasershadowdomtouchmoverepro.html

It mounts a Phaser game whose canvas is created inside an open shadow root and logs two independent event streams: a raw DOM `touchmove` listener on the canvas, and Phaser's own `pointermove`. Open the live link and drag inside the dark area on a touch device (or with DevTools touch emulation: Ctrl/Cmd+Shift+M).

- **Before this fix** (pinned `phaser@3.90.0`): the raw `touchmove` events fire, but Phaser `pointermove` never fires for touch, and the status bar turns **red — "BUG REPRODUCED"**. A *mouse* drag still logs `pointermove`, since the mouse path never calls `elementFromPoint` — so only the touch path is broken.
- **After this fix** (swap the `<script src>` for a build containing the patched `InputManager.js`): `touchmove` and `pointermove` fire together and the status bar turns **green**.