### PR TITLE
Docs: correct AnimationManager get() return type

### DIFF
--- a/src/animations/AnimationManager.js
+++ b/src/animations/AnimationManager.js
@@ -806,7 +806,7 @@ var AnimationManager = new Class({
      *
      * @param {string} key - The key of the Animation to retrieve.
      *
-     * @return {Phaser.Animations.Animation} The Animation.
+     * @return {(Phaser.Animations.Animation|undefined)} The Animation or `undefined`.
      */
     get: function (key)
     {


### PR DESCRIPTION
This PR

* Updates the Documentation

Fixes #7324

