### PR TITLE
Fix TilemapGPULayer rendering at double its position

### DIFF
--- a/src/renderer/webgl/renderNodes/submitter/SubmitterTilemapGPULayer.js
+++ b/src/renderer/webgl/renderNodes/submitter/SubmitterTilemapGPULayer.js
@@ -515,11 +515,16 @@ var SubmitterTilemapGPULayer = new Class({
         calcMatrix.multiply(spriteMatrix);
 
         // Compute output quad.
+        // The layer's x/y position is already baked into `spriteMatrix` (via
+        // `applyITRS`) and thus into `calcMatrix`, so the quad must be built
+        // from local coordinates (0, 0)-(width, height). Passing the absolute
+        // x/y here would apply the position twice, offsetting the layer by
+        // (x, y) (i.e. rendering a layer placed at (x, y) at (2x, 2y)).
         calcMatrix.setQuad(
-            x,
-            y,
-            x + width,
-            y + height,
+            0,
+            0,
+            width,
+            height,
             quad
         );
 


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug


A `TilemapGPULayer` placed at (x, y) was rendered at (2x, 2y). The layer's position is already baked into the transform via `applyITRS(x, y, ...)`, but `setQuad()` was then called with the absolute x/y again, applying the offset twice.

The existing GPU tilemap examples only place layers at (0, 0), so the doubling (2*0 = 0) was never visible and the bug went unnoticed.

A full repro is available in this fork of the examples repository: https://github.com/moufmouf/examples/commit/4e831f624f566c301ac404a24ed3bf89d9c39465

```
class Example extends Phaser.Scene
{
    preload ()
    {
        this.load.image('tiles', 'assets/tilemaps/MedievalRTS/medieval_tilesheet.png');
        this.load.tilemapTiledJSON('map', 'assets/tilemaps/MedievalRTS/sample.json');
    }

    create ()
    {
        const OX = 250;
        const OY = 180;

        const map = this.make.tilemap({ key: 'map' });
        const tileset = map.addTilesetImage('medieval_tilesheet', 'tiles', 64, 64);

        // GPU tilemap layer (5th argument = true), positioned at (OX, OY).
        map.createLayer('Land', tileset, OX, OY, true);

        // Marker for the expected top-left corner of the layer.
        this.add.rectangle(OX, OY, 64, 64).setStrokeStyle(2, 0xff00ff).setOrigin(0, 0);
        this.add.text(OX, OY - 22, `createLayer('Land', ts, ${OX}, ${OY}, true)`, {
            fontFamily: 'monospace', fontSize: 15, color: '#ff00ff'
        });
    }
}
```

Result before the fix:

<img width="900" height="700" alt="bugA-position-before-annotated" src="https://github.com/user-attachments/assets/7e6e77c2-9a9f-4ebe-b0b9-5480b661a22d" />

Result after the fix:

<img width="900" height="700" alt="bugA-position-after-annotated" src="https://github.com/user-attachments/assets/27d6bdee-1e95-4a84-a760-9cd12247379f" />
