### PR TITLE
Fix DOMElement origin drift under camera zoom

### DIFF
--- a/src/gameobjects/domelement/DOMElementCSSRenderer.js
+++ b/src/gameobjects/domelement/DOMElementCSSRenderer.js
@@ -61,8 +61,14 @@ var DOMElementCSSRenderer = function (renderer, src, camera, parentMatrix)
     var srcMatrix = tempMatrix2;
     var calcMatrix = tempMatrix3;
 
-    var dx = src.width * src.originX;
-    var dy = src.height * src.originY;
+    //  Bake the (scale-aware) origin offset into the matrix and keep `transform-origin` at 0,0.
+    //  This is what the `parentMatrix` branch already did; applying it to scene-level elements too
+    //  keeps both paths consistent. Previously the scene-level (else) branch set
+    //  `transform-origin: (100 * origin)%` while ALSO baking the offset into the matrix below,
+    //  applying the origin offset twice. The two only cancel at camera zoom 1, so under camera
+    //  zoom the element drifted by `origin * size * (1 - zoom)`.
+    var dx = src.width * src.originX * src.scaleX;
+    var dy = src.height * src.originY * src.scaleY;
 
     var tx = '0%';
     var ty = '0%';
@@ -76,13 +82,6 @@ var DOMElementCSSRenderer = function (renderer, src, camera, parentMatrix)
     if (parentMatrix)
     {
         camMatrix.multiply(parentMatrix);
-        dx *= src.scaleX;
-        dy *= src.scaleY;
-    }
-    else
-    {
-        tx = (100 * src.originX) + '%';
-        ty = (100 * src.originY) + '%';
     }
 
     camMatrix.translate(-dx, -dy);


### PR DESCRIPTION
This PR:

* Fixes a bug

Fixes #7329.

### Describe the changes

A scene-level `DOMElement` with a non-zero origin (the default is `0.5, 0.5`) drifted
away from its world position when `camera.zoom !== 1`, by `originX * width * (1 - zoom)`
horizontally and the equivalent vertically. The same `DOMElement` nested in a `Container`
did not drift — the two render paths were inconsistent.

**Cause:** in `DOMElementCSSRenderer`, `camMatrix.translate(-dx, -dy)` bakes the origin
offset into the CSS matrix in *both* branches. The `parentMatrix` branch correctly leaves
`transform-origin` at `0% 0%` (offset applied once). The scene-level `else` branch *also*
set `transform-origin: (100 * origin)%`, applying the offset a second time. The two only
cancel when the camera-matrix scale is `1`, so under camera zoom the residual
`originX * width * (1 - zoom)` shows up as drift.

**Fix:** make the scene-level path match the (correct) container path — keep
`transform-origin` at `0% 0%` and bake the scale-aware offset into the matrix. The
`scaleX` / `scaleY` factor the `parentMatrix` branch already applied is correct for the
scene-level branch too, so it's hoisted up rather than duplicated:

```js
var dx = src.width * src.originX * src.scaleX;
var dy = src.height * src.originY * src.scaleY;
// ...
if (parentMatrix)
{
    camMatrix.multiply(parentMatrix);
}

camMatrix.translate(-dx, -dy);
```

(`tx` / `ty` now stay `'0%'`, so `transform-origin` is `0% 0%` on both paths.)

The container-nested element is unchanged (no drift before or after), and scaled / rotated
scene-level elements now also stay correctly anchored at any zoom because the baked offset
is scale-aware.

A minimal repro is available here and can be copy/pasted: 

https://phaser.io/sandbox/f0eb3f05

Disclaimer: this PR was mostly written by Claude Code but manually checked to be working (so AI assisted but hopefully not AI slop :) )