### PR TITLE
fix: Preserve physics group config with existing children

### DIFF
--- a/src/physics/arcade/PhysicsGroup.js
+++ b/src/physics/arcade/PhysicsGroup.js
@@ -87,11 +87,10 @@ var PhysicsGroup = new Class({
         }
         else
         {
-            // config is not defined and children is not a plain object nor an array of plain objects
-            config = {
-                internalCreateCallback: this.createCallbackHandler,
-                internalRemoveCallback: this.removeCallbackHandler
-            };
+            // children is not a plain object nor an array of plain objects
+            config = config || {};
+            config.internalCreateCallback = this.createCallbackHandler;
+            config.internalRemoveCallback = this.removeCallbackHandler;
         }
 
         /**

--- a/src/physics/arcade/StaticPhysicsGroup.js
+++ b/src/physics/arcade/StaticPhysicsGroup.js
@@ -88,11 +88,10 @@ var StaticPhysicsGroup = new Class({
         }
         else
         {
-            // config is not defined and children is not a plain object nor an array of plain objects
-            config = {
-                internalCreateCallback: this.createCallbackHandler,
-                internalRemoveCallback: this.removeCallbackHandler
-            };
+            // children is not a plain object nor an array of plain objects
+            config = config || {};
+            config.internalCreateCallback = this.createCallbackHandler;
+            config.internalRemoveCallback = this.removeCallbackHandler;
         }
 
         /**


### PR DESCRIPTION
## Summary

Preserve the provided config when creating Arcade Physics groups with existing children.

Both dynamic and static physics groups replaced the provided `config` when `children` was not a plain object or an array of plain objects. This caused options passed as the second argument to be ignored for calls like:

```js
this.physics.add.group([sprite], {
    collideWorldBounds: true
});

this.physics.add.staticGroup([platform], config);
```

This change keeps the existing config object and appends the internal callbacks instead of replacing it.

## Manual test

Created an Arcade Physics Group from an existing GameObject array with `{ collideWorldBounds: true }`.

Before this change:

```js
group.defaults.setCollideWorldBounds === false
sprite.body.collideWorldBounds === false
```

After this change:

```js
group.defaults.setCollideWorldBounds === true
sprite.body.collideWorldBounds === true
```