### PR TITLE
Fix TilemapGPULayer when spacing != margin

### DIFF
--- a/src/renderer/webgl/shaders/TilemapGPULayer-vert.js
+++ b/src/renderer/webgl/shaders/TilemapGPULayer-vert.js
@@ -21,7 +21,7 @@ module.exports = [
     '{',
     '    gl_Position = uProjectionMatrix * vec4(inPosition, 1.0, 1.0);',
     '    outTexCoord = inTexCoord;',
-    '    outTileStride = uTileWidthHeightMarginSpacing.xy + uTileWidthHeightMarginSpacing.zz;',
+    '    outTileStride = uTileWidthHeightMarginSpacing.xy + uTileWidthHeightMarginSpacing.ww;',
     '    #pragma phaserTemplate(vertexProcess)',
     '}',
 ].join('\n');

--- a/src/renderer/webgl/shaders/src/TilemapGPULayer.vert
+++ b/src/renderer/webgl/shaders/src/TilemapGPULayer.vert
@@ -31,7 +31,7 @@ void main ()
     gl_Position = uProjectionMatrix * vec4(inPosition, 1.0, 1.0);
 
     outTexCoord = inTexCoord;
-    outTileStride = uTileWidthHeightMarginSpacing.xy + uTileWidthHeightMarginSpacing.zz;
+    outTileStride = uTileWidthHeightMarginSpacing.xy + uTileWidthHeightMarginSpacing.ww;
 
     #pragma phaserTemplate(vertexProcess)
 }


### PR DESCRIPTION
This PR (delete as applicable)

* Fixes a bug

### The bug

`TilemapGPULayer.vert` computes the per-tile stride as `tileSize + margin` instead of
`tileSize + spacing`:

```glsl
outTileStride = uTileWidthHeightMarginSpacing.xy + uTileWidthHeightMarginSpacing.zz;
```

`SubmitterTilemapGPULayer` packs that uniform as
`(tileWidth, tileHeight, tileMargin, tileSpacing)`, so `.z` is **margin** and `.w` is
**spacing**.

The stride from one tile to the next in a tileset image is `tileSize + spacing`.
Margin is only the one-off border around the whole sheet, and `getFrameCorner()`
already adds it separately (`TilemapGPULayer.frag`, where the `.zz` *is* correct). So
margin was counted twice — once as the border and again on every step — while spacing
was never counted at all.

The sampled frame therefore drifts by `(spacing - margin) * index`: exact at index 0
and progressively wrong further down the sheet, eventually sampling entirely unrelated
tiles. Tilesets where `margin == spacing` are unaffected, which is why this went
unnoticed.

The CPU path is correct, so canvas and WebGL disagree on the same map —
`Tileset.updateTileData()` strides by `tileWidth + tileSpacing` from an origin of
`tileMargin`.

### The fix

```glsl
outTileStride = uTileWidthHeightMarginSpacing.xy + uTileWidthHeightMarginSpacing.ww;
```

### Verification

A new example covering `margin != spacing`, since no existing one does: https://github.com/phaserjs/examples/pull/410

Before the fix:

<img width="920" height="823" alt="image" src="https://github.com/user-attachments/assets/4c0aab7b-b6cd-427b-a374-cc6e0f5d1e76" />


After the fix:

<img width="920" height="823" alt="image" src="https://github.com/user-attachments/assets/82f1c0d1-2389-4c18-b691-307a72b8f5ff" />

