### PR TITLE
Fix wrong animated tiles used in TilemapGPULayer

### DIFF
--- a/src/tilemaps/Tileset.js
+++ b/src/tilemaps/Tileset.js
@@ -614,7 +614,13 @@ var Tileset = new Class({
                 var animationDuration = tileDatum.animationDuration;
 
                 // This index maps to an animation, not a single tile.
-                indexToAnimMap.set(i, animations.length);
+                // The value is a texel offset into the animation data texture,
+                // where each animation header occupies 2 texels (duration and
+                // frame offset), so it must be `2 * ordinal` - the same way the
+                // frame offset above is stored in texel units. The shader reads
+                // the header at texel `index`; storing the raw ordinal made
+                // every animated tile after the first read a wrong header.
+                indexToAnimMap.set(i, animations.length * 2);
 
                 // This animation points to a run of frames.
                 animations.push([ animationDuration, animFrames.length ]);


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

Fixes #7331.

`createAnimationDataTexture` stored the raw animation ordinal in `_animationDataIndexMap`, but each animation header occupies 2 texels in the animation data texture (duration and frame offset) and the shader reads the header at texel `index`. Only ordinal 0 landed on a valid header; every animated tile after the first read a bogus header and resolved to a wrong tile.

Store the texel offset (`ordinal * 2`), matching how the frame offset is already stored. The map value is consumed only by
`TilemapGPULayer.generateLayerDataTexture` (which looks it up directly) and by `SubmitterTilemapGPULayer` (which only reads `.size`), so doubling is safe.

You can view a repro in this fork of the example directory: https://github.com/moufmouf/examples/blob/d2a8077ceb86c3159e67599d89f30e5e9a0a310f/public/src/tilemaps/tilemap%20gpu%20layer/gpu%20tile%20layer%20two%20animated%20tiles.js

(Phaser Sandbox seems down as I am opening this PR)

Before the fix:

<img width="820" height="340" alt="bugB-anim-before-annotated" src="https://github.com/user-attachments/assets/d2a3d73b-a045-4188-a0cd-67433e535871" />

After the fix:

<img width="820" height="340" alt="bugB-anim-after-annotated" src="https://github.com/user-attachments/assets/89a0f880-648d-4219-83ba-bd75476ab260" />
